### PR TITLE
Add on comment cancel prop

### DIFF
--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -18,7 +18,8 @@ class Comment extends Component {
     editComment: PropTypes.func.isRequired,
     removeComment: PropTypes.func.isRequired,
     onCommentChange: PropTypes.func.isRequired,
-    onRowCountChange: PropTypes.func,
+    onCommentCancel: PropTypes.func.isRequired,
+    onRowCountChange: PropTypes.func.isRequired,
     removalRequiresConfirmation: PropTypes.bool,
   };
 
@@ -49,6 +50,7 @@ class Comment extends Component {
       showEditForm: false,
       confirmRemoval: false
     });
+    this.props.onCommentCancel();
     this.props.focusFallback.focus();
   }
 

--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -20,7 +20,7 @@ class Comment extends Component {
     onCommentChange: PropTypes.func.isRequired,
     onCommentCancel: PropTypes.func.isRequired,
     onRowCountChange: PropTypes.func.isRequired,
-    removalRequiresConfirmation: PropTypes.bool,
+    index: PropTypes.number.isRequired
   };
 
   static defaultProps = {
@@ -33,7 +33,7 @@ class Comment extends Component {
     super();
     this.state = {
       showEditForm: false,
-      confirmRemoval: false,
+      confirmRemoval: false
     };
     this.showEditForm = this.showEditForm.bind(this);
     this.hideEditForm = this.hideEditForm.bind(this);
@@ -69,15 +69,13 @@ class Comment extends Component {
       return this.toggleRemovalConfirmation();
     }
 
-    if (confirmed) {
-      this.hideEditForm();
-      return this.props.removeComment(this.props.id, this.props.conversationId);
-    }
+    this.hideEditForm();
+    return this.props.removeComment(this.props.id, this.props.conversationId);
   }
 
   render() {
     const { createdAt, createdBy, body, author, user, index } = this.props;
-    const removalText = (index === 0) ? 'thread' : 'comment';
+    const removalText = index === 0 ? 'thread' : 'comment';
     const userCanEdit = createdBy === user.id;
     const className = cx('conversation__comment', {
       'is-disabled': this.state.confirmRemoval
@@ -85,7 +83,7 @@ class Comment extends Component {
 
     return (
       <div className={className}>
-        { !this.state.showEditForm && (
+        {!this.state.showEditForm && (
           <div>
             <Person person={author} className="conversation" />
 
@@ -120,7 +118,7 @@ class Comment extends Component {
           </div>
         )}
 
-        { userCanEdit &&
+        {userCanEdit &&
           this.state.showEditForm && (
             <CommentForm
               id={this.props.id}
@@ -134,8 +132,7 @@ class Comment extends Component {
               onCommentChange={this.props.onCommentChange}
               onRowCountChange={this.props.onRowCountChange}
             />
-          )
-        }
+          )}
 
         <div className="conversation__confirmation">
           <div className="conversation__confirmation-inner">

--- a/lib/Conversation/CommentList.js
+++ b/lib/Conversation/CommentList.js
@@ -4,12 +4,7 @@ import Comment from './Comment';
 
 const CommentList = ({ comments, ...rest }) => {
   const list = comments.map((comment, index) => (
-    <Comment
-      key={comment.id}
-      {...rest}
-      {...comment}
-      index={index}
-    />
+    <Comment key={comment.id} {...rest} {...comment} index={index} />
   ));
 
   return <div className="conversation__comment-list">{list}</div>;

--- a/lib/Conversation/README.md
+++ b/lib/Conversation/README.md
@@ -13,7 +13,8 @@ A collection of components used to render conversations
 | comments            | Array         | `[]`      | No       | An array of comments that are in the conversation.                            |
 | removeComment       | Function      | `() {}`   | No       | Executes when the comment is removed.                                         |
 | editComment         | Function      | `() {}`   | No       | Executes when the comment is edited.                                          |
-| onCommentChange     | Function      | `() {}`   | No       | Executes when a comments value changes.                                       |
+| onCommentChange     | Function      | `() {}`   | No       | Executes when a comment value changes.                                        |
+| onCommentCancel     | Function      | `() {}`   | No       | Executes when a comment edit has been canceled.                               |
 | onRowCountChange    | Function      | `() {}`   | No       | Executes when a the number of rows in the comment form changes.               |
 | resolveConversation | Function      | `() {}`   | No       | Executes when the add resolve conversation button is clicked.                 |
 | onCancel            | Function      | `() {}`   | No       | Executes when the cancel button is clicked.                                   |

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -99,8 +99,7 @@ class Conversation extends Component {
                 onCommentCancel={this.props.onCommentCancel}
               />
             </div>
-          )
-        }
+          )}
 
         {!showComments &&
           comments.length > 1 && (

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -17,6 +17,7 @@ class Conversation extends Component {
     editComment: PropTypes.func,
     removeComment: PropTypes.func,
     onCommentChange: PropTypes.func,
+    onCommentCancel: PropTypes.func,
     onRowCountChange: PropTypes.func,
     user: PropTypes.shape().isRequired,
     comments: PropTypes.arrayOf(PropTypes.shape()),
@@ -38,6 +39,7 @@ class Conversation extends Component {
     removeComment() {},
     resolveConversation() {},
     onCommentChange() {},
+    onCommentCancel() {},
     onRowCountChange() {},
     comments: [],
     isSubmitting: false,
@@ -94,9 +96,11 @@ class Conversation extends Component {
                 comments={comments}
                 focusFallback={this.focusFallback}
                 onCommentChange={this.props.onCommentChange}
+                onCommentCancel={this.props.onCommentCancel}
               />
             </div>
-          )}
+          )
+        }
 
         {!showComments &&
           comments.length > 1 && (

--- a/lib/ExpandingTextArea/index.js
+++ b/lib/ExpandingTextArea/index.js
@@ -17,6 +17,7 @@ class ExpandingTextArea extends Component {
   static defaultProps = {
     handleOnChange: () => {},
     handleOnFocus: () => {},
+    onRowCountChange: () => {},
     value: '',
     focusOnMount: false,
     setValue: false,

--- a/lib/Person/index.js
+++ b/lib/Person/index.js
@@ -10,7 +10,9 @@ const Person = ({ person, className }) => (
       name={person.name}
       initials={person.initials}
     />
-    <span className={`person__name ${className}__person-name`}>{person.name}</span>
+    <span className={`person__name ${className}__person-name`}>
+      {person.name}
+    </span>
   </div>
 );
 

--- a/stories/components/ExpandingTextArea.js
+++ b/stories/components/ExpandingTextArea.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import StoryItem from '../styleguide/StoryItem';
-import ExpandingTextArea from '../../lib/ExpandingTextArea';
+import { ExpandingTextArea } from '../../lib';
 
 storiesOf('Components', module)
   .add('ExpandingTextArea', () => {

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -6,6 +6,7 @@ import Button from '../../lib/Button';
 
 describe('Comment', () => {
   let wrapper;
+  const onCommentCancelSpy = jest.fn();
   const editCommentSpy = jest.fn();
   const removeCommentSpy = jest.fn();
 
@@ -23,6 +24,7 @@ describe('Comment', () => {
     editComment: editCommentSpy,
     removeComment: removeCommentSpy,
     onCommentChange() {},
+    onCommentCancel: onCommentCancelSpy,
     onRowCountChange() {},
     focusFallback: document.createElement('input')
   };
@@ -115,6 +117,7 @@ describe('Comment', () => {
     wrapper.instance().showEditForm();
     wrapper.instance().hideEditForm();
     expect(wrapper.state('showEditForm')).toBe(false);
+    expect(onCommentCancelSpy).toBeCalled();
   });
 
   test('renders the removal confirmation', () => {

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -67,7 +67,10 @@ describe('Comment', () => {
         .first()
         .prop('clickHandler')
     ).toEqual(wrapper.instance().showEditForm);
-    actions.find(Button).last().prop('clickHandler')();
+    actions
+      .find(Button)
+      .last()
+      .prop('clickHandler')();
     expect(wrapper.state('confirmRemoval')).toEqual(true);
   });
 
@@ -85,7 +88,9 @@ describe('Comment', () => {
     expect(commentForm.prop('value')).toBe(props.body);
     expect(commentForm.prop('focusOnMount')).toBe(true);
     expect(commentForm.prop('onCommentChange')).toEqual(props.onCommentChange);
-    expect(commentForm.prop('onRowCountChange')).toEqual(props.onRowCountChange);
+    expect(commentForm.prop('onRowCountChange')).toEqual(
+      props.onRowCountChange
+    );
     expect(commentForm.prop('id')).toBe(props.id);
   });
 
@@ -124,7 +129,9 @@ describe('Comment', () => {
     const container = wrapper.find('.conversation__confirmation');
     const buttons = container.find(Button);
     expect(buttons).toHaveLength(2);
-    expect(buttons.first().prop('clickHandler')).toEqual(wrapper.instance().toggleRemovalConfirmation);
+    expect(buttons.first().prop('clickHandler')).toEqual(
+      wrapper.instance().toggleRemovalConfirmation
+    );
     buttons.last().prop('clickHandler')();
     expect(removeCommentSpy).toHaveBeenCalledTimes(1);
   });

--- a/tests/Conversation/CommentForm/CommentForm.js
+++ b/tests/Conversation/CommentForm/CommentForm.js
@@ -10,7 +10,7 @@ describe('Comment Form', () => {
   let onSubmitSpy;
   let onCancelSpy;
   let onCommentChangeSpy;
-  let onRowCountChange = () => {};
+  const onRowCountChange = () => {};
 
   const props = {
     id: '123',

--- a/tests/Conversation/Conversation.js
+++ b/tests/Conversation/Conversation.js
@@ -81,7 +81,9 @@ describe('Conversation', () => {
     expect(commentList.prop('id')).not.toBe(props.id);
     expect(commentList.prop('focusFallback')).toEqual(props.focusFallback);
     expect(commentList.prop('onCommentChange')).toEqual(props.onCommentChange);
-    expect(commentList.prop('onRowCountChange')).toEqual(props.onRowCountChange);
+    expect(commentList.prop('onRowCountChange')).toEqual(
+      props.onRowCountChange
+    );
   });
 
   test('does not render the reply count text', () => {

--- a/tests/Conversation/Conversation.js
+++ b/tests/Conversation/Conversation.js
@@ -17,6 +17,7 @@ describe('Conversation', () => {
       { person: { name: 'Sapphire' }, id: 321 }
     ],
     onCommentChange() {},
+    onCommentCancel() {},
     onRowCountChange() {}
   };
 
@@ -84,6 +85,7 @@ describe('Conversation', () => {
     expect(commentList.prop('onRowCountChange')).toEqual(
       props.onRowCountChange
     );
+    expect(commentList.prop('onCommentCancel')).toEqual(props.onCommentCancel);
   });
 
   test('does not render the reply count text', () => {


### PR DESCRIPTION
This PR adds a `onCommentCancel` prop to the `Conversation` component 👍 

Handy if we need to reset or stop some functionality after the user has cancelled a edit and we don't have access to the input value for said comment.