### PR TITLE
fixing a few bugs around comment editing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: "node"
 script:
-  - travis_wait 30 yarn test:travis
+  - travis_wait 30 yarn test:ci
   - travis_wait 30 yarn lint
 cache: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: "node"
 script:
-  - travis_wait 30 yarn test
+  - travis_wait 30 yarn test:travis
   - travis_wait 30 yarn lint
 cache: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js: "node"
-script: yarn test && yarn lint
+script: travis_wait 30 yarn test && yarn lint
 cache: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js: "node"
-script: travis_wait 30 yarn test && yarn lint
+script:
+  - travis_wait 30 yarn test
+  - travis_wait 30 yarn lint
 cache: yarn

--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -10,7 +10,6 @@ class Comment extends Component {
   static propTypes = {
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     body: PropTypes.string.isRequired,
-    focusFallback: PropTypes.oneOfType([PropTypes.func, PropTypes.shape()]),
     createdAt: PropTypes.string.isRequired,
     createdBy: PropTypes.number.isRequired,
     author: PropTypes.shape().isRequired,
@@ -26,7 +25,6 @@ class Comment extends Component {
 
   static defaultProps = {
     user: {},
-    focusFallback() {},
     onRowCountChange() {}
   };
 
@@ -52,7 +50,7 @@ class Comment extends Component {
       confirmRemoval: false
     });
     this.props.onCommentCancel();
-    this.props.focusFallback.focus();
+    this.focusFallback.focus();
   }
 
   editComment(commentBody) {
@@ -163,6 +161,14 @@ class Comment extends Component {
             </Button>
           </div>
         </div>
+        <input
+          type="text"
+          className="conversation__focus-fallback"
+          ref={focusFallback => {
+            this.focusFallback = focusFallback;
+          }}
+          aria-hidden="true"
+        />
       </div>
     );
   }

--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -74,6 +74,12 @@ class Comment extends Component {
     return this.props.removeComment(this.props.id, this.props.conversationId);
   }
 
+  handleEditKeyPress = event => {
+    if (event.key === 'Enter') {
+      this.showEditForm();
+    }
+  };
+
   render() {
     const { createdAt, createdBy, body, author, user, index } = this.props;
     const removalText = index === 0 ? 'thread' : 'comment';
@@ -100,13 +106,15 @@ class Comment extends Component {
 
                 {userCanEdit && (
                   <span className="conversation__actions">
-                    <Button
-                      className="conversation__meta"
-                      types={['link', 'link-default', 'collapse']}
-                      clickHandler={this.showEditForm}
+                    <div
+                      className="button button--link button--link-default button--collapse conversation__meta"
+                      onClick={this.showEditForm}
+                      onKeyUp={this.handleEditKeyPress}
+                      role="button"
+                      tabIndex={0}
                     >
                       Edit
-                    </Button>
+                    </div>
                     <Button
                       className="conversation__meta"
                       types={['link', 'link-danger', 'collapse']}

--- a/lib/Conversation/CommentForm/index.js
+++ b/lib/Conversation/CommentForm/index.js
@@ -48,6 +48,12 @@ class CommentForm extends Component {
     this.toggleInputHasFocus = this.toggleInputHasFocus.bind(this);
   }
 
+  componentDidMount() {
+    if (this.state.inputValue) {
+      this.props.onCommentChange(this.props.id, this.state.inputValue);
+    }
+  }
+
   onSubmit(e) {
     if (e) {
       e.preventDefault();
@@ -93,7 +99,7 @@ class CommentForm extends Component {
             handleOnChange={this.updateInputValue}
             handleOnFocus={this.toggleInputHasFocus}
             focusOnMount={this.props.focusOnMount}
-            value={this.state.inputValue || this.props.value}
+            value={this.state.inputValue}
             placeholder={this.props.placeholder}
             onRowCountChange={this.props.onRowCountChange}
             setValue

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -94,7 +94,6 @@ class Conversation extends Component {
                 {...rest}
                 conversationId={id}
                 comments={comments}
-                focusFallback={this.focusFallback}
                 onCommentChange={this.props.onCommentChange}
                 onCommentCancel={this.props.onCommentCancel}
               />
@@ -131,15 +130,6 @@ class Conversation extends Component {
             />
           </div>
         )}
-
-        <input
-          type="text"
-          className="conversation__focus-fallback"
-          ref={focusFallback => {
-            this.focusFallback = focusFallback;
-          }}
-          aria-hidden="true"
-        />
       </div>
     );
   }

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -121,7 +121,7 @@ $conversation-meta-text-color: $neutral-base !default;
 }
 
 .conversation__focus-fallback {
-  position: fixed;
+  position: absolute;
   bottom: 0;
   left: -999em;
 }

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -121,7 +121,7 @@ $conversation-meta-text-color: $neutral-base !default;
 }
 
 .conversation__focus-fallback {
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: -999em;
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "storybook": "start-storybook -p 6006 -c .storybook",
     "build-storybook": "build-storybook",
     "test": "jest tests/**/** --notify || exit 0",
+    "test:travis": "jest tests/**/** --runInBand || exit 0",
     "test:watch": "jest tests/**/** --notify --watch || exit 0",
     "tdd": "yarn run test:watch",
     "lint": "eslint -c .eslintrc.json lib/* tests/* || exit 0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "storybook": "start-storybook -p 6006 -c .storybook",
     "build-storybook": "build-storybook",
     "test": "jest tests/**/** --notify || exit 0",
-    "test:travis": "jest tests/**/** --runInBand || exit 0",
+    "test:ci": "jest tests/**/** --runInBand || exit 0",
     "test:watch": "jest tests/**/** --notify --watch || exit 0",
     "tdd": "yarn run test:watch",
     "lint": "eslint -c .eslintrc.json lib/* tests/* || exit 0",

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -61,12 +61,13 @@ describe('Comment', () => {
 
   test('renders the edit comment controls (when a user can edit)', () => {
     const actions = wrapper.find('.conversation__actions');
-    expect(actions.find(Button)).toHaveLength(2);
+    expect(actions.find('.button')).toHaveLength(1);
+    expect(actions.find(Button)).toHaveLength(1);
     expect(
       actions
-        .find(Button)
+        .find('.button')
         .first()
-        .prop('clickHandler')
+        .prop('onClick')
     ).toEqual(wrapper.instance().showEditForm);
     actions
       .find(Button)

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -1,5 +1,5 @@
 import Linkify from 'linkifyjs/react';
-import { React, shallow } from '../setup';
+import { React, mount } from '../setup';
 import Comment from '../../lib/Conversation/Comment';
 import CommentForm from '../../lib/Conversation/CommentForm';
 import Person from '../../lib/Person';
@@ -31,7 +31,7 @@ describe('Comment', () => {
   };
 
   beforeEach(() => {
-    wrapper = shallow(<Comment {...props} />);
+    wrapper = mount(<Comment {...props} />);
   });
 
   afterEach(() => {
@@ -45,7 +45,7 @@ describe('Comment', () => {
   });
 
   test('renders the comment body text and passes it through the Linkify component', () => {
-    expect(wrapper.find(Linkify).contains(props.body)).toBe(true);
+    expect(wrapper.find(Linkify).prop('children')).toEqual(props.body);
   });
 
   test('renders the comment created at text', () => {
@@ -61,8 +61,7 @@ describe('Comment', () => {
 
   test('renders the edit comment controls (when a user can edit)', () => {
     const actions = wrapper.find('.conversation__actions');
-    expect(actions.find('.button')).toHaveLength(1);
-    expect(actions.find(Button)).toHaveLength(1);
+    expect(actions.find('.button')).toHaveLength(2);
     expect(
       actions
         .find('.button')


### PR DESCRIPTION
A few bugs fixed: 

1. The showComment state being lost when clicking on the edit Button (now a div)
2. You couldn't delete all the text in a CommentForm if you pass a value prop
3. The focus fallback would throw you down the page when focused (set back to fixed, if this was changed for a reason give me a shout, couldn't see any nastiness caused)