### PR TITLE
New ConfirmationOverlay component

### DIFF
--- a/lib/ConfirmationOverlay/README.md
+++ b/lib/ConfirmationOverlay/README.md
@@ -1,0 +1,22 @@
+# ConfirmationOverlay
+Overlays a confirm and cancel button
+
+## Usage
+
+### Props
+
+| Name                  | Type          | Default       | Required | Description                                         |
+| --------------------- |-------------- | ------------- | -------- |---------------------------------------------------- |
+| cancel                | Function      | N/A           | Yes      | Executes when the user clicks the cancel button.    |
+| confirm               | Function      | N/A           | Yes      | Executes when the user clicks the confirm button.   |
+| show                  | bool          | false         | No       | If true the overlay will display.                   |
+| confirmationText      | string        | 'Confirm'     | No       | Text to display for the confirm button.             |
+
+```
+<ConfirmationOverlay
+  cancel={() => {}}
+  confirm={() => {}}
+  confirmationText="Do the thing!"
+  show
+/>
+```

--- a/lib/ConfirmationOverlay/index.js
+++ b/lib/ConfirmationOverlay/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import Button from '../Button';
+
+const ConfirmationOverlay = props => {
+  const classNames = cx(`confirmation-overlay ${props.className}`, {
+    'confirmation-overlay--show': props.show
+  });
+
+  return (
+    <div className={classNames}>
+      <div className="confirmation-overlay__inner">
+        <Button
+          types={['primary', 'size-sm']}
+          className="confirmation-overlay__button"
+          clickHandler={props.cancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          types={['danger', 'size-sm']}
+          className="confirmation-overlay__button"
+          clickHandler={props.confirm}
+        >
+          {props.confirmationText}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+ConfirmationOverlay.propTypes = {
+  cancel: PropTypes.func.isRequired,
+  confirm: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  confirmationText: PropTypes.string,
+  show: PropTypes.bool
+};
+
+ConfirmationOverlay.defaultProps = {
+  className: '',
+  confirmationText: 'Confirm',
+  show: false
+};
+
+export default ConfirmationOverlay;

--- a/lib/ConfirmationOverlay/styles.scss
+++ b/lib/ConfirmationOverlay/styles.scss
@@ -1,0 +1,25 @@
+.confirmation-overlay {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+  &__inner {
+    display: flex;
+  }
+  &__button {
+    margin: $layout-spacing-base/4;
+  }
+  &--show {
+    display: flex;
+  }
+}
+
+.confirmation-overlay,
+.confirmation-overlay__inner {
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -5,6 +5,7 @@ import Linkify from 'linkifyjs/react';
 import Button from '../Button';
 import CommentForm from './CommentForm';
 import Person from '../Person';
+import ConfirmationOverlay from '../ConfirmationOverlay';
 
 class Comment extends Component {
   static propTypes = {
@@ -67,7 +68,7 @@ class Comment extends Component {
 
   render() {
     const { createdAt, createdBy, body, author, user, index } = this.props;
-    const removalText = index === 0 ? 'thread' : 'comment';
+    const removalText = index === 0 ? 'Delete thread' : 'Delete comment';
     const userCanEdit = createdBy === user.id;
     const className = cx('conversation__comment', {
       'is-disabled': this.state.confirmRemoval
@@ -130,25 +131,13 @@ class Comment extends Component {
               )}
           </div>
         </div>
-
-        <div className="conversation__confirmation">
-          <div className="conversation__confirmation-inner">
-            <Button
-              types={['primary', 'size-sm']}
-              className="conversation__confirmation-button"
-              clickHandler={this.toggleRemovalConfirmation}
-            >
-              Cancel
-            </Button>
-            <Button
-              types={['danger', 'size-sm']}
-              className="conversation__confirmation-button"
-              clickHandler={() => this.removeComment(true)}
-            >
-              Delete {removalText}
-            </Button>
-          </div>
-        </div>
+        <ConfirmationOverlay
+          className="conversation__confirmation-overlay"
+          cancel={this.toggleRemovalConfirmation}
+          confirm={() => this.removeComment(true)}
+          confirmationText={removalText}
+          show={this.state.confirmRemoval}
+        />
         <input
           type="text"
           className="conversation__focus-fallback"

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -139,6 +139,10 @@ $conversation-meta-text-color: $neutral-base !default;
   margin-bottom: $conversation-padding;
 }
 
+.conversation__confirmation-overlay {
+  left: $conversation-comment-body-indentation;
+}
+
 /* ==========================================================================
    State Styles
    ========================================================================== */
@@ -187,33 +191,5 @@ $conversation-meta-text-color: $neutral-base !default;
     filter: blur(4px);
     background: none;
   }
-}
 
-.conversation__confirmation {
-  display: none;
-  position: absolute;
-  top: 0;
-  left: $conversation-comment-body-indentation;
-  right: 0;
-  bottom: 0;
-  z-index: 1;
-}
-
-.conversation__confirmation,
-.conversation__confirmation-inner {
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.conversation__confirmation-inner {
-  display: flex;
-}
-
-.conversation__confirmation-button {
-  margin: $layout-spacing-base/4;
-}
-
-.is-disabled .conversation__confirmation {
-  display: flex;
 }

--- a/lib/FileCard/index.js
+++ b/lib/FileCard/index.js
@@ -9,18 +9,22 @@ class FileCard extends Component {
     filename: PropTypes.string,
     label: PropTypes.string,
     active: PropTypes.bool,
+    disabled: PropTypes.bool,
     children: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.arrayOf(PropTypes.node)
-    ])
+    ]),
+    className: PropTypes.string
   };
 
   static defaultProps = {
     previewSrc: '',
     filename: '',
     label: '',
+    className: '',
     active: false,
     isHighlighted: false,
+    disabled: false,
     children: []
   };
 
@@ -35,11 +39,14 @@ class FileCard extends Component {
       isHighlighted,
       label,
       children,
-      active
+      active,
+      className,
+      disabled
     } = this.props;
-    const classes = cx('file-card', {
+    const classes = cx(`file-card ${className}`, {
       'file-card--highlighted': isHighlighted,
-      'file-card--active': active
+      'file-card--active': active,
+      'file-card--disabled': disabled
     });
 
     return (

--- a/lib/FileCard/styles.scss
+++ b/lib/FileCard/styles.scss
@@ -41,6 +41,15 @@ $file-card-border-radius: 3px !default;
       }
     }
   }
+  &--disabled {
+    background: rgba(255, 255, 255, .75);
+
+    @supports (filter: blur()) {
+      transition: filter $animation-time-micro/2;
+      filter: blur(3px);
+      background: none;
+    }
+  }
 }
 
 .file-card__wrapper {

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,3 +62,4 @@ export DueDatePicker from './DueDatePicker';
 export DueDateLabel from './DueDatePicker/DueDateLabel';
 export SearchDropdown from './SearchDropdown';
 export UserList from './UserList';
+export ConfirmationOverlay from './ConfirmationOverlay';

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -2,6 +2,7 @@
 @import '../../lib/AvatarGroup/styles.scss';
 @import '../../lib/BoundaryClickWatcher/styles.scss';
 @import '../../lib/Button/styles.scss';
+@import '../../lib/ConfirmationOverlay/styles.scss';
 @import '../../lib/Avatar/styles.scss';
 @import '../../lib/CheckToggle/styles.scss';
 @import '../../lib/Notification/styles.scss';

--- a/tests/ConfirmationOverlay/index.js
+++ b/tests/ConfirmationOverlay/index.js
@@ -1,0 +1,46 @@
+import { React, shallow } from '../setup';
+import { ConfirmationOverlay, Button } from '../../lib';
+
+describe('Confirmation Overlay', () => {
+  let wrapper;
+
+  const cancelSpy = jest.fn();
+  const confirmSpy = jest.fn();
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <ConfirmationOverlay
+        cancel={cancelSpy}
+        confirm={confirmSpy}
+        confirmationText="dooo ittttt"
+        show
+      />
+    );
+  });
+
+  afterEach(() => {
+    cancelSpy.mockReset();
+    confirmSpy.mockReset();
+  });
+
+  test('adds a show modifier', () => {
+    expect(wrapper.hasClass('confirmation-overlay--show')).toBe(true);
+    wrapper.setProps({ show: false });
+    expect(wrapper.hasClass('confirmation-overlay--show')).toBe(false);
+  });
+
+  test('renders two Buttons', () => {
+    const buttons = wrapper.find(Button);
+    expect(buttons).toHaveLength(2);
+    buttons.first().prop('clickHandler')();
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    buttons.last().prop('clickHandler')();
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(
+      buttons
+        .last()
+        .render()
+        .text()
+    ).toEqual('dooo ittttt');
+  });
+});

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -4,6 +4,7 @@ import Comment from '../../lib/Conversation/Comment';
 import CommentForm from '../../lib/Conversation/CommentForm';
 import Person from '../../lib/Person';
 import Button from '../../lib/Button';
+import ConfirmationOverlay from '../../lib/ConfirmationOverlay';
 
 describe('Comment', () => {
   let wrapper;
@@ -131,13 +132,10 @@ describe('Comment', () => {
   });
 
   test('renders the removal confirmation', () => {
-    const container = wrapper.find('.conversation__confirmation');
-    const buttons = container.find(Button);
-    expect(buttons).toHaveLength(2);
-    expect(buttons.first().prop('clickHandler')).toEqual(
+    expect(wrapper.find(ConfirmationOverlay).prop('cancel')).toEqual(
       wrapper.instance().toggleRemovalConfirmation
     );
-    buttons.last().prop('clickHandler')();
+    wrapper.find(ConfirmationOverlay).prop('confirm')();
     expect(removeCommentSpy).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Splitting the confirmation overlay (used to live in conversations) into its own component.

We can make this a little more complete in the future once `backdrop-filter` is better supported.  