### PR TITLE
Fixing long strings overflowing outside of conversations

### DIFF
--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -78,6 +78,8 @@ $conversation-meta-text-color: $neutral-base !default;
   font-size: $typo-size-slight;
   padding-right: $layout-spacing-base/2;
   color: $neutral-dark;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .conversation__actions {


### PR DESCRIPTION
Really small PR

Added a bit of CSS to stop long strings popping out of the conversation text area. overflow-wrap and word-wrap are both used as firefox only likes word-wrap, and everything else likes overflow-wrap apparently. lol browsers 