### PR TITLE
Fix button wrapping

### DIFF
--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -136,8 +136,22 @@ class Comment extends Component {
         }
 
         <div className="conversation__confirmation">
-          <Button types={['secondary', 'size-sm']} clickHandler={this.toggleRemovalConfirmation}>Cancel</Button>
-          <Button types={['danger', 'size-sm']} clickHandler={() => this.removeComment(true)}>Delete {removalText}</Button>
+          <div className="conversation__confirmation-inner">
+            <Button
+              types={['secondary', 'size-sm']}
+              className="conversation__confirmation-button"
+              clickHandler={this.toggleRemovalConfirmation}
+            >
+              Cancel
+            </Button>
+            <Button
+              types={['danger', 'size-sm']}
+              className="conversation__confirmation-button"
+              clickHandler={() => this.removeComment(true)}
+            >
+              Delete {removalText}
+            </Button>
+          </div>
         </div>
       </div>
     );

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -180,9 +180,22 @@ $conversation-meta-text-color: $neutral-base !default;
   left: $conversation-comment-body-indentation;
   right: 0;
   bottom: 0;
+  z-index: 1;
+}
+
+.conversation__confirmation,
+.conversation__confirmation-inner {
   align-items: center;
   justify-content: center;
-  z-index: 1;
+  flex-wrap: wrap;
+}
+
+.conversation__confirmation-inner {
+  display: flex;
+}
+
+.conversation__confirmation-button {
+  margin: $layout-spacing-base/4;
 }
 
 .is-disabled .conversation__confirmation {


### PR DESCRIPTION
After integrating a preview patch there is a new issue with wrapping for the delete comment confirmation UI.