### PR TITLE
Fix form choices

### DIFF
--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -2,7 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FieldValidations from './FieldValidations';
 import FieldActions from './FieldActions';
-import { Grid, Row, Col } from 'react-bootstrap/lib';
+import Grid from 'react-bootstrap/lib/Grid';
+import Row from 'react-bootstrap/lib/Row';
+import Col from 'react-bootstrap/lib/Col';
 
 const Field = (props) => {
   if (props.isLoading) {

--- a/lib/FileCard/index.js
+++ b/lib/FileCard/index.js
@@ -13,7 +13,7 @@ class FileCard extends Component {
     label: PropTypes.string,
     showDelete: PropTypes.bool,
     type: PropTypes.string.isRequired,
-    actions: PropTypes.shape([]).isRequired,
+    actions: PropTypes.shape({}).isRequired,
   }
 
   static defaultProps = {
@@ -25,7 +25,13 @@ class FileCard extends Component {
     hasComments: false,
   };
 
+  constructor() {
+    super();
+    this.getActions = this.getActions.bind(this);
+  }
+
   getActions(type) {
+    console.log(this.props.actions);
     switch (type) {
       case 'image':
         return [

--- a/lib/Form/Checkbox/Input.js
+++ b/lib/Form/Checkbox/Input.js
@@ -9,7 +9,7 @@ const Input = ({name, id, checked, disabled, onChangeHandler, ...rest}) =>
     name={name}
     id={id}
     onChange={onChangeHandler}
-    defaultChecked={checked}
+    checked={checked}
     {...rest}
   />;
 
@@ -22,7 +22,6 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
-  checked: false,
   name: '',
   disabled: false,
   onChangeHandler: () => {},

--- a/lib/Form/RadioButton/Input.js
+++ b/lib/Form/RadioButton/Input.js
@@ -10,7 +10,7 @@ const Input = ({disabled, name, value, id, checked, onChangeHandler, ...rest}) =
     value={value}
     id={id}
     onChange={onChangeHandler}
-    defaultChecked={checked}
+    checked={checked}
     {...rest}
   />;
 
@@ -24,7 +24,6 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
-  checked: false,
   value: '',
   disabled: false,
   onChangeHandler: () => {},

--- a/stories/components/FileCard.js
+++ b/stories/components/FileCard.js
@@ -3,11 +3,20 @@ import { storiesOf, action } from '@storybook/react';
 import FileCard from '../../lib/FileCard';
 import StoryItem from '../styleguide/StoryItem';
 
-const actions = [
-  function downloadHandler() {},
-  function fullscreenHandler() {},
-  function commentHandler() {},
-];
+const actions = {
+  deleteHandler() {
+    console.log('delete handler')
+  },
+  fullscreenHandler() {
+    console.log('full screen handler');
+  },
+  downloadHandler() {
+    console.log('download handler');
+  },
+  commentHandler() {
+    console.log('comment handler');
+  }
+};
 
 storiesOf('Components', module)
   .add('FileCard', () => {


### PR DESCRIPTION
This turns effectively the Choices/Radio components into controlled components, rather than uncontrolled ones (which we'll need to revisit, sooner rather than later). But the priority is to make them work with the Item editor first, and then in isolation.

This also fixes the actions object being passed down to the FileCard.