### PR TITLE
Issue: Comment editing content loss bug

### DIFF
--- a/lib/Conversation/CommentForm/index.js
+++ b/lib/Conversation/CommentForm/index.js
@@ -36,10 +36,10 @@ class CommentForm extends Component {
     }
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      inputValue: '',
+      inputValue: props.value,
       inputHasFocused: false
     };
     this.updateInputValue = this.updateInputValue.bind(this);


### PR DESCRIPTION
This fixes a bug where if you edited a comment without changing the value the comment content would disappear.

This was down to the inputValue state in CommentForm only getting a value if the input value had actually changed. 