### PR TITLE
Add keyboard shortcuts for submitting comments

### DIFF
--- a/lib/Conversation/CommentForm/index.js
+++ b/lib/Conversation/CommentForm/index.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Avatar from '../../Avatar';
 import ExpandingTextArea from '../../ExpandingTextArea';
 import CommentFormActions from './CommentFormActions';
+import ShortcutTrigger from '../../ShortcutTrigger/index';
 
 class CommentForm extends Component {
   static propTypes = {
@@ -33,17 +34,27 @@ class CommentForm extends Component {
 
   constructor() {
     super();
-    this.state = { inputValue: '' };
+    this.state = {
+      inputValue: '',
+      inputHasFocused: false
+    };
     this.updateInputValue = this.updateInputValue.bind(this);
     this.cancelComment = this.cancelComment.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
+    this.toggleInputHasFocus = this.toggleInputHasFocus.bind(this);
   }
 
   onSubmit(e) {
-    e.preventDefault();
+    if (e) {
+      e.preventDefault();
+    }
     this.props.onSubmit(this.state.inputValue);
     const inputValue = !this.props.isSubmitting ? '' : this.state.inputValue;
     this.setState({ inputValue });
+  }
+
+  toggleInputHasFocus() {
+    this.setState({ inputHasFocused: !this.state.inputHasFocused });
   }
 
   cancelComment() {
@@ -75,12 +86,27 @@ class CommentForm extends Component {
           <ExpandingTextArea
             className="comment-form__input"
             handleOnChange={this.updateInputValue}
+            handleOnFocus={this.toggleInputHasFocus}
             focusOnMount={this.props.focusOnMount}
             value={this.state.inputValue || this.props.value}
             placeholder={this.props.placeholder}
             setValue
           />
         </div>
+        {this.state.inputHasFocused && (
+          <div>
+            <ShortcutTrigger
+              shortcutKey="Enter"
+              onShortcutTrigger={this.onSubmit}
+              withCtrlKey
+            />
+            <ShortcutTrigger
+              shortcutKey="Enter"
+              onShortcutTrigger={this.onSubmit}
+              withMetaKey
+            />
+          </div>
+        )}
         <CommentFormActions
           onSubmit={this.onSubmit}
           onCancel={this.cancelComment}

--- a/lib/ExpandingTextArea/README.md
+++ b/lib/ExpandingTextArea/README.md
@@ -9,6 +9,7 @@ A component that renders a textarea that automatically resizes depending on its 
 | ------------------- |-------------- | --------- | -------- |--------------------------------------------------------------------------------------- |
 | placeholder         | String        | N/A       | Yes      | Placeholder text for the field                                                         |
 | handleOnChange      | Function      | `() {}`   | No       | Executes when the input value is changed                                               |
+| handleOnFocus      | Function      | `() {}`   | No       | Executes when the input is focused and blurred                                              |
 | value               | String        | ''        | No       | The value of the input                                                                 |
 | focusOnMount        | Boolean       | `false`   | No       | Determines whether to focus the textfield on mount                                     |
 | setValue            | Boolean       | `false`   | No       | If false the component will handle input changes and assign the value to its own state |

--- a/lib/ExpandingTextArea/index.js
+++ b/lib/ExpandingTextArea/index.js
@@ -5,6 +5,7 @@ class ExpandingTextArea extends Component {
   static propTypes = {
     placeholder: PropTypes.string.isRequired,
     handleOnChange: PropTypes.func,
+    handleOnFocus: PropTypes.func,
     value: PropTypes.string,
     focusOnMount: PropTypes.bool,
     setValue: PropTypes.bool,
@@ -13,6 +14,7 @@ class ExpandingTextArea extends Component {
 
   static defaultProps = {
     handleOnChange: () => {},
+    handleOnFocus: () => {},
     value: '',
     focusOnMount: false,
     setValue: false,
@@ -95,6 +97,8 @@ class ExpandingTextArea extends Component {
         value={this.state.inputValue || this.props.value}
         placeholder={this.props.placeholder}
         onChange={this.handleChange}
+        onFocus={this.props.handleOnFocus}
+        onBlur={this.props.handleOnFocus}
         rows={this.state.rowCount}
       />
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gather-content-ui",
-  "version": "0.3.52",
+  "version": "0.3.53",
   "description": "GatherContent UI Library",
   "main": "dist/lib/index.js",
   "repository": {

--- a/tests/Conversation/CommentForm/CommentForm.js
+++ b/tests/Conversation/CommentForm/CommentForm.js
@@ -3,6 +3,7 @@ import CommentForm from '../../../lib/Conversation/CommentForm';
 import ExpandingTextArea from '../../../lib/ExpandingTextArea';
 import CommentFormActions from '../../../lib/Conversation/CommentForm/CommentFormActions';
 import Avatar from '../../../lib/Avatar/index';
+import ShortcutTrigger from '../../../lib/ShortcutTrigger/index';
 
 describe('Comment Form', () => {
   let wrapper;
@@ -75,6 +76,10 @@ describe('Comment Form', () => {
 
     wrapper.setProps({ value: 'test' });
     expect(input.prop('value')).to.equal('test');
+
+    expect(input.prop('handleOnFocus')).to.deep.equal(
+      wrapper.instance().toggleInputHasFocus
+    );
   });
 
   it('renders CommentFormActions (with correct props)', () => {
@@ -95,5 +100,32 @@ describe('Comment Form', () => {
   it('updates the input value', () => {
     wrapper.instance().updateInputValue({ target: { value: 'test 2' } });
     expect(wrapper.state('inputValue')).to.equal('test 2');
+  });
+
+  it('toggles the focus state for the input', () => {
+    wrapper.instance().toggleInputHasFocus();
+    expect(wrapper.state('inputHasFocused')).to.equal(true);
+
+    wrapper.instance().toggleInputHasFocus();
+    expect(wrapper.state('inputHasFocused')).to.equal(false);
+  });
+
+  it('renders ShortcutTriggers', () => {
+    expect(wrapper.find(ShortcutTrigger)).to.have.length(0);
+    wrapper.setState({ inputHasFocused: true });
+    const shortcutTriggers = wrapper.find(ShortcutTrigger);
+    expect(shortcutTriggers).to.have.length(2);
+
+    expect(shortcutTriggers.first().prop('shortcutKey')).to.equal('Enter');
+    expect(shortcutTriggers.first().prop('onShortcutTrigger')).to.deep.equal(
+      wrapper.instance().onSubmit
+    );
+    expect(shortcutTriggers.first().prop('withCtrlKey')).to.equal(true);
+
+    expect(shortcutTriggers.last().prop('shortcutKey')).to.equal('Enter');
+    expect(shortcutTriggers.last().prop('onShortcutTrigger')).to.deep.equal(
+      wrapper.instance().onSubmit
+    );
+    expect(shortcutTriggers.last().prop('withMetaKey')).to.equal(true);
   });
 });

--- a/tests/ExpandingTextArea/ExpandingTextArea.js
+++ b/tests/ExpandingTextArea/ExpandingTextArea.js
@@ -3,10 +3,11 @@ import { ExpandingTextArea } from '../../lib';
 
 describe('EditableTextWrapper', () => {
   jsDomGlobal();
+  const sandbox = sinon.sandbox.create();
 
   let wrapper;
-  let sandbox;
   let handleOnChangeSpy;
+  let handleOnFocusSpy;
   let setInitialRowsSpy;
   let handleChangeSpy;
   let resizeTextAreaSpy;
@@ -18,33 +19,33 @@ describe('EditableTextWrapper', () => {
       lineHeight: '20px',
       padding: '10px 0 10px'
     };
-    handleOnChangeSpy = sinon.spy();
-    setInitialRowsSpy = sinon.spy(
+    handleOnChangeSpy = sandbox.spy();
+    handleOnFocusSpy = sandbox.spy();
+    setInitialRowsSpy = sandbox.spy(
       ExpandingTextArea.prototype,
       'setInitialRows'
     );
-    handleChangeSpy = sinon.spy(ExpandingTextArea.prototype, 'handleChange');
-    resizeTextAreaSpy = sinon.spy(
+    handleChangeSpy = sandbox.spy(ExpandingTextArea.prototype, 'handleChange');
+    resizeTextAreaSpy = sandbox.spy(
       ExpandingTextArea.prototype,
       'resizeTextArea'
     );
-    calculateRowsSpy = sinon.spy(ExpandingTextArea.prototype, 'calculateRows');
-    sandbox = sinon.sandbox.create();
+    calculateRowsSpy = sandbox.spy(
+      ExpandingTextArea.prototype,
+      'calculateRows'
+    );
     wrapper = mount(
       <ExpandingTextArea
         style={style}
         placeholder="Placeholder..."
         handleOnChange={handleOnChangeSpy}
+        handleOnFocus={handleOnFocusSpy}
       />
     );
   });
 
   afterEach(() => {
     sandbox.restore();
-    ExpandingTextArea.prototype.setInitialRows.restore();
-    ExpandingTextArea.prototype.handleChange.restore();
-    ExpandingTextArea.prototype.resizeTextArea.restore();
-    ExpandingTextArea.prototype.calculateRows.restore();
   });
 
   it('sets initial rows on render', () => {
@@ -75,6 +76,14 @@ describe('EditableTextWrapper', () => {
     expect(wrapper.state('rowCount')).to.equal(
       calculateRowsSpy.lastCall.returnValue
     );
+  });
+
+  it('calls a prop function when focus and blue', () => {
+    wrapper.simulate('focus', {});
+    expect(handleOnFocusSpy).to.be.calledOnce();
+
+    wrapper.simulate('blur', {});
+    expect(handleOnFocusSpy).to.be.calledTwice();
   });
 
   it('sets the value state if the setValue prop is false', () => {


### PR DESCRIPTION
This PR adds the newly added `ShortcutTrigger` component to the `CommentForm` component. This allows us to trigger the submit for comment via `cmd+enter` or `ctrl+enter`.