### PR TITLE
giving page information's editable text wrapper a bit more room

### DIFF
--- a/lib/EditableTextWrapper/styles.scss
+++ b/lib/EditableTextWrapper/styles.scss
@@ -39,4 +39,5 @@
   line-height: 1.25;
   font-weight: 500;
   height: 1.25em;
+  width: 100%;
 }

--- a/lib/TopBar/styles.scss
+++ b/lib/TopBar/styles.scss
@@ -53,6 +53,9 @@ $top-bar-box-shadow: 0 0 6px 0 rgba(230,234,237,0.29);
       top: 0;
       bottom: 0;
     }
+    .top-bar__cell:last-child {
+      flex-grow: 1;
+    }
   }
 
   .top-bar__content--center {


### PR DESCRIPTION
Little fix that stops the text prematurely being cut off when editing a title that sits within the top bar