### PR TITLE
Feature/message bar

### DIFF
--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -71,9 +71,7 @@ class BoundaryClickWatcher extends Component {
     let containerDoesNotContainTarget = false;
     let containerDoesNotContainFocus = false;
     if (this.container) {
-      containerDoesNotContainTarget = !this.container.contains(
-        event.target
-      );
+      containerDoesNotContainTarget = !this.container.contains(event.target);
       containerDoesNotContainFocus = !this.container.contains(
         document.activeElement
       );

--- a/lib/Button/styles.scss
+++ b/lib/Button/styles.scss
@@ -168,6 +168,22 @@ $color-btn-contained--bg: white !default;
   }
 }
 
+.button--purple-text {
+  background: white;
+  color: $primary-purple;
+  .icon path {
+    fill: $primary-purple;
+  }
+}
+
+.button--slim {
+  padding: $layout-spacing-base/10 $layout-spacing-base/2;
+  .icon {
+    margin-left: $layout-spacing-base/4;
+    vertical-align: text-bottom;
+  }
+}
+
 .button--clear {
   background: none;
   padding: 0;

--- a/lib/Button/styles.scss
+++ b/lib/Button/styles.scss
@@ -179,7 +179,7 @@ $color-btn-contained--bg: white !default;
 .button--slim {
   padding: $layout-spacing-base/10 $layout-spacing-base/2;
   .icon {
-    margin-left: $layout-spacing-base/4;
+    margin-left: $layout-spacing-base/3;
     vertical-align: text-bottom;
   }
 }

--- a/lib/MessageBar/MessageBarContent.js
+++ b/lib/MessageBar/MessageBarContent.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import Col from 'react-bootstrap/lib/Col';
+
+const MessageBarContent = ({ left, center, right, ...props }) => {
+  const classes = cx('message-bar__content', {
+    'message-bar__content--left': left,
+    'message-bar__content--center': center,
+    'message-bar__content--right': right
+  });
+  return (
+    <Col className={classes} {...props}>
+      {props.children}
+    </Col>
+  );
+};
+
+MessageBarContent.propTypes = {
+  left: PropTypes.bool,
+  center: PropTypes.bool,
+  right: PropTypes.bool,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.shape())
+  ])
+};
+
+MessageBarContent.defaultProps = {
+  left: false,
+  center: false,
+  right: false,
+  children: []
+};
+
+export default MessageBarContent;

--- a/lib/MessageBar/README.md
+++ b/lib/MessageBar/README.md
@@ -1,0 +1,36 @@
+# MessageBar
+A collection of components used to render a simple bar to display messages
+
+## Usage
+
+### Props
+
+| Name                | Type          | Default   | Required | Description          |
+| ------------------- |-------------- | --------- | -------- |---------------------------------------------------------------------------------- |
+| fixed               | Boolean       | `false`   | No       | The fixed option.    |
+| type                | String        | ''        | No       | applies a dark theme |
+
+```
+<MessageBar
+  type="purple"
+/>
+```
+
+# MessageBarContent
+
+## Usage
+Props are passed down to the [react-bootstrap/col](https://react-bootstrap.github.io/components.html#grid-props-col)
+
+### Props
+
+| Name                | Type          | Default   | Required | Description                |
+| ------------------- |-------------- | --------- | -------- |---------------------------------------------------------------------------------------- |
+| left                | Boolean       | `false`   | No       | Left align the content.    |
+| center              | Boolean       | `false`   | No       | Center align the content.  |
+| right               | Boolean       | `false`   | No       | Right align the content.   |
+
+```
+<MessageBarContent
+  center
+/>
+```

--- a/lib/MessageBar/README.md
+++ b/lib/MessageBar/README.md
@@ -5,10 +5,10 @@ A collection of components used to render a simple bar to display messages
 
 ### Props
 
-| Name                | Type          | Default   | Required | Description          |
-| ------------------- |-------------- | --------- | -------- |---------------------------------------------------------------------------------- |
-| fixed               | Boolean       | `false`   | No       | The fixed option.    |
-| type                | String        | ''        | No       | applies a dark theme |
+| Name                | Type          | Default   | Required | Description                                 |
+| ------------------- |-------------- | --------- | -------- |--------------------------------------------------------------------------------------------------------- |
+| fixed               | Boolean       | `false`   | No       | The fixed option.                           |
+| type                | String        | ''        | No       | Dictates what style the MessageBar will use |
 
 ```
 <MessageBar

--- a/lib/MessageBar/index.js
+++ b/lib/MessageBar/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Grid from 'react-bootstrap/lib/Grid';
+import Row from 'react-bootstrap/lib/Row';
+import cx from 'classnames';
+
+const MessageBar = props => {
+  const classes = cx('message-bar', {
+    [`message-bar__${props.type}`]: props.type,
+    'message-bar__fixed': props.fixed
+  });
+
+  return (
+    <Grid className={classes} fluid>
+      <Row className="message-bar__inner">{props.children}</Row>
+    </Grid>
+  );
+};
+
+MessageBar.propTypes = {
+  fixed: PropTypes.bool,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.shape())
+  ]),
+  type: PropTypes.string
+};
+
+MessageBar.defaultProps = {
+  fixed: false,
+  children: [],
+  type: ''
+};
+
+export default MessageBar;

--- a/lib/MessageBar/styles.scss
+++ b/lib/MessageBar/styles.scss
@@ -1,0 +1,38 @@
+.message-bar {
+  font-size: $typo-size-small;
+  color: white;
+  width: 100%;
+  background: $neutral-dark;
+  padding: $layout-spacing-base/4 $layout-spacing-base/2;
+  position: relative;
+  z-index: 3;
+  a {
+    color: white;
+  }
+  &__inner {
+    display: flex;
+  }
+  &__content {
+    position: static;
+    display: flex;
+    align-items: center;
+    &--center {
+      justify-content: center;
+    }
+    &--right {
+      justify-content: flex-end;
+    }
+  }
+  &__fixed {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 3;
+  }
+  &__purple {
+    background: $primary-purple;
+  }
+  &__red {
+    background: $primary-red;
+  }
+}

--- a/lib/TopBar/README.md
+++ b/lib/TopBar/README.md
@@ -7,8 +7,9 @@ A collection of components used to render conversations
 
 | Name                | Type          | Default   | Required | Description                                                                   |
 | ------------------- |-------------- | --------- | -------- |------------------------------------------------------------------------------ |
-| fixed               | Boolean       | `false`   | No       | The fixed option.                                                          |
-| useDarkTheme        | Boolean       | `false`         | No       | applies a dark theme |
+| fixed               | Boolean       | `false`   | No       | The fixed option.                               |
+| scrollToFixed       | Boolean       | `false`   | No       | Will fix the TopBar when the user scrolls to it |
+| useDarkTheme        | Boolean       | `false`   | No       | applies a dark theme                            |
 
 ```
 <TopBar />

--- a/lib/TopBar/index.js
+++ b/lib/TopBar/index.js
@@ -1,29 +1,74 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
 import cx from 'classnames';
 
-const TopBar = props => {
-  const wrapperClasses = cx('top-bar__wrapper', {
-    'top-bar__wrapper--fixed': props.fixed
-  });
+class TopBar extends Component {
+  constructor() {
+    super();
 
-  const classes = cx('top-bar', {
-    'top-bar--dark': props.useDarkTheme
-  });
+    this.state = {
+      initialPostion: 0,
+      scrollFixed: false
+    };
+  }
 
-  return (
-    <Grid className={classes} fluid>
-      <div className={wrapperClasses}>
-        <Row className="top-bar__inner">{props.children}</Row>
-      </div>
-    </Grid>
-  );
-};
+  componentDidMount = () => {
+    if (this.props.scrollToFixed) {
+      window.addEventListener('scroll', this.handleScroll);
+      this.setState({
+        initialPostion:
+          this.topbar.getBoundingClientRect().top + window.pageYOffset
+      });
+    }
+  };
+
+  componentWillUnmount = () => {
+    if (this.props.scrollToFixed) {
+      window.removeEventListener('scroll', this.handleScroll);
+    }
+  };
+
+  handleScroll = () => {
+    const topBarPosition = this.topbar.getBoundingClientRect().top;
+    if (topBarPosition <= 0 && !this.state.scrollFixed) {
+      this.setState({ scrollFixed: true });
+    }
+    if (
+      window.pageYOffset < this.state.initialPostion &&
+      this.state.scrollFixed
+    ) {
+      this.setState({ scrollFixed: false });
+    }
+  };
+
+  render() {
+    const wrapperClasses = cx('top-bar__wrapper', {
+      'top-bar__wrapper--fixed': this.props.fixed || this.state.scrollFixed
+    });
+
+    const classes = cx('top-bar', {
+      'top-bar--dark': this.props.useDarkTheme
+    });
+    return (
+      <Grid className={classes} fluid>
+        <div
+          className={wrapperClasses}
+          ref={node => {
+            this.topbar = node;
+          }}
+        >
+          <Row className="top-bar__inner">{this.props.children}</Row>
+        </div>
+      </Grid>
+    );
+  }
+}
 
 TopBar.propTypes = {
   fixed: PropTypes.bool,
+  scrollToFixed: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
@@ -34,6 +79,7 @@ TopBar.propTypes = {
 
 TopBar.defaultProps = {
   fixed: false,
+  scrollToFixed: false,
   useDarkTheme: false,
   children: []
 };

--- a/lib/TopBar/styles.scss
+++ b/lib/TopBar/styles.scss
@@ -118,16 +118,17 @@ $top-bar-box-shadow: $shadow-base;
   .top-bar__drop-down {
     background: #fff;
     overflow: scroll;
-    position: fixed;
-    top: $top-bar-height;
-    bottom: 0;
+    position: absolute;
+    height: 100vh;
+    top: $top-bar-height - ($layout-spacing-base / 2);
+    bottom: auto;
     left: 0;
     right: 0;
     z-index: 999;
 
     @include respond-to($top-bar-main-breakpoint) {
       max-width: 400px;
-      top: $top-bar-height-medium;
+      top: $top-bar-height-medium - ($layout-spacing-base / 2);
     }
   }
   &--dark {

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,3 +54,4 @@ export ShortcutTrigger from './ShortcutTrigger';
 export SectionHeader from './SectionHeader';
 export Tabs from './Tabs';
 export LoadingOverlay from './LoadingOverlay';
+export MessageBar from './MessageBar';

--- a/stories/components/MessageBar.js
+++ b/stories/components/MessageBar.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import MenuItem from 'react-bootstrap/lib/MenuItem';
+import StoryItem from '../styleguide/StoryItem';
+import MessageBar from '../../lib/MessageBar';
+import MessageBarContent from '../../lib/MessageBar/MessageBarContent';
+import Button from '../../lib/Button';
+import Icon from '../../lib/Icon';
+
+storiesOf('Components', module).add('MessageBar', () => (
+  <div>
+    <StoryItem
+      title="MessageBar default"
+      description="A bar used to display simple messaging."
+    >
+      <MessageBar>
+        <MessageBarContent center xs={12} md={12}>
+          <span>Here is a message for you to read!</span>
+        </MessageBarContent>
+      </MessageBar>
+    </StoryItem>
+    <StoryItem
+      title="MessageBar purple"
+      description="purple message bar."
+    >
+    <MessageBar
+      type="purple"
+    >
+      <MessageBarContent center xs={8} md={10}>
+        <span>I'm a nice purple message, hello! I have a button too, how exciting!</span>
+      </MessageBarContent>
+      <MessageBarContent right xs={4} md={2}>
+        <Button
+          types={['purple-text', 'slim']}
+        >
+          hello
+          <Icon name="comment" />
+        </Button>
+      </MessageBarContent>
+    </MessageBar>
+    </StoryItem>
+    <StoryItem
+      title="MessageBar red"
+      description="red message bar."
+    >
+    <MessageBar
+      type="red"
+    >
+      <MessageBarContent center xs={12} md={12}>
+        <span>I am a scary red message, better pay attention to me!</span>
+      </MessageBarContent>
+    </MessageBar>
+    </StoryItem>
+  </div>
+));

--- a/stories/index.js
+++ b/stories/index.js
@@ -37,3 +37,4 @@ import SectionHeader from './components/SectionHeader';
 import ShortcutTrigger from './components/ShortcutTrigger';
 import Tabs from './components/Tabs';
 import LoadingOverlay from './components/LoadingOverlay';
+import MessageBar from './components/MessageBar';

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -36,3 +36,4 @@
 @import '../../lib/SectionHeader/styles.scss';
 @import '../../lib/Tabs/styles.scss';
 @import '../../lib/LoadingOverlay/styles.scss';
+@import '../../lib/MessageBar/styles.scss';

--- a/tests/MessageBar/MessageBarContent.js
+++ b/tests/MessageBar/MessageBarContent.js
@@ -1,0 +1,44 @@
+import { React, shallow } from '../setup';
+import MessageBarContent from '../../lib/MessageBar/MessageBarContent';
+
+describe('MessageBarContent', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <MessageBarContent>
+        <div className="child">i am a small child</div>
+      </MessageBarContent>
+    );
+  });
+
+  afterEach(() => {});
+
+  test('renders its children', () => {
+    expect(wrapper.find('.child')).toHaveLength(1);
+  });
+
+  test('adds a left class when left prop is there', () => {
+    expect(wrapper.find('.message-bar__content--left')).toHaveLength(0);
+    wrapper.setProps({
+      left: true
+    });
+    expect(wrapper.find('.message-bar__content--left')).toHaveLength(1);
+  });
+
+  test('adds a center class when center prop is there', () => {
+    expect(wrapper.find('.message-bar__content--center')).toHaveLength(0);
+    wrapper.setProps({
+      center: true
+    });
+    expect(wrapper.find('.message-bar__content--center')).toHaveLength(1);
+  });
+
+  test('adds a right class when right prop is there', () => {
+    expect(wrapper.find('.message-bar__content--right')).toHaveLength(0);
+    wrapper.setProps({
+      right: true
+    });
+    expect(wrapper.find('.message-bar__content--right')).toHaveLength(1);
+  });
+});

--- a/tests/MessageBar/index.js
+++ b/tests/MessageBar/index.js
@@ -1,0 +1,36 @@
+import { React, shallow } from '../setup';
+import MessageBar from '../../lib/MessageBar';
+
+describe('MessageBar', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <MessageBar>
+        <div className="child">i am a small child</div>
+      </MessageBar>
+    );
+  });
+
+  afterEach(() => {});
+
+  test('renders its children', () => {
+    expect(wrapper.find('.child')).toHaveLength(1);
+  });
+
+  test('adds a fixed class when fixed prop is passed', () => {
+    expect(wrapper.find('.message-bar__fixed')).toHaveLength(0);
+    wrapper.setProps({
+      fixed: true
+    });
+    expect(wrapper.find('.message-bar__fixed')).toHaveLength(1);
+  });
+
+  test('adds a type class when a type prop is passed', () => {
+    expect(wrapper.find('.message-bar__purple')).toHaveLength(0);
+    wrapper.setProps({
+      type: 'purple'
+    });
+    expect(wrapper.find('.message-bar__purple')).toHaveLength(1);
+  });
+});

--- a/tests/TopBar/index.js
+++ b/tests/TopBar/index.js
@@ -25,6 +25,14 @@ describe('TopBar', () => {
     expect(wrapper.find('.top-bar__wrapper--fixed')).toHaveLength(1);
   });
 
+  test('adds a fixed class when the scrollFixed state is true', () => {
+    expect(wrapper.find('.top-bar__wrapper--fixed')).toHaveLength(0);
+    wrapper.setState({
+      scrollFixed: true
+    });
+    expect(wrapper.find('.top-bar__wrapper--fixed')).toHaveLength(1);
+  });
+
   test('adds a dark class when useDarkTheme prop is true', () => {
     expect(wrapper.find('.top-bar--dark')).toHaveLength(0);
     wrapper.setProps({


### PR DESCRIPTION
A few additions.

- A new MessageBar component used to display a simple messaging banner
- A new scrollToFixed prop on TopBar, which if true will only fix the TopBar once the user has scrolled to it. (Useful for when we have things, like the MessageBar, displaying above the TopBar)
- Some styling changes to TopBar dropdowns, so they are still positioned correctly if the TopBar isnt at the very top of the page
- A couple of new button styles, a slim one and a purple one
- A couple of linting fixes