### PR TITLE
DropdownMenu additions

### DIFF
--- a/assets/data.js
+++ b/assets/data.js
@@ -12,6 +12,21 @@ export function getDropdownItems() {
   }];
 }
 
+export function getDropdownItemsWithActive() {
+  return [{
+    name: 'Restore Items',
+    action() {
+      console.log('restore items');
+    }
+  }, {
+    name: 'Delete Items',
+    active: true,
+    action() {
+      console.log('delete items');
+    }
+  }];
+}
+
 export function getDropdownItemsWithSeparator() {
   return [{
     name: 'Restore Items',

--- a/lib/Button/styles.scss
+++ b/lib/Button/styles.scss
@@ -243,3 +243,11 @@ $color-btn-contained--bg: white !default;
     transform: scale(1.1);
   }
 }
+
+.button--outline {
+  border: 1px solid $color-border-base;
+  outline: none;
+  &:hover, &:focus, &.is-active {
+    border-color:  $primary-blue;
+  }
+}

--- a/lib/DropdownMenu/index.js
+++ b/lib/DropdownMenu/index.js
@@ -45,6 +45,12 @@ class DropdownMenu extends Component {
         type = 'button';
       }
 
+      const activeContents = (
+        <span className="dropdown-item__tick is-active">
+          <Icon name="tick" size="micro" />
+        </span>
+      );
+
       switch (type) {
         case 'separator':
           return <li className="dropdown__separator" key={idKey} />;
@@ -52,11 +58,7 @@ class DropdownMenu extends Component {
         case 'link':
           return (
             <li className="dropdown__item" key={idKey}>
-              {item.active && (
-                <span className="dropdown-item__tick is-active">
-                  <Icon name="tick" size="micro" />
-                </span>
-              )}
+              {item.active && activeContents}
               <a className="dropdown__link" href={item.href}>
                 {item.name}
               </a>
@@ -70,14 +72,12 @@ class DropdownMenu extends Component {
                 className="dropdown__link dropdown__additional"
                 onClick={item.action}
               >
-                {item.active && (
-                  <span className="dropdown-item__tick is-active">
-                    <Icon name="tick" size="micro" />
-                  </span>
-                )}
-                <span className="item-name">{item.name}</span>
+                {item.active && activeContents}
+                <span className="dropdown__item--name">{item.name}</span>
                 {item.additional && (
-                  <span className="item-additional">{item.additional}</span>
+                  <span className="dropdown__item--additional">
+                    {item.additional}
+                  </span>
                 )}
               </button>
             </li>
@@ -87,11 +87,7 @@ class DropdownMenu extends Component {
           return (
             <li className="dropdown__item" key={idKey}>
               <button className="dropdown__link" onClick={item.action}>
-                {item.active && (
-                  <span className="dropdown-item__tick is-active">
-                    <Icon name="tick" size="micro" />
-                  </span>
-                )}
+                {item.active && activeContents}
                 {item.name}
               </button>
             </li>
@@ -160,7 +156,7 @@ class DropdownMenu extends Component {
       <div className={menuClass}>
         <Button
           types={[type]}
-          className="dropdown-menu__button"
+          className={`dropdown-menu__button dropdown-menu__button--${[type]}`}
           clickHandler={this.toggleItems}
         >
           {this.props.children}

--- a/lib/DropdownMenu/index.js
+++ b/lib/DropdownMenu/index.js
@@ -17,7 +17,10 @@ class DropdownMenu extends Component {
       React.PropTypes.bool,
       React.PropTypes.number
     ]),
-    alignRight: PropTypes.bool
+    alignRight: PropTypes.bool,
+    selected: PropTypes.bool,
+    downIcon: PropTypes.bool,
+    fullWidth: PropTypes.bool
   };
 
   static defaultProps = {
@@ -27,8 +30,10 @@ class DropdownMenu extends Component {
     className: '',
     listClassName: '',
     caret: false,
+    downIcon: false,
     direction: 'down',
-    shouldDisplay: true
+    shouldDisplay: true,
+    fullWidth: false
   };
 
   static makeItems(items) {
@@ -47,9 +52,34 @@ class DropdownMenu extends Component {
         case 'link':
           return (
             <li className="dropdown__item" key={idKey}>
+              {item.active && (
+                <span className="dropdown-item__tick is-active">
+                  <Icon name="tick" size="micro" />
+                </span>
+              )}
               <a className="dropdown__link" href={item.href}>
                 {item.name}
               </a>
+            </li>
+          );
+
+        case 'withAdditional':
+          return (
+            <li className="dropdown__item" key={idKey}>
+              <button
+                className="dropdown__link dropdown__additional"
+                onClick={item.action}
+              >
+                {item.active && (
+                  <span className="dropdown-item__tick is-active">
+                    <Icon name="tick" size="micro" />
+                  </span>
+                )}
+                <span className="item-name">{item.name}</span>
+                {item.additional && (
+                  <span className="item-additional">{item.additional}</span>
+                )}
+              </button>
             </li>
           );
 
@@ -57,6 +87,11 @@ class DropdownMenu extends Component {
           return (
             <li className="dropdown__item" key={idKey}>
               <button className="dropdown__link" onClick={item.action}>
+                {item.active && (
+                  <span className="dropdown-item__tick is-active">
+                    <Icon name="tick" size="micro" />
+                  </span>
+                )}
                 {item.name}
               </button>
             </li>
@@ -70,7 +105,7 @@ class DropdownMenu extends Component {
     this.toggleItems = this.toggleItems.bind(this);
     this.closeDropdown = this.closeDropdown.bind(this);
 
-    this.state = { selected: false };
+    this.state = { selected: this.props.selected };
   }
 
   componentWillMount() {
@@ -81,8 +116,11 @@ class DropdownMenu extends Component {
     document.body.removeEventListener('click', this.closeDropdown);
   }
 
-  closeDropdown() {
-    if (this.state.selected) {
+  closeDropdown(e) {
+    const isTargetDropDownButton = e.target.classList.contains(
+      'dropdown-menu__button'
+    );
+    if (this.state.selected && !isTargetDropDownButton) {
       this.setState({ selected: false });
     }
   }
@@ -95,18 +133,21 @@ class DropdownMenu extends Component {
     let { items } = this.props;
     const {
       caret,
+      downIcon,
       type,
       shouldDisplay,
       alignRight,
       className,
-      listClassName
+      listClassName,
+      fullWidth
     } = this.props;
 
     const menuClass = cx(`dropdown ${className}`, {
       'is-visible': shouldDisplay,
       'is-hidden': !shouldDisplay,
       'open is-active': this.state.selected,
-      dropup: this.props.direction === 'up'
+      dropup: this.props.direction === 'up',
+      'full-width': fullWidth
     });
 
     const listClass = cx(`dropdown-menu ${listClassName}`, {
@@ -126,6 +167,11 @@ class DropdownMenu extends Component {
           {caret && (
             <span className="dropdown-menu__caret">
               <Icon name="caret" size="micro" />
+            </span>
+          )}
+          {downIcon && (
+            <span className="dropdown-menu__down">
+              <Icon name="down" size="micro" />
             </span>
           )}
         </Button>

--- a/lib/DropdownMenu/styles.scss
+++ b/lib/DropdownMenu/styles.scss
@@ -30,8 +30,8 @@ $dropdown-menu-font-color: $color-text-base !default;
   }
 }
 
-.button--outline,
-.button--link {
+.dropdown-menu__button--outline,
+.dropdown-menu__button--link {
   svg path {
     .dropdown & {
       fill: $neutral-dark;
@@ -43,10 +43,13 @@ $dropdown-menu-font-color: $color-text-base !default;
 }
 
 .dropdown .dropdown-item__tick {
+  span {
+    vertical-align: middle;
+  }
   svg path {
     fill: $primary-blue;
   }
-  & + .item-name {
+  & + .dropdown__item--name {
     color: $primary-blue;
   }
 }
@@ -54,12 +57,6 @@ $dropdown-menu-font-color: $color-text-base !default;
 .dropdown-menu__button {
   display: flex;
   align-items: center;
-  &.button--outline,
-  &.button--link {
-    path fill {
-
-    }
-  }
 }
 
 .dropdown-menu__caret,
@@ -163,14 +160,14 @@ $dropdown-menu-font-color: $color-text-base !default;
 
 .dropdown__additional {
   display: flex;
-  .item-name {
+  .dropdown__item--name {
     display: block;
     width: 65%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .item-additional {
+  .dropdown__item--additional {
     display: block;
     margin-left: auto;
     color: $neutral-base;

--- a/lib/DropdownMenu/styles.scss
+++ b/lib/DropdownMenu/styles.scss
@@ -18,12 +18,52 @@ $dropdown-menu-font-color: $color-text-base !default;
   }
 }
 
+.dropdown.full-width {
+  width: 100%;
+  .dropdown-menu__button,
+  .dropdown-menu  {
+    width: 100%;
+  }
+  .dropdown-menu__caret,
+  .dropdown-menu__down {
+    margin-left: auto;
+  }
+}
+
+.button--outline,
+.button--link {
+  svg path {
+    .dropdown & {
+      fill: $neutral-dark;
+    }
+    .dropdown.is-active & {
+      fill: $primary-blue;
+    }
+  }
+}
+
+.dropdown .dropdown-item__tick {
+  svg path {
+    fill: $primary-blue;
+  }
+  & + .item-name {
+    color: $primary-blue;
+  }
+}
+
 .dropdown-menu__button {
   display: flex;
   align-items: center;
+  &.button--outline,
+  &.button--link {
+    path fill {
+
+    }
+  }
 }
 
-.dropdown-menu__caret {
+.dropdown-menu__caret,
+.dropdown-menu__down {
   display: inline-flex;
   margin-left: $dropdown-menu-caret-margin;
 }
@@ -118,5 +158,21 @@ $dropdown-menu-font-color: $color-text-base !default;
 
   a[role="menuitem"]:focus {
     outline: none;
+  }
+}
+
+.dropdown__additional {
+  display: flex;
+  .item-name {
+    display: block;
+    width: 65%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .item-additional {
+    display: block;
+    margin-left: auto;
+    color: $neutral-base;
   }
 }

--- a/stories/components/Button.js
+++ b/stories/components/Button.js
@@ -31,6 +31,13 @@ const button = storiesOf('Components', module)
       </StoryItem>
 
       <StoryItem
+        title="Outline button"
+        description="A button with an outline style"
+      >
+        <Button types={['outline']} clickHandler={action('clickedHandler')}>Outline button</Button>
+      </StoryItem>
+
+      <StoryItem
         title="Loading button"
         description="A button that generates a spinner when pressed. It is of type `button` by default but can also be a `submit` button by setting the `isSubmit` prop to `true`."
       >

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -27,6 +27,14 @@ storiesOf('Components', module)
         </StoryItem>
 
         <StoryItem
+          title="Dropdown Menu"
+          description="A dropdown menu with an active item">
+          <DropdownMenu fullWidth type="outline" value="Actions" downIcon shouldDisplay items={assets.getDropdownItemsWithActive()}>
+            Actions
+          </DropdownMenu>
+        </StoryItem>
+
+        <StoryItem
           title="Dropdown without a button"
           description="A link that opens a dropdown.">
           <DropdownMenu type="link" caret shouldDisplay items={assets.getDropdownItemsWithSeparator()}>

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -19,6 +19,14 @@ storiesOf('Components', module)
         </StoryItem>
 
         <StoryItem
+          title="Dropdown Menu"
+          description="A dropdown menu with an outline button and full width">
+          <DropdownMenu fullWidth type="outline" value="Actions" downIcon shouldDisplay items={assets.getDropdownItems()}>
+            Actions
+          </DropdownMenu>
+        </StoryItem>
+
+        <StoryItem
           title="Dropdown without a button"
           description="A link that opens a dropdown.">
           <DropdownMenu type="link" caret shouldDisplay items={assets.getDropdownItemsWithSeparator()}>

--- a/tests/DropdownMenu/index.js
+++ b/tests/DropdownMenu/index.js
@@ -131,6 +131,6 @@ describe('DropdownMenu', () => {
       items: mockAdditionalItems
     });
     expect(wrapper.find('.dropdown__additional').length).toEqual(2);
-    expect(wrapper.find('.item-additional').length).toEqual(2);
+    expect(wrapper.find('.dropdown__item--additional').length).toEqual(2);
   });
 });

--- a/tests/DropdownMenu/index.js
+++ b/tests/DropdownMenu/index.js
@@ -1,0 +1,136 @@
+import { React, mount } from '../setup';
+import DropdownMenu from '../../lib/DropdownMenu';
+
+describe('DropdownMenu', () => {
+  let wrapper;
+  let mockItems;
+
+  beforeEach(() => {
+    mockItems = [
+      {
+        name: 'item 1',
+        action: () => {}
+      },
+      {
+        name: 'item 2',
+        action: () => {}
+      }
+    ];
+    wrapper = mount(<DropdownMenu items={mockItems}>Menu text</DropdownMenu>);
+  });
+
+  test('should render text passed on children', () => {
+    expect(wrapper.prop('children')).toEqual('Menu text');
+  });
+
+  test('should render the dropdown items', () => {
+    expect(wrapper.prop('items')).toEqual(mockItems);
+  });
+
+  test('clicking the dropdown menu button should toggle the menu', () => {
+    wrapper.find('.dropdown-menu__button').simulate('click');
+    expect(wrapper.hasClass('open')).toEqual(true);
+    expect(wrapper.hasClass('is-active')).toEqual(true);
+    wrapper.find('.dropdown-menu__button').simulate('click');
+    expect(wrapper.hasClass('open')).toEqual(false);
+    expect(wrapper.hasClass('is-active')).toEqual(false);
+  });
+
+  test('setting the caret prop to true should render a caret icon', () => {
+    expect(wrapper.find('.dropdown-menu__caret').length).toEqual(0);
+    wrapper.setProps({
+      caret: true
+    });
+    expect(wrapper.find('.dropdown-menu__caret').length).toEqual(1);
+  });
+
+  test('setting the downIcon prop to true should render a down icon', () => {
+    expect(wrapper.find('.dropdown-menu__down').length).toEqual(0);
+    wrapper.setProps({
+      downIcon: true
+    });
+    expect(wrapper.find('.dropdown-menu__down').length).toEqual(1);
+  });
+
+  test('setting the fullWidth prop to true should add a full-width class', () => {
+    expect(wrapper.find('.full-width').length).toEqual(0);
+    wrapper.setProps({
+      fullWidth: true
+    });
+    expect(wrapper.find('.full-width').length).toEqual(1);
+  });
+
+  test('setting the direction prop to up should add a dropup class', () => {
+    expect(wrapper.find('.dropup').length).toEqual(0);
+    wrapper.setProps({
+      direction: 'up'
+    });
+    expect(wrapper.find('.dropup').length).toEqual(1);
+  });
+
+  test('items should default to a link type', () => {
+    expect(wrapper.find('.dropdown__link').length).toEqual(2);
+  });
+
+  test('items can have a separator type', () => {
+    const mockItemsWithSeparator = [
+      {
+        name: 'item 1',
+        action: () => {}
+      },
+      {
+        type: 'separator'
+      },
+      {
+        name: 'item 2',
+        action: () => {}
+      }
+    ];
+    wrapper.setProps({
+      items: mockItemsWithSeparator
+    });
+    expect(wrapper.find('.dropdown__link').length).toEqual(2);
+    expect(wrapper.find('.dropdown__separator').length).toEqual(1);
+  });
+
+  test('active items will render a tick icon', () => {
+    const mockItemsWithSeparator = [
+      {
+        name: 'item 1',
+        action: () => {},
+        active: true
+      },
+      {
+        name: 'item 2',
+        action: () => {}
+      }
+    ];
+    wrapper.setProps({
+      items: mockItemsWithSeparator
+    });
+    expect(wrapper.find('.dropdown__link').length).toEqual(2);
+    expect(wrapper.find('.dropdown-item__tick').length).toEqual(1);
+  });
+
+  test('items can have additional information', () => {
+    const mockAdditionalItems = [
+      {
+        name: 'item 1',
+        additional: 'more info',
+        type: 'withAdditional',
+        action: () => {}
+      },
+      {
+        name: 'item 2',
+        additional: 'more info too',
+        type: 'withAdditional',
+        action: () => {}
+      }
+    ];
+    wrapper.setProps({
+      items: mockAdditionalItems
+    });
+    expect(wrapper.find('.dropdown__additional').length).toEqual(2);
+    expect(wrapper.find('.item-additional').length).toEqual(2);
+  });
+});


### PR DESCRIPTION
Adding a new 'outline' button style and a few bits to DropdownMenu:
- Changed closeDropdown as it was closing the dropdown regardless of where you clicked, overriding the toggleItems function.
- Adding a new 'withAdditional' item type
- Adding a downIcon prop incase you want to use that icon instead of the caret
- Adding a fullWidth prop to render the dropdown button and items full width
- Adding 'active' item functionality
- Tests now exist for this component