### PR TITLE
Add Modals

### DIFF
--- a/lib/Button/styles.scss
+++ b/lib/Button/styles.scss
@@ -31,6 +31,10 @@
       color: $color-btn-primary--text;
       text-decoration: none;
     }
+
+    &:focus {
+      color: $color-btn-primary--text;
+    }
   }
 
   &--secondary {
@@ -39,6 +43,10 @@
 
     &:hover {
       background: $color-btn-secondary--hover;
+      color: $color-btn-primary--text;
+    }
+
+    &:focus {
       color: $color-btn-primary--text;
     }
   }
@@ -66,6 +74,10 @@
     &:hover {
       color: $color-btn-warning--text;
       background: $color-btn-warning--hover;
+    }
+
+    &:focus {
+      color: $color-btn-warning--text;
     }
   }
 

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -1,0 +1,94 @@
+import React, { Component, PropTypes } from 'react';
+import ModalBootstrap from 'react-bootstrap/lib/Modal';
+
+class Modal extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      show: this.shouldDisplayModal(),
+      callback: null,
+    };
+
+    this.hideModal = this.hideModal.bind(this);
+    this.submitCallback = this.submitCallback.bind(this);
+  }
+
+  shouldDisplayModal() {
+    return this.props.show;
+  }
+
+  hideModal(e) {
+    if (e) e.preventDefault();
+
+    this.resetModal();
+  }
+
+  showModal(callback) {
+    this.setState({ show: true, callback });
+  }
+
+  submitCallback(e) {
+    e.preventDefault();
+    this.state.callback();
+  }
+
+  resetModal() {
+    this.setState({ show: false, callback: null });
+  }
+
+  renderContentOnly(size) {
+    let classNames;
+
+    switch (size) {
+      case 'x-large':
+        classNames = ['modal--no-padding', 'modal--x-large'].join(' ');
+        break;
+      case 'large':
+        classNames = ['modal--no-padding', 'modal--large'].join(' ');
+        break;
+      default:
+        classNames = [''];
+        break;
+    }
+
+    return (
+      <ModalBootstrap className={classNames} {...this.props}>
+        { this.props.children }
+      </ModalBootstrap>
+    );
+  }
+
+  render() {
+    const { size, contentOnly } = this.props;
+
+    if (contentOnly) {
+      return this.renderContentOnly(size);
+    }
+
+    return (
+      <ModalBootstrap className="modal--no-padding" {...this.props}>
+        <form onSubmit={this.submitCallback}>
+          <ModalBootstrap.Body>
+            { this.props.children }
+          </ModalBootstrap.Body>
+        </form>
+      </ModalBootstrap>
+    );
+  }
+}
+
+Modal.defaultProps = {
+  show: false,
+  size: '',
+  contentOnly: false,
+};
+
+Modal.propTypes = {
+  show: PropTypes.bool,
+  children: PropTypes.node,
+  size: PropTypes.string,
+  contentOnly: PropTypes.bool,
+};
+
+export default Modal;

--- a/lib/Modal/ModalColumn.js
+++ b/lib/Modal/ModalColumn.js
@@ -1,0 +1,13 @@
+import React, { PropTypes } from 'react';
+
+const ModalColumn = props =>
+  <div className={`modal__column ${props.className}`}>
+    {props.children}
+  </div>;
+
+ModalColumn.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+export default ModalColumn;

--- a/lib/Modal/ModalContent.js
+++ b/lib/Modal/ModalContent.js
@@ -1,0 +1,13 @@
+import React, { PropTypes } from 'react';
+
+const ModalContent = props =>
+  <div className={`modal__content ${props.className}`}>
+    {props.children}
+  </div>;
+
+ModalContent.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.node),
+  className: PropTypes.string,
+};
+
+export default ModalContent;

--- a/lib/Modal/ModalFooter.js
+++ b/lib/Modal/ModalFooter.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+
+const ModalFooter = (props) => {
+  return (
+    <Modal.Footer>
+      {props.children}
+    </Modal.Footer>
+  );
+}
+
+export default ModalFooter;

--- a/lib/Modal/ModalHeader.js
+++ b/lib/Modal/ModalHeader.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+
+const ModalHeader = (props) => {
+  return (
+    <Modal.Header>
+      <Modal.Title>{props.children}</Modal.Title>
+    </Modal.Header>
+  );
+}
+
+export default ModalHeader;

--- a/lib/Modal/index.js
+++ b/lib/Modal/index.js
@@ -1,0 +1,15 @@
+import Modal from './Modal';
+import ModalColumn from './ModalColumn';
+import ModalHeader from './ModalHeader';
+import ModalFooter from './ModalFooter';
+import ModalContent from './ModalContent';
+
+const Modals = {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalColumn,
+  ModalFooter
+};
+
+export default Modals;

--- a/lib/Modal/styles.scss
+++ b/lib/Modal/styles.scss
@@ -1,0 +1,108 @@
+.modal-body p {
+	line-height: 1.4;
+}
+
+/**
+ * React bootstrap suddenly injects a padding-right: 15px to the modals
+ * we're using. Until we figure out why, we override it manually...
+ */
+.modal--no-padding {
+	padding: 0 !important;
+}
+
+.modal {
+	* { box-sizing: border-box; }
+
+  &__content {
+    overflow: hidden;
+  }
+
+	&__column {
+		padding: 30px;
+		width: 50%;
+		float: left;
+		position: relative;
+
+		&--1-3 {
+			width: 33%;
+			min-height: 430px;
+		}
+
+		&--3-4 {
+			width: 67%;
+			min-height: 430px;
+		}
+
+		&--highlight {
+			background: rgb(247, 250, 253);
+			color: rgb(76, 88, 96);
+			border-right: 1px solid rgb(229, 233, 238);
+		}
+	}
+
+	&__title {
+		font-size: 21px;
+		font-weight: 400;
+		line-height: 1.3;
+		color: rgb(75, 86, 95);
+	}
+
+	&__illustration {
+		margin: 90px 0 0;
+
+		svg {
+			transform: scale(1);
+			height: 100px;
+		}
+	}
+
+	&__actions {
+		position: absolute;
+		background-color: transparent !important;
+		bottom: 20px;
+		right: 30px;
+	}
+
+	&__password-setup {
+		margin-top: 30px;
+		background-color: transparent !important; // Override Chrome's autofill bg
+
+		.c-input {
+			float: left;
+		}
+
+		.c-input + .btn {
+			float: left;
+		}
+	}
+
+	&__password-setup-error {
+		color: $color-alert--danger-text;
+		font-size: 12px;
+		margin-top: 10px;
+	}
+
+	&--large,
+	&--x-large {
+		left: 0;
+		right: 0;
+		width: auto;
+		margin: auto;
+		background-color: transparent;
+		box-shadow: none;
+		border: none;
+
+		.modal-dialog {
+			border-radius: 10px;
+			margin: 30px auto;
+			background: #fff;
+			min-height: 420px;
+			width: 780px;
+			overflow: hidden;
+		}
+	}
+
+	&--x-large {
+		.modal-dialog { width: 900px; }
+	}
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "echo Building GatherUI assets... && npm build",
     "storybook": "start-storybook -p 6006 -c .storybook",
     "build-storybook": "build-storybook",
-    "test": "mocha tests --compilers js:babel-register || exit 0",
+    "test": "mocha tests/** --compilers js:babel-register || exit 0",
     "test:watch": "mocha tests --watch --compilers js:babel-register",
     "tdd": "npm run test:watch"
   },

--- a/stories/index.js
+++ b/stories/index.js
@@ -14,6 +14,13 @@ import PlanBoxPricing from '../lib/PlanBox/Pricing';
 import PlanBoxAllowanceDetails from '../lib/PlanBox/AllowanceDetails';
 import Table from '../lib/Table';
 import SearchInput from '../lib/SearchInput';
+/*import Modal from '../lib/Modal/Modal';
+import ModalColumn from '../lib/Modal/ModalColumn';
+import ModalContent from '../lib/Modal/ModalContent';
+import ModalHeader from '../lib/Modal/ModalHeader';
+import ModalFooter from '../lib/Modal/ModalFooter';*/
+
+import Modal from '../lib/Modal/';
 
 // Button
 storiesOf('Button', module)
@@ -153,4 +160,23 @@ storiesOf('Table', module)
 storiesOf('Inputs', module)
   .add('Search input with clear button', () =>
     <SearchInput onChangeHandler={ action('change') } />
+);
+
+// Modals
+storiesOf('Modal', module)
+  .add('2-column', () =>
+      <Modal.Modal show contentOnly>
+        <Modal.ModalHeader>Hello</Modal.ModalHeader>
+        <Modal.ModalContent>
+          <Modal.ModalColumn>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident
+          </Modal.ModalColumn>
+          <Modal.ModalColumn>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident
+          </Modal.ModalColumn>
+        </Modal.ModalContent>
+        <Modal.ModalFooter>
+          <Button value="Confirm"></Button>
+        </Modal.ModalFooter>
+      </Modal.Modal>
   );

--- a/stories/index.js
+++ b/stories/index.js
@@ -14,12 +14,6 @@ import PlanBoxPricing from '../lib/PlanBox/Pricing';
 import PlanBoxAllowanceDetails from '../lib/PlanBox/AllowanceDetails';
 import Table from '../lib/Table';
 import SearchInput from '../lib/SearchInput';
-/*import Modal from '../lib/Modal/Modal';
-import ModalColumn from '../lib/Modal/ModalColumn';
-import ModalContent from '../lib/Modal/ModalContent';
-import ModalHeader from '../lib/Modal/ModalHeader';
-import ModalFooter from '../lib/Modal/ModalFooter';*/
-
 import Modal from '../lib/Modal/';
 
 // Button

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -14,6 +14,7 @@
 @import '../lib/PlanBox/styles.scss';
 @import '../lib/Table/Heading/styles.scss';
 @import '../lib/SearchInput/styles.scss';
+@import '../lib/Modal/styles.scss';
 
 #root {
   padding: 20px; // Give the playarea some room to breathe

--- a/tests/Modal/Modal.js
+++ b/tests/Modal/Modal.js
@@ -1,0 +1,20 @@
+import { React, expect, sinon, jsDomGlobal, shallow, mount } from '../setup';
+import Modal from '../../lib/Modal/';
+
+jsDomGlobal();
+
+describe('Modal', () => {
+  let sandbox, props;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('renders a <Modal> component', () => {
+    expect(false).to.be.true;
+  });
+});


### PR DESCRIPTION
Add an example for a simple Modal.

I had to create two small components for this, Header and Footer, since our only implementation of the React Modal component so far in the app hides them... and we didn't really account for them when we first built it.

This is one of those to really be refactored! 