### PR TITLE
Amends the styling so the current styling is only applied to 1 item

### DIFF
--- a/lib/List/styles.scss
+++ b/lib/List/styles.scss
@@ -48,7 +48,7 @@ $list-border: 1px solid $color-border-base;
     padding-left: $layout-spacing-base*3.5;
   }
 
-  .is-current & {
+  .is-current > & {
     background: #f9f9f9;
   }
 }


### PR DESCRIPTION
Currently when a parent is current in the list component it shades the child components in the same background colour. This PR fixes that 😄 