### PR TITLE
FileCard label z-index

### DIFF
--- a/lib/FileCard/styles.scss
+++ b/lib/FileCard/styles.scss
@@ -125,7 +125,6 @@ $file-card-border-radius: 3px !default;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  z-index: 1;
 }
 
 .file-card__actions {


### PR DESCRIPTION
The FileCard label would appear over other dom elements (i.e. a fixed position header).

So I've just removed the z-index, this seems to have no negative impact, the label is still visible with or without a preview image, not sure why it was there to begin with. 😅