### PR TITLE
Hide instructions when none are set

### DIFF
--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -43,9 +43,12 @@ const Field = (props) => {
         >
           <div className="field__content">
             <div className="field__child">
-              {props.children}
+              { props.children }
             </div>
-            <div className="field__instructions">{props.instructions}</div>
+
+            { props.instructions &&
+              <div className="field__instructions">{props.instructions}</div>
+            }
           </div>
         </Col>
       </Row>

--- a/tests/Field/Field.js
+++ b/tests/Field/Field.js
@@ -50,5 +50,11 @@ describe('Field', () => {
 
   it('renders instructions', () => {
     expect(wrapper.contains('Instructions test text')).to.be.true;
+
+    wrapper.setProps({
+      instructions: '',
+    });
+
+    expect(wrapper.contains('Instructions test text')).to.be.false;
   });
 });


### PR DESCRIPTION
A small change which fixes instances where the instructions aren't set and set the margin is still applied causing more space to be created.