### PR TITLE
stopping flex from shrinking avatar--supporting

### DIFF
--- a/lib/Avatar/styles.scss
+++ b/lib/Avatar/styles.scss
@@ -41,6 +41,7 @@ $avatar-pillbox-padding: $typo-size-lead/4 $typo-size-lead/3 !default;
 }
 
 .avatar--supporting {
+  flex-shrink: 0;
   margin: 0 $layout-spacing-base 0 0;
 }
 


### PR DESCRIPTION
Easy fix for avatars appearing 'oval', this happened most notably in conversations when the conversation container was narrow.