### PR TITLE
Add FieldAside

### DIFF
--- a/lib/Field/FieldActions.js
+++ b/lib/Field/FieldActions.js
@@ -5,13 +5,14 @@ import Button from '../Button';
 const FieldActions = (props) => {
   const actions = props.actions.map(action => (
     <Button
+      key={`${props.fieldId}-action-${action.text}`}
       className="field__action"
       clickHandler={action.clickHandler}
       types={['link-default', 'collapse']}
     >
       {action.text}
     </Button>
-    ));
+  ));
 
   return (
     <div className="field__actions">{actions}</div>
@@ -20,6 +21,7 @@ const FieldActions = (props) => {
 
 FieldActions.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  fieldId: PropTypes.string.isRequired,
 };
 
 export default FieldActions;

--- a/lib/Field/FieldAside.js
+++ b/lib/Field/FieldAside.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const FieldAside = props => (
+  <div className="field__aside">
+    {props.children}
+  </div>
+);
+
+FieldAside.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default FieldAside;

--- a/lib/Field/FieldValidations.js
+++ b/lib/Field/FieldValidations.js
@@ -2,11 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FieldValidations = (props) => {
-  const validations = props.validations.map((action) => {
-    const cssClass = (action.hasFailed) ? 'has-failed' : '';
+  const validations = props.validations.map((validation) => {
+    const cssClass = (validation.hasFailed) ? 'has-failed' : '';
 
     return (
-      <span className={`field__validation ${cssClass}`}>{action.text}</span>
+      <span
+        key={`${props.fieldId}-validation-${validation.text}`}
+        className={`field__validation ${cssClass}`}
+      >
+        {validation.text}
+      </span>
     );
   });
 
@@ -17,6 +22,7 @@ const FieldValidations = (props) => {
 
 FieldValidations.propTypes = {
   validations: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  fieldId: PropTypes.string.isRequired,
 };
 
 export default FieldValidations;

--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -27,8 +27,14 @@ const Field = (props) => {
           className="field__data"
         >
           <div className="field__label">{props.label}</div>
-          <FieldActions actions={props.actions} />
-          <FieldValidations validations={props.validations} />
+          <FieldActions
+            fieldId={props.fieldId}
+            actions={props.actions}
+          />
+          <FieldValidations
+            fieldId={props.fieldId}
+            validations={props.validations}
+          />
         </Col>
 
         <Col
@@ -36,7 +42,9 @@ const Field = (props) => {
           sm={8}
           className="field__content"
         >
-          {props.children}
+          <div className="field__child">
+            {props.children}
+          </div>
           <div className="field__instructions">{props.instructions}</div>
         </Col>
       </Row>
@@ -52,7 +60,7 @@ Field.propTypes = {
   isLoading: PropTypes.bool,
   actions: PropTypes.arrayOf(PropTypes.shape()),
   validations: PropTypes.arrayOf(PropTypes.shape()),
-  fieldId: PropTypes.string,
+  fieldId: PropTypes.string.isRequired,
 };
 
 Field.defaultProps = {
@@ -60,7 +68,6 @@ Field.defaultProps = {
   label: '',
   instructions: '',
   isReadOnly: false,
-  fieldId: '',
   isLoading: false,
   actions: [],
   validations: [],

--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -2,6 +2,7 @@
    Config
    ========================================================================== */
 $field-spacing-base: $layout-spacing-base !default;
+$field-aside-width: 40px !default;
 
 $field-label-size: $typo-size-lead !default;
 $field-label-weight: $typo-weight-semi-bold !default;
@@ -45,4 +46,22 @@ $field-data-color: $color-brand-dark !default;
 .field__instructions {
   font-style: italic;
   margin: $field-spacing-base 0 0;
+}
+
+.field__child {
+  position: relative;
+}
+
+.field__aside {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  top: 0;
+  width: $field-aside-width;
+}
+
+.field__aside-action {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ export RadioButtonGroup from './Form/RadioButtonGroup';
 export DropdownSwitcher from './DropdownSwitcher';
 export Modal from './Modal';
 export Field from './Field';
+export FieldAside from './Field/FieldAside';
 export FileCard from './FileCard';
 export Conversation from './Conversation';
 export RadioButton from './Form/RadioButton';

--- a/stories/components/Field.js
+++ b/stories/components/Field.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf, action } from '@storybook/react';
-import Field from '../../lib/Field';
+import { Field, FieldAside, Button, Icon } from '../../lib/index';
 import StoryItem from '../styleguide/StoryItem';
 
 const mockValidations = [{
@@ -20,34 +20,46 @@ const mockActions = [{
 }];
 
 storiesOf('Components', module)
-  .add('Field', () => {
-    return (
-      <div>
-        <StoryItem
-          title="Field"
-          description="A field component provides supporting UI for gathering content. The child component should be responsible for handling the gathering experience but this component renders labels, actions and validations to support that experience."
+  .add('Field', () => (
+    <div>
+      <StoryItem
+        title="Field"
+        description="A field component provides supporting UI for gathering content. The child component should be responsible for handling the gathering experience but this component renders labels, actions and validations to support that experience."
+      >
+        <Field
+          fieldId="123"
+          label="Field label text"
+          actions={mockActions}
+          validations={mockValidations}
+          instructions="Instruction text to help inform the user of what they are mean't to add into this field."
         >
-          <Field
-            label="Field label text"
-            actions={mockActions}
-            validations={mockValidations}
-            instructions="Instruction text to help inform the user of what they are mean't to add into this field."
-          >
-            <small><i>A child component will be rendered here...</i></small>
-          </Field>
-        </StoryItem>
+          <div>
+            <p>Hello world...</p>
+            <FieldAside>
+              <Button
+                className="field__aside-action"
+                types={['icon-only']}
+                clickHandler={() => action('field aside action clicked')}
+              >
+                <Icon name="plus" size="small" />
+              </Button>
+            </FieldAside>
+          </div>
+        </Field>
+      </StoryItem>
 
-        <StoryItem
-          title="Field (loading)"
-          description="A field component when loading">
-          <Field isLoading={true} />
-        </StoryItem>
+      <StoryItem
+        title="Field (loading)"
+        description="A field component when loading"
+      >
+        <Field isLoading fieldId="321" />
+      </StoryItem>
 
-        <StoryItem
-          title="Field (read only)"
-          description="A field component when it's read only">
-          <Field isReadOnly={true} />
-        </StoryItem>
-      </div>
-    );
-  });
+      <StoryItem
+        title="Field (read only)"
+        description="A field component when it's read only"
+      >
+        <Field isReadOnly fieldId="987" />
+      </StoryItem>
+    </div>
+  ));


### PR DESCRIPTION
A `Field` component can use a aside component within it. A field aside can hold anything but it's main purpose is to hold a single button/action.

An example for an action would be something like adding a comment/annotation to the entire field or depending on the consumer maybe something more specific.