### PR TITLE
Add className to BoundaryClickWatcher

### DIFF
--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -99,10 +99,7 @@ class BoundaryClickWatcher extends Component {
         onKeyPress={this.handleInnerClick}
         className={`boundary-click-watcher ${className}`}
       >
-        { typeof children === 'function'
-          ? children(boundaryIsActive)
-          : children
-        }
+        {typeof children === 'function' ? children(boundaryIsActive) : children}
       </div>
     );
   }

--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -6,12 +6,14 @@ class BoundaryClickWatcher extends Component {
     insideClickHandler: PropTypes.func,
     outsideClickHandler: PropTypes.func,
     alwaysListen: PropTypes.bool,
+    className: PropTypes.string,
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired
   };
 
   static defaultProps = {
     insideClickHandler() {},
     outsideClickHandler() {},
+    className: '',
     alwaysListen: false
   };
 
@@ -83,6 +85,9 @@ class BoundaryClickWatcher extends Component {
   }
 
   render() {
+    const { children, className } = this.props;
+    const { boundaryIsActive } = this.state;
+
     return (
       <div
         role="button"
@@ -92,11 +97,12 @@ class BoundaryClickWatcher extends Component {
         }}
         onClick={this.handleInnerClick}
         onKeyPress={this.handleInnerClick}
-        className="boundary-click-watcher"
+        className={`boundary-click-watcher ${className}`}
       >
-        {typeof this.props.children === 'function'
-          ? this.props.children(this.state.boundaryIsActive)
-          : this.props.children}
+        { typeof children === 'function'
+          ? children(boundaryIsActive)
+          : children
+        }
       </div>
     );
   }

--- a/lib/Guideline/index.js
+++ b/lib/Guideline/index.js
@@ -25,7 +25,9 @@ class Guideline extends Component {
   }
 
   render() {
-    const toggleText = this.state.showContent ? 'Hide guidelines' : 'Show guidelines';
+    const toggleText = this.state.showContent
+      ? 'Hide guidelines'
+      : 'Show guidelines';
     const classNames = cx('guideline', {
       'is-active': this.state.showContent
     });

--- a/lib/LoadingOverlay/index.js
+++ b/lib/LoadingOverlay/index.js
@@ -8,11 +8,7 @@ const LoadingOverlay = ({ fixed }) => {
     'loading-overlay--fixed': fixed
   });
 
-  return (
-    <div className={className}>
-      { loadingSVG() }
-    </div>
-  );
+  return <div className={className}>{loadingSVG()}</div>;
 };
 
 LoadingOverlay.propTypes = {

--- a/tests/BoundaryClickWatcher/BoundaryClickWatcher.spec.js
+++ b/tests/BoundaryClickWatcher/BoundaryClickWatcher.spec.js
@@ -12,7 +12,7 @@ describe('BoundaryClickWatcher', () => {
   });
 
   const wrapper = shallow(
-    <BoundaryClickWatcher>
+    <BoundaryClickWatcher className="test">
       {boundaryIsActive => (
         <div className="child" isActive={boundaryIsActive} />
       )}
@@ -33,5 +33,9 @@ describe('BoundaryClickWatcher', () => {
     expect(wrapper.state('boundaryIsActive')).toEqual(
       wrapper.prop('children').props.isActive
     );
+  });
+
+  test('adds the className prop', () => {
+    expect(wrapper.hasClass('test')).toBe(true);
   });
 });

--- a/tests/Guideline/Guideline.js
+++ b/tests/Guideline/Guideline.js
@@ -27,8 +27,8 @@ describe('Guideline', () => {
   });
 
   test('switches the text for the show toggle', () => {
-    expect(wrapper.find(Button).prop('children')).toEqual('Hide details');
+    expect(wrapper.find(Button).prop('children')).toEqual('Hide guidelines');
     wrapper.setState({ showContent: false });
-    expect(wrapper.find(Button).prop('children')).toEqual('Show details');
+    expect(wrapper.find(Button).prop('children')).toEqual('Show guidelines');
   });
 });


### PR DESCRIPTION
There are times where the additional `div` applied by `BoundaryClickWatcher` will affect styling. This change allows the developer to add classes to resolve this.