### PR TITLE
fix UserList not clearing search results on SearchDropdown hide

### DIFF
--- a/lib/UserList/index.js
+++ b/lib/UserList/index.js
@@ -41,6 +41,16 @@ class UserList extends Component {
     showSearch: false
   };
 
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      prevState.showSearch &&
+      !this.state.showSearch &&
+      this.props.searchResults.length > 0
+    ) {
+      this.props.handleClearResults();
+    }
+  }
+
   toggleSearch = () => this.setState({ showSearch: !this.state.showSearch });
 
   render() {

--- a/tests/UserList/index.js
+++ b/tests/UserList/index.js
@@ -126,4 +126,12 @@ describe('UserList', () => {
     wrapper.setProps({ showUserControls: false });
     expect(wrapper.find('.show-search')).toHaveLength(0);
   });
+
+  test('calls props.handleClearResults when closing the SearchDropdown', () => {
+    expect(handleClearResultsSpy).not.toHaveBeenCalled();
+    wrapper.find('.show-search').simulate('click');
+    expect(handleClearResultsSpy).not.toHaveBeenCalled();
+    wrapper.find('.show-search').simulate('click');
+    expect(handleClearResultsSpy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
it now calls props.handleClearResults if state.showSearch has been changed to false (and only if there were any results at all)