### PR TITLE
Refactor Carousel

### DIFF
--- a/lib/Carousel/Slides.js
+++ b/lib/Carousel/Slides.js
@@ -24,7 +24,7 @@ const CarouselSlides = (props) => {
 
   const indicators = React.Children.map(props.children, (child, index) => {
     const isActive = props.selected === index ? 'is-active' : '';
-    const classes = ['carousel-indicator__item', isActive].join(' ');
+    const classes = ['carousel__indicator-item', isActive].join(' ');
 
     return (
       <button
@@ -42,7 +42,7 @@ const CarouselSlides = (props) => {
 
   return (
     <div style={styles.root} className={props.className}>
-      <div className="carousel-indicators">
+      <div className="carousel__indicators">
         {props.showIndicators && indicators}
       </div>
       <div style={styles.inner}>

--- a/lib/Carousel/index.js
+++ b/lib/Carousel/index.js
@@ -1,15 +1,38 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import CarouselSlides from './Slides';
-import composeNavigation from './composition/navigation';
+import mapNavigationToProps from './composition/navigation';
 
-const Carousel = (props) =>
-  <CarouselSlides
-    showIndicators
-    selected={props.selected}
-    goToSlide={props.goToSlide}
-    className={`gc-carousel ${props.className}`}
-  >
-    { props.children }
-  </CarouselSlides>;
+class Carousel extends Component {
+  static propTypes = {
+    children: PropTypes.arrayOf(PropTypes.node),
+  };
 
-export default composeNavigation(Carousel);
+  constructor() {
+    super();
+    this.renderChildren = this.renderChildren.bind(this);
+  }
+
+  renderChildren() {
+    return React.Children.map(this.props.children,
+      (child) => React.cloneElement(child, {
+        goNext: this.props.goNext,
+        goPrevious: this.props.goPrevious,
+      })
+    );
+  }
+
+  render() {
+    return (
+      <CarouselSlides
+        showIndicators
+        selected={this.props.selected}
+        goToSlide={this.props.goToSlide}
+        className={`gc-carousel ${this.props.className}`}
+      >
+        { this.renderChildren() }
+      </CarouselSlides>
+    )
+  }
+}
+
+export default mapNavigationToProps(Carousel);

--- a/lib/Carousel/index.js
+++ b/lib/Carousel/index.js
@@ -5,6 +5,7 @@ import mapNavigationToProps from './composition/navigation';
 class Carousel extends Component {
   static propTypes = {
     children: PropTypes.arrayOf(PropTypes.node),
+    className: PropTypes.string,
   };
 
   constructor() {
@@ -27,7 +28,7 @@ class Carousel extends Component {
         showIndicators
         selected={this.props.selected}
         goToSlide={this.props.goToSlide}
-        className={`gc-carousel ${this.props.className}`}
+        className={`carousel ${this.props.className}`}
       >
         { this.renderChildren() }
       </CarouselSlides>

--- a/lib/Carousel/styles.scss
+++ b/lib/Carousel/styles.scss
@@ -5,7 +5,8 @@ $carousel-indicators-margin: $layout-spacing-base !default;
 $carousel-indicator-item-width: 10px !default;
 $carousel-indicator-item-height: 10px !default;
 $carousel-indicator-item-margin-right: $layout-spacing-base/2 !default;
-$carousel-indicator-item-background: $color-btn-default-light--bg !default;
+$carousel-indicator-item-background: $color-background-light !default;
+$carousel-indicator-item-active-background: $color-background-blue !default;
 
 /* ==========================================================================
    Styles
@@ -29,6 +30,6 @@ $carousel-indicator-item-background: $color-btn-default-light--bg !default;
     transition: all .2s ease;
 
     &.is-active {
-        background-color: $color-btn-secondary--bg;
+        background-color: $carousel-indicator-item-active-background;
     }
 }

--- a/lib/Carousel/styles.scss
+++ b/lib/Carousel/styles.scss
@@ -1,43 +1,34 @@
-.gc-carousel {
+/* ==========================================================================
+   Config
+   ========================================================================== */
+$carousel-indicators-margin: $layout-spacing-base !default;
+$carousel-indicator-item-width: 10px !default;
+$carousel-indicator-item-height: 10px !default;
+$carousel-indicator-item-margin-right: $layout-spacing-base/2 !default;
+$carousel-indicator-item-background: $color-btn-default-light--bg !default;
+
+/* ==========================================================================
+   Styles
+   ========================================================================== */
+.carousel {
     position: relative;
-    line-height: 1.45;
 }
 
-.gc-carousel {
-    .carousel-indicators {
-        position: relative;
-        margin-bottom: 20px;
+.carousel__indicators {
+    margin-bottom: $carousel-indicators-margin;
+}
+
+.carousel__indicator-item {
+    border: none;
+    padding: 0;
+    background-color: $carousel-indicator-item-background;
+    width: $carousel-indicator-item-width;
+    height: $carousel-indicator-item-height;
+    margin-right: $carousel-indicator-item-margin-right;
+    border-radius: 50%;
+    transition: all .2s ease;
+
+    &.is-active {
+        background-color: $color-btn-secondary--bg;
     }
-
-    .carousel-indicator__item {
-        border: none;
-        padding: 0;
-        background-color: #E4E8EE;
-        cursor: pointer;
-        width: 10px;
-        height: 10px;
-        display: inline-block;
-        margin-right: 10px;
-        border-radius: 50%;
-        vertical-align: middle;
-        transition: all .2s ease;
-
-        &.is-active {
-            background-color: #3D8AEB;
-        }
-    }
-}
-
-.gc-carousel__controls {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-}
-
-/**
- * Modifiers
- */
-
-.gc-carousel--welcome .carousel__slide-wrapper {
-    height: 330px;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ export Table from './Table';
 export PlanBox from './PlanBox';
 export PlanBoxPricing from './PlanBox/Pricing';
 export PlanBoxAllowanceDetails from './PlanBox/AllowanceDetails';
-export CarouselSlides from './Carousel';
+export Carousel from './Carousel';
 export RadioButtonGroup from './Form/RadioButtonGroup';
 export DropdownSwitcher from './DropdownSwitcher';
 export Modal from './Modal';

--- a/stories/components/Carousel.js
+++ b/stories/components/Carousel.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
 import Carousel from '../../lib/Carousel/';
 import StoryItem from '../styleguide/StoryItem';
+import ExampleCarouselChild from '../styleguide/ExampleCarouselChild';
 
 storiesOf('Components', module)
   .add('Carousel', () => {
@@ -15,9 +16,9 @@ storiesOf('Components', module)
             selected={1}
             className="gc-carousel"
           >
-            <div>Slide 1</div>
-            <div>Slide 2</div>
-            <div>Slide 3</div>
+            <ExampleCarouselChild title="Slide 1" />
+            <ExampleCarouselChild title="Slide 2" />
+            <ExampleCarouselChild title="Slide 3" />
           </Carousel>
         </StoryItem>
       </div>

--- a/stories/styleguide/ExampleCarouselChild.js
+++ b/stories/styleguide/ExampleCarouselChild.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ExampleCarouselChild = (props) =>
+  <div>
+    <h2>{props.title}</h2>
+    <button onClick={props.goNext}>Next</button>
+  </div>;
+
+export default ExampleCarouselChild;

--- a/styles/settings/_colours.scss
+++ b/styles/settings/_colours.scss
@@ -15,34 +15,10 @@ $color-link-hover: rgb(61, 125, 204);
 $color-link-quiet: #C8C8C8;
 
 /* ==========================================================================
-   Status (danger, warning, success & info)
-   ========================================================================== */
-
-/* ==========================================================================
    Backgrounds
    ========================================================================== */
-
-$color-well-background: rgb(251, 252, 253);
 $color-background-light: rgb(241, 241, 241);
-
-/* ==========================================================================
-   Alerts
-   ========================================================================== */
-$color-alert--danger: #FEEEEE;
-$color-alert--danger-text: #B33D37;
-$color-alert--danger-border: #FCCECB;
-
-$color-alert--warning: #FFFCEF;
-$color-alert--warning-text: #71591C;
-$color-alert--warning-border: #FCF5D2;
-
-$color-alert--success: #EFFAF2;
-$color-alert--success-text: #206B17;
-$color-alert--success-border: #CFF1D8;
-
-$color-alert--info: #F7F9FA;
-$color-alert--info-text: #4B5761;
-$color-alert--info-border: #EDEEEF;
+$color-background-blue: rgb(70, 142, 229);
 
 /* ==========================================================================
    Buttons


### PR DESCRIPTION
I have resolved how we expose the navigation methods to those consuming the component via cloning the children prop and adding props to them.

This mean that if you need to access navigation methods then you'll need to pass a component down as a child, which I believe is nicer anyways.

If you don't need to access the navigation then just add divs etc as children 👍 

------

I've added an Issue on a bug around how the component calculates the active indicator when the user goes passed the last slide.