### PR TITLE
Add comment edit handlers

### DIFF
--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -46,7 +46,9 @@ class BoundaryClickWatcher extends Component {
 
   handleInnerClick() {
     this.props.insideClickHandler();
-    this.setState({ boundaryIsActive: true });
+    if (typeof this.props.children === 'function') {
+      this.setState({ boundaryIsActive: true });
+    }
     if (!this.props.alwaysListen) {
       this.addDocumentEventListener();
     }
@@ -54,7 +56,9 @@ class BoundaryClickWatcher extends Component {
 
   handleOuterClick(event) {
     this.props.outsideClickHandler(event);
-    this.setState({ boundaryIsActive: false });
+    if (typeof this.props.children === 'function') {
+      this.setState({ boundaryIsActive: false });
+    }
     if (!this.props.alwaysListen) {
       this.removeDocumentEventListener();
     }

--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -16,7 +16,7 @@ class Comment extends Component {
     conversationId: PropTypes.string.isRequired,
     editComment: PropTypes.func.isRequired,
     removeComment: PropTypes.func.isRequired,
-    onEdit: PropTypes.func.isRequired
+    onCommentChange: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -103,7 +103,7 @@ class Comment extends Component {
               placeholder=""
               focusOnMount
               isSubmitting={false}
-              onEdit={this.props.onEdit}
+              onCommentChange={this.props.onCommentChange}
             />
           )}
       </div>

--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -15,7 +15,8 @@ class Comment extends Component {
     user: PropTypes.shape(),
     conversationId: PropTypes.string.isRequired,
     editComment: PropTypes.func.isRequired,
-    removeComment: PropTypes.func.isRequired
+    removeComment: PropTypes.func.isRequired,
+    onEdit: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -94,11 +95,15 @@ class Comment extends Component {
         {userCanEdit &&
           this.state.showEditForm && (
             <CommentForm
+              id={this.props.id}
               onSubmit={this.editComment}
               onCancel={this.hideEditForm}
               author={author}
               value={body}
+              placeholder=""
               focusOnMount
+              isSubmitting={false}
+              onEdit={this.props.onEdit}
             />
           )}
       </div>

--- a/lib/Conversation/CommentForm/index.js
+++ b/lib/Conversation/CommentForm/index.js
@@ -10,7 +10,7 @@ class CommentForm extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     onSubmit: PropTypes.func.isRequired,
-    onEdit: PropTypes.func.isRequired,
+    onCommentChange: PropTypes.func.isRequired,
     onCancel: PropTypes.func,
     author: PropTypes.shape({
       avatar: PropTypes.string,
@@ -65,7 +65,7 @@ class CommentForm extends Component {
   }
 
   updateInputValue(e) {
-    this.props.onEdit(this.props.id, e.target.value);
+    this.props.onCommentChange(this.props.id, e.target.value);
     this.setState({ inputValue: e.target.value });
   }
 

--- a/lib/Conversation/CommentForm/index.js
+++ b/lib/Conversation/CommentForm/index.js
@@ -8,7 +8,9 @@ import ShortcutTrigger from '../../ShortcutTrigger/index';
 
 class CommentForm extends Component {
   static propTypes = {
+    id: PropTypes.string.isRequired,
     onSubmit: PropTypes.func.isRequired,
+    onEdit: PropTypes.func.isRequired,
     onCancel: PropTypes.func,
     author: PropTypes.shape({
       avatar: PropTypes.string,
@@ -63,6 +65,7 @@ class CommentForm extends Component {
   }
 
   updateInputValue(e) {
+    this.props.onEdit(this.props.id, e.target.value);
     this.setState({ inputValue: e.target.value });
   }
 

--- a/lib/Conversation/README.md
+++ b/lib/Conversation/README.md
@@ -13,6 +13,7 @@ A collection of components used to render conversations
 | comments            | Array         | `[]`      | No       | An array of comments that are in the conversation.                            |
 | removeComment       | Function      | `() {}`   | No       | Executes when the comment is removed.                                         |
 | editComment         | Function      | `() {}`   | No       | Executes when the comment is edited.                                          |
+| onCommentChange     | Function      | `() {}`   | No       | Executes when a comments value changes.                                       |
 | resolveConversation | Function      | `() {}`   | No       | Executes when the add resolve conversation button is clicked.                 |
 | onCancel            | Function      | `() {}`   | No       | Executes when the cancel button is clicked.                                   |
 | placeholder         | String        | `Reply...`| No       | Placeholder text to display in the conversation form input.                   |

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -16,6 +16,7 @@ class Conversation extends Component {
     addComment: PropTypes.func.isRequired,
     editComment: PropTypes.func,
     removeComment: PropTypes.func,
+    onConversationEdit: PropTypes.func,
     user: PropTypes.shape().isRequired,
     comments: PropTypes.arrayOf(PropTypes.shape()),
     placeholder: PropTypes.string,
@@ -31,10 +32,11 @@ class Conversation extends Component {
     showComments: true,
     focusOnMount: true,
     hasError: false,
-    onCancel: () => {},
-    editComment: () => {},
-    removeComment: () => {},
+    onCancel() {},
+    editComment() {},
+    removeComment() {},
     resolveConversation() {},
+    onConversationEdit() {},
     comments: [],
     isSubmitting: false,
     placeholder: 'Reply...'
@@ -89,6 +91,7 @@ class Conversation extends Component {
                 conversationId={id}
                 comments={comments}
                 focusFallback={this.focusFallback}
+                onEdit={this.props.onConversationEdit}
               />
             </div>
           )}
@@ -111,9 +114,11 @@ class Conversation extends Component {
         {this.props.userCanComment && (
           <div className="conversation__foot">
             <CommentForm
+              id={this.props.id}
               onSubmit={this.addComment}
               author={this.props.user}
               onCancel={this.props.onCancel}
+              onEdit={this.props.onConversationEdit}
               focusOnMount={this.props.focusOnMount}
               isSubmitting={this.props.isSubmitting}
               placeholder={this.props.placeholder}

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -16,7 +16,7 @@ class Conversation extends Component {
     addComment: PropTypes.func.isRequired,
     editComment: PropTypes.func,
     removeComment: PropTypes.func,
-    onConversationEdit: PropTypes.func,
+    onCommentChange: PropTypes.func,
     user: PropTypes.shape().isRequired,
     comments: PropTypes.arrayOf(PropTypes.shape()),
     placeholder: PropTypes.string,
@@ -36,7 +36,7 @@ class Conversation extends Component {
     editComment() {},
     removeComment() {},
     resolveConversation() {},
-    onConversationEdit() {},
+    onCommentChange() {},
     comments: [],
     isSubmitting: false,
     placeholder: 'Reply...'
@@ -91,7 +91,7 @@ class Conversation extends Component {
                 conversationId={id}
                 comments={comments}
                 focusFallback={this.focusFallback}
-                onEdit={this.props.onConversationEdit}
+                onCommentChange={this.props.onCommentChange}
               />
             </div>
           )}
@@ -118,7 +118,7 @@ class Conversation extends Component {
               onSubmit={this.addComment}
               author={this.props.user}
               onCancel={this.props.onCancel}
-              onEdit={this.props.onConversationEdit}
+              onCommentChange={this.props.onCommentChange}
               focusOnMount={this.props.focusOnMount}
               isSubmitting={this.props.isSubmitting}
               placeholder={this.props.placeholder}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gather-content-ui",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "GatherContent UI Library",
   "main": "dist/lib/index.js",
   "repository": {

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -22,7 +22,7 @@ describe('Comment', () => {
     conversationId: '123',
     editComment: editCommentSpy,
     removeComment: removeCommentSpy,
-    onEdit() {},
+    onCommentChange() {},
     focusFallback: document.createElement('input')
   };
 
@@ -80,7 +80,7 @@ describe('Comment', () => {
     expect(commentForm.prop('author')).to.equal(props.author);
     expect(commentForm.prop('value')).to.equal(props.body);
     expect(commentForm.prop('focusOnMount')).to.equal(true);
-    expect(commentForm.prop('onEdit')).to.equal(props.onEdit);
+    expect(commentForm.prop('onCommentChange')).to.equal(props.onCommentChange);
     expect(commentForm.prop('id')).to.equal(props.id);
   });
 

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -22,6 +22,7 @@ describe('Comment', () => {
     conversationId: '123',
     editComment: editCommentSpy,
     removeComment: removeCommentSpy,
+    onEdit() {},
     focusFallback: document.createElement('input')
   };
 
@@ -79,6 +80,8 @@ describe('Comment', () => {
     expect(commentForm.prop('author')).to.equal(props.author);
     expect(commentForm.prop('value')).to.equal(props.body);
     expect(commentForm.prop('focusOnMount')).to.equal(true);
+    expect(commentForm.prop('onEdit')).to.equal(props.onEdit);
+    expect(commentForm.prop('id')).to.equal(props.id);
   });
 
   it('calls the edit comment action', () => {

--- a/tests/Conversation/CommentForm/CommentForm.js
+++ b/tests/Conversation/CommentForm/CommentForm.js
@@ -10,9 +10,10 @@ describe('Comment Form', () => {
   const sandbox = sinon.sandbox.create();
   let onSubmitSpy;
   let onCancelSpy;
+  let onEditSpy;
 
   const props = {
-    conversationId: '123',
+    id: '123',
     isSubmitting: false,
     author: {
       name: 'Bruce',
@@ -24,8 +25,14 @@ describe('Comment Form', () => {
   beforeEach(() => {
     onSubmitSpy = sandbox.spy();
     onCancelSpy = sandbox.spy();
+    onEditSpy = sandbox.spy();
     wrapper = mount(
-      <CommentForm {...props} onSubmit={onSubmitSpy} onCancel={onCancelSpy} />
+      <CommentForm
+        {...props}
+        onSubmit={onSubmitSpy}
+        onCancel={onCancelSpy}
+        onEdit={onEditSpy}
+      />
     );
   });
 
@@ -100,6 +107,7 @@ describe('Comment Form', () => {
   it('updates the input value', () => {
     wrapper.instance().updateInputValue({ target: { value: 'test 2' } });
     expect(wrapper.state('inputValue')).to.equal('test 2');
+    expect(onEditSpy).to.be.calledWithExactly('123', 'test 2');
   });
 
   it('toggles the focus state for the input', () => {

--- a/tests/Conversation/CommentForm/CommentForm.js
+++ b/tests/Conversation/CommentForm/CommentForm.js
@@ -10,7 +10,7 @@ describe('Comment Form', () => {
   const sandbox = sinon.sandbox.create();
   let onSubmitSpy;
   let onCancelSpy;
-  let onEditSpy;
+  let onCommentChangeSpy;
 
   const props = {
     id: '123',
@@ -25,13 +25,13 @@ describe('Comment Form', () => {
   beforeEach(() => {
     onSubmitSpy = sandbox.spy();
     onCancelSpy = sandbox.spy();
-    onEditSpy = sandbox.spy();
+    onCommentChangeSpy = sandbox.spy();
     wrapper = mount(
       <CommentForm
         {...props}
         onSubmit={onSubmitSpy}
         onCancel={onCancelSpy}
-        onEdit={onEditSpy}
+        onCommentChange={onCommentChangeSpy}
       />
     );
   });
@@ -107,7 +107,7 @@ describe('Comment Form', () => {
   it('updates the input value', () => {
     wrapper.instance().updateInputValue({ target: { value: 'test 2' } });
     expect(wrapper.state('inputValue')).to.equal('test 2');
-    expect(onEditSpy).to.be.calledWithExactly('123', 'test 2');
+    expect(onCommentChangeSpy).to.be.calledWithExactly('123', 'test 2');
   });
 
   it('toggles the focus state for the input', () => {

--- a/tests/Conversation/Conversation.js
+++ b/tests/Conversation/Conversation.js
@@ -16,7 +16,8 @@ describe('Conversation', () => {
     comments: [
       { person: { name: 'Toyah' }, id: 123 },
       { person: { name: 'Sapphire' }, id: 321 }
-    ]
+    ],
+    onConversationEdit() {}
   };
 
   beforeEach(() => {
@@ -85,6 +86,7 @@ describe('Conversation', () => {
     expect(commentList.prop('focusFallback')).to.deep.equal(
       props.focusFallback
     );
+    expect(commentList.prop('onEdit')).to.equal(props.onConversationEdit);
   });
 
   it('does not render the reply count text', () => {
@@ -127,6 +129,10 @@ describe('Conversation', () => {
   it('calls the addComment action', () => {
     const addComment = wrapper.instance().addComment;
     expect(wrapper.find(CommentForm).prop('onSubmit')).to.equal(addComment);
+    expect(wrapper.find(CommentForm).prop('id')).to.equal('123');
+    expect(wrapper.find(CommentForm).prop('onEdit')).to.equal(
+      props.onConversationEdit
+    );
     addComment('test');
     expect(addCommentSpy.getCall(0).args[0]).to.equal('test');
   });

--- a/tests/Conversation/Conversation.js
+++ b/tests/Conversation/Conversation.js
@@ -17,7 +17,7 @@ describe('Conversation', () => {
       { person: { name: 'Toyah' }, id: 123 },
       { person: { name: 'Sapphire' }, id: 321 }
     ],
-    onConversationEdit() {}
+    onCommentChange() {}
   };
 
   beforeEach(() => {
@@ -86,7 +86,7 @@ describe('Conversation', () => {
     expect(commentList.prop('focusFallback')).to.deep.equal(
       props.focusFallback
     );
-    expect(commentList.prop('onEdit')).to.equal(props.onConversationEdit);
+    expect(commentList.prop('onCommentChange')).to.equal(props.onCommentChange);
   });
 
   it('does not render the reply count text', () => {
@@ -130,8 +130,8 @@ describe('Conversation', () => {
     const addComment = wrapper.instance().addComment;
     expect(wrapper.find(CommentForm).prop('onSubmit')).to.equal(addComment);
     expect(wrapper.find(CommentForm).prop('id')).to.equal('123');
-    expect(wrapper.find(CommentForm).prop('onEdit')).to.equal(
-      props.onConversationEdit
+    expect(wrapper.find(CommentForm).prop('onCommentChange')).to.equal(
+      props.onCommentChange
     );
     addComment('test');
     expect(addCommentSpy.getCall(0).args[0]).to.equal('test');


### PR DESCRIPTION
This PR adds the handlers for when comments are edited and passes up the id of the comment and the current value.

This is handy when you need to perform an action based on when the value is empty etc...