### PR TITLE
Fixed the focus fallback

### DIFF
--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -111,7 +111,7 @@ $conversation-meta-text-color: $neutral-base !default;
 }
 
 .conversation__focus-fallback {
-  position: fixed;
+  position: absolute;
   bottom: 0;
   left: -999em;
 }


### PR DESCRIPTION
The focus fallback is used so when we cancel comment edits etc we can still be focused in the component.