### PR TITLE
changing focus-fallback styling

### DIFF
--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -104,7 +104,8 @@ $conversation-meta-text-color: $neutral-base !default;
 }
 
 .conversation__focus-fallback {
-  position: absolute;
+  position: fixed;
+  bottom: 0;
   left: -999em;
 }
 


### PR DESCRIPTION
A fix for conversation focusFallback causing scroll to shift if the bottom of the conversation (and the focusFallback itself) was out of view.

Simple fix, just making it so the fallback is always at the bottom of the window rather than the conversation itself.