### PR TITLE
Field Formatting Prop

### DIFF
--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -16,7 +16,8 @@ const Field = props => {
   }
 
   const additionalClasses = cx({
-    field__editor: props.canEdit
+    field__editor: props.canEdit,
+    'has-formatting': props.hasFormatting
   });
 
   return (
@@ -69,6 +70,7 @@ Field.propTypes = {
   isReadOnly: PropTypes.bool,
   isLoading: PropTypes.bool,
   canEdit: PropTypes.bool,
+  hasFormatting: PropTypes.bool,
   actions: PropTypes.arrayOf(PropTypes.shape()),
   validations: PropTypes.arrayOf(PropTypes.shape()),
   fieldId: PropTypes.string.isRequired,
@@ -83,6 +85,7 @@ Field.defaultProps = {
   isReadOnly: false,
   isLoading: false,
   canEdit: false,
+  hasFormatting: false,
   actions: [],
   validations: [],
   labelChange: () => {},

--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -53,7 +53,74 @@ $field-data-color: $neutral-base !default;
   padding-left: $field-spacing-base;
   font-size: $typo-size-lead;
   margin-right: $field-aside-width;
+}
 
+.field__aside {
+  position: absolute;
+  height: 100%;
+  right: 0;
+  top: 0;
+  width: $field-aside-width;
+}
+
+.field__aside-action {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.field-aside__button {
+  margin-bottom: $field-spacing-base/2;
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.field__editor {
+  .field__content {
+    box-shadow: $shadow-shallow;
+    background-color: white;
+    padding: 0;
+    border-radius: 5px;
+    border: 1px solid $neutral-light;
+  }
+  .field__child {
+    padding: $field-spacing-base/2;
+    color: $neutral-light;
+    font-size: $typo-size-lead;
+    p {
+      margin: 0;
+      font-size: $typo-size-lead;
+    }
+  }
+
+  .field__label,
+  .field__instructions {
+    border: 0;
+    resize: none;
+    overflow: auto;
+    outline: none;
+    display: block;
+    width: 100%;
+    height: auto;
+    color: $neutral-dark;
+  }
+  .field__instructions {
+    font-size: $typo-size-small;
+    text-decoration: none;
+    font-style: normal;
+    padding: $field-spacing-base/2;
+    margin: 0;
+    border-top: 1px solid $neutral-light;
+    border-radius: 0 0 $field-spacing-base/4 $field-spacing-base/4;
+  }
+  .field__label {
+    text-align: right;
+    background: transparent;
+  }
+}
+
+.field.has-formatting {
   *:nth-child(1) {
     margin-top: 0;
   }
@@ -145,70 +212,5 @@ $field-data-color: $neutral-base !default;
         margin-top: 10px;
       }
     }
-  }
-}
-
-.field__aside {
-  position: absolute;
-  height: 100%;
-  right: 0;
-  top: 0;
-  width: $field-aside-width;
-}
-
-.field__aside-action {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-.field-aside__button {
-  margin-bottom: $field-spacing-base/2;
-  &:last-of-type {
-    margin-bottom: 0;
-  }
-}
-
-.field__editor {
-  .field__content {
-    box-shadow: $shadow-shallow;
-    background-color: white;
-    padding: 0;
-    border-radius: 5px;
-    border: 1px solid $neutral-light;
-  }
-  .field__child {
-    padding: $field-spacing-base/2;
-    color: $neutral-light;
-    font-size: $typo-size-lead;
-    p {
-      margin: 0;
-      font-size: $typo-size-lead;
-    }
-  }
-
-  .field__label,
-  .field__instructions {
-    border: 0;
-    resize: none;
-    overflow: auto;
-    outline: none;
-    display: block;
-    width: 100%;
-    height: auto;
-    color: $neutral-dark;
-  }
-  .field__instructions {
-    font-size: $typo-size-small;
-    text-decoration: none;
-    font-style: normal;
-    padding: $field-spacing-base/2;
-    margin: 0;
-    border-top: 1px solid $neutral-light;
-    border-radius: 0 0 $field-spacing-base/4 $field-spacing-base/4;
-  }
-  .field__label {
-    text-align: right;
-    background: transparent;
   }
 }

--- a/stories/components/Field.js
+++ b/stories/components/Field.js
@@ -32,6 +32,7 @@ storiesOf('Components', module)
           actions={mockActions}
           validations={mockValidations}
           instructions="Instruction text to help inform the user of what they are mean't to add into this field."
+          hasFormatting
         >
           <div>
             <h1>Heading content</h1>

--- a/tests/Field/Field.js
+++ b/tests/Field/Field.js
@@ -63,4 +63,9 @@ describe('Field', () => {
 
     expect(wrapper.contains('Instructions test text')).to.be.false();
   });
+
+  it('adds conditional classes for formatting', () => {
+    wrapper.setProps({ hasFormatting: true });
+    expect(wrapper.hasClass('has-formatting')).to.equal(true);
+  });
 });

--- a/tests/SectionHeader/index.js
+++ b/tests/SectionHeader/index.js
@@ -12,7 +12,6 @@ describe('SectionHeader', () => {
   afterEach(() => {});
 
   it('renders its title', () => {
-    console.log(wrapper.debug());
     expect(wrapper.find('.section-header__title').text()).to.have.equal(
       'Test Title'
     );


### PR DESCRIPTION
There is an issue where using `Guideline`s inside of `Field` means that we apply text styles that we don't want. For situations like this we should be able to turn formatting off.

This PR allows that 👍 