### PR TITLE
Hide Instructions (when not set)

### DIFF
--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -46,7 +46,9 @@ const Field = props => {
             <div className="field__child">{props.children}</div>
 
             {!props.canEdit ? (
-              <div className="field__instructions">{props.instructions}</div>
+              props.instructions && (
+                <div className="field__instructions">{props.instructions}</div>
+              )
             ) : (
               <ExpandingTextArea
                 type="text"

--- a/tests/Field/Field.js
+++ b/tests/Field/Field.js
@@ -75,4 +75,12 @@ describe('Field', () => {
     expect(wrapper.hasClass('has-formatting')).toEqual(true);
     expect(wrapper.hasClass('is-disabled')).toEqual(true);
   });
+
+  test('that fields do not render instructions when none are set', () => {
+    expect(wrapper.find('.field__instructions')).toHaveLength(1);
+    wrapper.setProps({
+      instructions: ''
+    });
+    expect(wrapper.find('.field__instructions')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Don't show instruction when none are set for base fields.