### PR TITLE
Spread props to div wrapper

### DIFF
--- a/lib/Field/FieldAside.js
+++ b/lib/Field/FieldAside.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FieldAside = props => (
-  <div className="field__aside">
+  <div
+    {...props}
+    className="field__aside"
+  >
     {props.children}
   </div>
 );

--- a/tests/Field/Field.js
+++ b/tests/Field/Field.js
@@ -14,7 +14,7 @@ describe('Field', () => {
         instructions="Instructions test text"
       >
         <Button clickHandler={() => {}}>Hello world</Button>
-      </Field>
+      </Field>,
     );
   });
 

--- a/tests/Field/FieldAside.js
+++ b/tests/Field/FieldAside.js
@@ -1,0 +1,24 @@
+import { React, expect, shallow } from '../setup';
+import { FieldAside, Button } from '../../lib/index';
+
+describe('Field aside', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <FieldAside label="Test label">
+        <Button clickHandler={() => {}}>Hello world</Button>
+      </FieldAside>,
+    );
+  });
+
+  afterEach(() => {});
+
+  it('shares props with field__aside div', () => {
+    expect(wrapper.find('.field__aside').prop('label')).to.equal('Test label');
+  });
+
+  it('renders its children', () => {
+    expect(wrapper.find(Button)).to.have.length(1);
+  });
+});


### PR DESCRIPTION
The PR https://github.com/gathercontent/gather-ui/pull/86 was missing the spreading of props to the inner wrapping div.

This is very import for setting inline styles for instances where you may need to align the aside with an element within the child component. E.g. when hovering over a paragraph align the aside to the height of the node.

This PR also adds the missing test for the `FieldAside` 👍 