### PR TITLE
Fix Inline Comment Edit Padding

### DIFF
--- a/lib/Conversation/CommentForm/styles.scss
+++ b/lib/Conversation/CommentForm/styles.scss
@@ -9,7 +9,7 @@ $comment-form-padding: $layout-spacing-base/2;
 .comment-form--inline {
   .comment-form__input,
   .comment-form__input:focus {
-    padding: 0;
+    padding: 0 $layout-spacing-base/2 0 0;
     border: 0;
   }
 


### PR DESCRIPTION
When editing comments the textarea doesn't share the same right padding which means the text can move between states causing a poor experience.