### PR TITLE
Add black and white offline property for Avatar. Minor styling tweaks

### DIFF
--- a/lib/Avatar/index.js
+++ b/lib/Avatar/index.js
@@ -5,28 +5,36 @@ import cx from 'classnames';
 /**
  * @usage
  *
- * <Avatar initials="MR" color="green" url="img/url" onlyInitials isHighlighted fadedOut />
+ * <Avatar initials="MR" color="green" url="img/url" onlyInitials isHighlighted offline />
  */
 const Avatar = (props) => {
-  const styleClass = cx({
-    'is-faded': props.fadedOut,
-    'is-highlighted': props.isHighlighted,
-  });
+  const displayImage = props.url && !props.onlyInitials && !props.offline;
+  const displayGreyedImage = props.url && props.offline;
 
   const styles = {
-    backgroundColor: props.colour,
+    backgroundColor: !displayGreyedImage ? props.colour : 'transparent',
     zIndex: props.index,
   };
 
+  const styleClass = cx({
+    'is-highlighted': props.isHighlighted,
+    'is-offline': props.offline,
+    'has-image': displayImage || displayGreyedImage,
+  });
+
   return (
     <div style={styles} className={`avatar ${props.className} ${styleClass}`}>
-      { props.onlyInitials &&
+      { (props.onlyInitials || !props.url) &&
         <div className="avatar__wrapper">
           <span className="avatar__initials">{props.initials}</span>
         </div>
       }
-      { props.url && !props.onlyInitials && !props.fadedOut &&
+      { displayImage &&
         <img className="avatar__image" src={props.url} alt={props.name} />
+      }
+
+      { displayGreyedImage &&
+        <img className="avatar__image avatar__image--offline" src={props.url} alt={props.name} />
       }
     </div>
   );
@@ -38,7 +46,7 @@ Avatar.defaultProps = {
   colour: 'rgb(60, 50, 60)',
   name: '',
   index: 0,
-  fadedOut: false,
+  offline: false,
   isHighlighted: false,
   url: null,
   initials: null,
@@ -52,7 +60,7 @@ Avatar.propTypes = {
   index: PropTypes.number,
   initials: PropTypes.string,
   url: PropTypes.string,
-  fadedOut: PropTypes.bool,
+  offline: PropTypes.bool,
   isHighlighted: PropTypes.bool,
 };
 

--- a/lib/Avatar/index.js
+++ b/lib/Avatar/index.js
@@ -8,11 +8,13 @@ import cx from 'classnames';
  * <Avatar initials="MR" color="green" url="img/url" onlyInitials isHighlighted offline />
  */
 const Avatar = (props) => {
+  const offlineBg = Avatar.defaultProps.colour;
   const displayImage = props.url && !props.onlyInitials && !props.offline;
   const displayGreyedImage = props.url && props.offline;
+  const backgroundColor = props.offline ? offlineBg : props.colour;
 
   const styles = {
-    backgroundColor: !displayGreyedImage ? props.colour : 'transparent',
+    backgroundColor: !displayGreyedImage ? backgroundColor : 'transparent',
     zIndex: props.index,
   };
 

--- a/lib/Avatar/styles.scss
+++ b/lib/Avatar/styles.scss
@@ -7,7 +7,7 @@ $avatar-tooltip-name-weight: $typo-weight-semi-bold !default;
 $avatar-tooltip-name-size: $typo-size-lead !default;
 
 $avatar-show-more-background: rgb(175, 165, 175) !default;
-$avatar-faded-background: rgb(60, 50, 60) !default;
+$avatar-offline-background: rgb(60, 50, 60) !default;
 $avatar-shadow: 0 0 0 1px rgba(100, 100, 100, 0.2) inset !default;
 $avatar-pillbox-padding: $typo-size-lead/3 $typo-size-lead/2 !default;
 
@@ -34,12 +34,18 @@ $avatar-highlight-shadow: 0 0 0 2px rgb(155, 169, 185) inset !default;
     z-index: 5 !important; // Overrides inline JSX styling
   }
 
-  &.is-faded {
-    background: $avatar-faded-background !important;
+  &.is-offline {
+    background: $avatar-offline-background;
+    box-shadow: none;
   }
 
   &.is-highlighted {
     box-shadow: $avatar-highlight-shadow;
+  }
+
+  &.has-image {
+    box-shadow: none;
+    background: transparent;
   }
 }
 
@@ -73,6 +79,15 @@ $avatar-highlight-shadow: 0 0 0 2px rgb(155, 169, 185) inset !default;
   height: 100%;
   overflow: hidden;
   border-radius: 50%;
+}
+
+.avatar__image--offline {
+  opacity: .6;
+
+  @supports (filter: grayscale(100)) {
+    filter: grayscale(100);
+    opacity: 1;
+  }
 }
 
 .avatar-group-list {

--- a/stories/components/Avatar.js
+++ b/stories/components/Avatar.js
@@ -10,6 +10,20 @@ storiesOf('Components', module)
     return (
       <div>
         <StoryItem
+          title="Avatar — falls back to initials"
+          description="If a url prop isn't given to Avatar, it will fallback to its initials."
+        >
+          <div>
+            <Avatar
+              url=""
+              initials="SB"
+              name="Seymour Butts"
+              email="example@gmail.com"
+              colour="rgb(155, 223, 190)"
+            />
+          </div>
+        </StoryItem>
+        <StoryItem
           title="Avatar — only with initials"
           description="Simple avatars, to be used individually (not in a group). Here, examples with two colours passed through the component, with one assigned user."
         >
@@ -78,7 +92,20 @@ storiesOf('Components', module)
             name="Seymour Butts"
             initials="SB"
             email="example@gmail.com"
-            fadedOut
+            offline
+          />
+        </StoryItem>
+
+        <StoryItem
+          title="Avatar — with image, offline"
+          description="An avatar with an image, but offline, appears greyed out."
+        >
+          <Avatar
+            url="https://pbs.twimg.com/profile_images/766954609306927104/ZHAfr9OP_400x400.jpg"
+            name="Seymour Butts"
+            initials="SB"
+            email="example@gmail.com"
+            offline
           />
         </StoryItem>
 
@@ -107,10 +134,10 @@ storiesOf('Components', module)
           title="Avatar List Group — extra users"
           description="A list of overlapping avatars can be used by wrapping them in a `AvatarGroup` component, only fitting in a maximum number of N. Other avatars can be displayed by tapping the plus sign.">
           <AvatarGroup maximum={1}>
-            <Avatar email="poppycox@gmail.com" onlyInitials isHighlighted fadedOut initials="MR" name="Mike Rotch"/>
-            <Avatar email="hugh@gmail.com" onlyInitials fadedOut initials="HJ" name="Hugh Jass"/>
-            <Avatar email="la@gmail.com" onlyInitials fadedOut initials="FD" name="Fedra Droid"/>
-            <Avatar email="la@gmail.com" onlyInitials fadedOut initials="KM" name="Kann Schemll"/>
+            <Avatar email="poppycox@gmail.com" onlyInitials isHighlighted offline initials="MR" name="Mike Rotch"/>
+            <Avatar email="hugh@gmail.com" onlyInitials offline initials="HJ" name="Hugh Jass"/>
+            <Avatar email="la@gmail.com" onlyInitials offline initials="FD" name="Fedra Droid"/>
+            <Avatar email="la@gmail.com" onlyInitials offline initials="KM" name="Kann Schemll"/>
           </AvatarGroup>
         </StoryItem>
       </div>

--- a/stories/components/Avatar.js
+++ b/stories/components/Avatar.js
@@ -134,10 +134,10 @@ storiesOf('Components', module)
           title="Avatar List Group — extra users"
           description="A list of overlapping avatars can be used by wrapping them in a `AvatarGroup` component, only fitting in a maximum number of N. Other avatars can be displayed by tapping the plus sign.">
           <AvatarGroup maximum={1}>
-            <Avatar email="poppycox@gmail.com" onlyInitials isHighlighted offline initials="MR" name="Mike Rotch"/>
-            <Avatar email="hugh@gmail.com" onlyInitials offline initials="HJ" name="Hugh Jass"/>
-            <Avatar email="la@gmail.com" onlyInitials offline initials="FD" name="Fedra Droid"/>
-            <Avatar email="la@gmail.com" onlyInitials offline initials="KM" name="Kann Schemll"/>
+            <Avatar url="https://pbs.twimg.com/profile_images/766954609306927104/ZHAfr9OP_400x400.jpg" email="poppycox@gmail.com" isHighlighted offline initials="MR" name="Mike Rotch"/>
+            <Avatar email="hugh@gmail.com" colour="rgb(249,99,89)" offline initials="HJ" name="Hugh Jass"/>
+            <Avatar email="la@gmail.com" offline initials="FD" name="Fedra Droid"/>
+            <Avatar email="la@gmail.com" offline initials="KM" name="Kann Schemll"/>
           </AvatarGroup>
         </StoryItem>
       </div>


### PR DESCRIPTION
This adds a few changes as discussed for the Avatar component, although not all of them are done.

- Black and white picture given an `offline` property (previously, `fadedOut`)
- Fall back to initials if the `url` property is Falsy
- Remove background if the image is shown (as not to show a leaking background colour)