### PR TITLE
fix EditableTextWrapper bug

### DIFF
--- a/lib/EditableTextWrapper/index.js
+++ b/lib/EditableTextWrapper/index.js
@@ -37,7 +37,7 @@ export default class EditableTextWrapper extends Component {
   }
 
   stopEditing() {
-    this.setState({ editing: false, value: this.props.value });
+    this.setState({ editing: false });
   }
 
   handleOnKeyDown(e) {
@@ -50,6 +50,7 @@ export default class EditableTextWrapper extends Component {
     }
 
     if (isEscKey) {
+      this.setState({ value: this.props.value });
       this.stopEditing();
     }
   }


### PR DESCRIPTION
Found an issue where EditableTextWrapper sets the value state to props.value a bit too aggressively. This had the effect of setting state.value before props.value had actually changed, as a result resetting state.value back to before any changes had happened. 

I've just moved that setState from stopEditing() into the isEscKey conditional as thats the only place we want that to happen.