### PR TITLE
Use ExpandingTextArea on field instructions instead of a plain input

### DIFF
--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -5,6 +5,7 @@ import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
 import FieldValidations from './FieldValidations';
 import FieldActions from './FieldActions';
+import ExpandingTextArea from '../ExpandingTextArea';
 
 const Field = props => {
   if (props.isLoading) {
@@ -46,17 +47,17 @@ const Field = props => {
           <div className="field__content">
             <div className="field__child">{props.children}</div>
 
-            {props.instructions &&
-              (!props.canEdit ? (
+            {!props.canEdit ? (
                 <div className="field__instructions">{props.instructions}</div>
               ) : (
-                <input
+                <ExpandingTextArea
                   type="text"
                   className="field__instructions"
-                  onChange={props.instructionChange}
+                  handleOnChange={props.instructionChange}
                   value={props.instructions}
+                  placeholder="Add field instructions here..."
                 />
-              ))}
+              )}
           </div>
         </Col>
       </Row>

--- a/tests/Field/Field.js
+++ b/tests/Field/Field.js
@@ -3,6 +3,7 @@ import { Field } from '../../lib';
 import FieldActions from '../../lib/Field/FieldActions';
 import FieldValidations from '../../lib/Field/FieldValidations';
 import Button from '../../lib/Button';
+import ExpandingTextArea from '../../lib/ExpandingTextArea';
 
 describe('Field', () => {
   let wrapper;
@@ -34,7 +35,7 @@ describe('Field', () => {
   it('renders an editing state', () => {
     wrapper.setProps({ canEdit: true });
     expect(wrapper.find('.field__label').type()).to.equal('input');
-    expect(wrapper.find('.field__instructions').type()).to.equal('input');
+    expect(wrapper.find(ExpandingTextArea)).to.have.length(1);
   });
 
   it('renders a label', () => {


### PR DESCRIPTION
As title says and removing conditional which requires field to have existing instructions for the input to load in