### PR TITLE
Fix prop errors for radio other options

### DIFF
--- a/lib/Form/Label/index.js
+++ b/lib/Form/Label/index.js
@@ -54,11 +54,10 @@ const Label = ({
 Label.propTypes = {
   label: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
-  overrideLabelDefault: PropTypes.oneOfType([PropTypes.func, PropTypes.bool])
-    .isRequired,
-  labelMouseEnter: PropTypes.func.isRequired,
-  labelMouseLeave: PropTypes.func.isRequired,
-  active: PropTypes.bool.isRequired,
+  overrideLabelDefault: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+  labelMouseEnter: PropTypes.func,
+  labelMouseLeave: PropTypes.func,
+  active: PropTypes.bool,
   subtitle: PropTypes.string,
   className: PropTypes.string,
   highlight: PropTypes.bool
@@ -67,7 +66,11 @@ Label.propTypes = {
 Label.defaultProps = {
   subtitle: '',
   className: '',
-  highlight: false
+  highlight: false,
+  overrideLabelDefault: false,
+  labelMouseEnter: () => {},
+  labelMouseLeave: () => {},
+  active: false
 };
 
 export default Label;


### PR DESCRIPTION
A few props set to required in Label wont be passed down if its an "other" option, causing some ugly errors. 