### PR TITLE
Fixes to Babel setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": ["es2015", "stage-0", "react"],
+  "plugins": ["inline-react-svg"]
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-cli": "^6.18.0",
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
+    "babel-plugin-inline-react-svg": "^0.2.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",


### PR DESCRIPTION
There was a bug that was causing one of our components to break the whole library. This was due to how inline SVG's were handled in the `ProgressButton` component.

Adding this plugin resolves the issue.

