### PR TITLE
Feature travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js: "node"
+script: yarn test && yarn lint

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ require('gather-ui/dist/styles.css');
 ## External dependencies
 
 This particular version of the Styleguide depends on the Bootstrap and FontAwesome libraries. These do not ship with the components' CSS and should be included separately wherever they are consumed.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GatherContent UI Library
+[![Build Status](https://travis-ci.org/gathercontent/gather-ui.svg?branch=master)](https://travis-ci.org/gathercontent/gather-ui)
 
 **Warning: This is still an experimental repository and all commands and functionality are bound to change.**
 UI component library for all GatherContent components.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bootstrap": "3.3.6",
     "bootstrap-sass": "^3.3.7",
     "classnames": "^2.2.5",
-    "font-awesome": "git+ssh://git@github.com/FortAwesome/Font-Awesome.git",
+    "font-awesome": "^4.7.0",
     "normalize-scss": "^6.0.0",
     "pluralize": "^5.0.0",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
Adds Travis CI to the project.
It also changes the way we load FontAwesome dependency - I'm not sure why it was loaded like this?

Note - I tried setting up on CodeShip but then changed my mind and have now removed that, it is just using Travis CI. But some of the builds are marked as "failed" - this is just because I didn't get Codeship passing before I removed it. I think this will go away the next commit/PR we make.