### PR TITLE
Removed outline from search input • Added a border on search input focus

### DIFF
--- a/lib/SearchInput/styles.scss
+++ b/lib/SearchInput/styles.scss
@@ -19,6 +19,12 @@ $search-input-padding: $layout-spacing-base/2 !default;
     font-size: $search-input-font-size;
     line-height: $search-input-line-height;
     padding: $search-input-padding;
+    outline: none;
+    border-radius: 4px;
+
+    &:focus {
+        border-color: $neutral-base;
+    }
 }
 
 .search-input__clear {


### PR DESCRIPTION
I've added `outline: none` to the search input, however it looks like buttons already have these applied, so maybe the structure button isn't using the same class as the buttons in gather-ui. 