### PR TITLE
Due date fix

### DIFF
--- a/lib/DueDatePicker/DueDateLabel.js
+++ b/lib/DueDatePicker/DueDateLabel.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Icon from '../Icon';
 
-const DueDateLabel = ({ dueDate }) => {
-  if (!dueDate) {
+const DueDateLabel = ({ overdue, children }) => {
+  if (!children) {
     return (
       <span className="duedate__label duedate__label--button">
         No due date set
@@ -13,26 +13,28 @@ const DueDateLabel = ({ dueDate }) => {
   }
 
   const classNames = cx('duedate__label', {
-    'color-overdue': dueDate.overdue
+    'color-overdue': overdue
   });
 
   return (
     <div className={classNames}>
-      {dueDate.overdue && <Icon name="warning" />}
+      {overdue && <Icon name="warning" />}
       <span>
         {`Due to be completed `}
-        <span className="duedate__label--button">{dueDate.date.fromNow()}</span>
+        <span className="duedate__label--button">{children}</span>
       </span>
     </div>
   );
 };
 
 DueDateLabel.propTypes = {
-  dueDate: PropTypes.shape()
+  children: PropTypes.string,
+  overdue: PropTypes.bool
 };
 
 DueDateLabel.defaultProps = {
-  dueDate: null
+  children: null,
+  overdue: false
 };
 
 export default DueDateLabel;

--- a/stories/components/DueDatePicker.js
+++ b/stories/components/DueDatePicker.js
@@ -10,7 +10,6 @@ storiesOf('Components', module)
     <div>
       <StoryItem title="Due date picker" description="+1 Day">
         <DueDatePicker
-          label="Due Tommorrow at 2:15pm"
           dueDate={moment()
             .add(1, 'day')
             .set({ hours: 14, minutes: 15 })}
@@ -20,7 +19,6 @@ storiesOf('Components', module)
       </StoryItem>
       <StoryItem title="Due date picker" description="None set">
         <DueDatePicker
-          label="Due Tommorrow at 2:15pm"
           dueDate={null}
           applyDueDate={action('applyDueDate')}
           removeDueDate={action('removeDueDate')}
@@ -28,7 +26,6 @@ storiesOf('Components', module)
       </StoryItem>
       <StoryItem title="Due date picker" description="+2 Months">
         <DueDatePicker
-          label="Due Tommorrow at 12:00pm"
           dueDate={moment().add(2, 'months')}
           applyDueDate={action('applyDueDate')}
           removeDueDate={action('removeDueDate')}
@@ -36,7 +33,6 @@ storiesOf('Components', module)
       </StoryItem>
       <StoryItem title="Due date picker" description="-1 hour">
         <DueDatePicker
-          label="Due Tommorrow at 12:00pm"
           dueDate={moment().subtract(1, 'hour')}
           applyDueDate={action('applyDueDate')}
           removeDueDate={action('removeDueDate')}
@@ -44,7 +40,6 @@ storiesOf('Components', module)
       </StoryItem>
       <StoryItem title="Due date picker" description="-4 Days">
         <DueDatePicker
-          label="Due Tommorrow at 12:00pm"
           dueDate={moment().subtract(4, 'day')}
           applyDueDate={action('applyDueDate')}
           removeDueDate={action('removeDueDate')}
@@ -52,7 +47,6 @@ storiesOf('Components', module)
       </StoryItem>
       <StoryItem title="Due date picker" description="-4 Months">
         <DueDatePicker
-          label="Due Tommorrow at 12:00pm"
           dueDate={moment().subtract(4, 'months')}
           applyDueDate={action('applyDueDate')}
           removeDueDate={action('removeDueDate')}
@@ -60,7 +54,6 @@ storiesOf('Components', module)
       </StoryItem>
       <StoryItem title="Due date picker" description="-4 Months (Completed)">
         <DueDatePicker
-          label="Due Tommorrow at 12:00pm"
           dueDate={moment().subtract(4, 'months')}
           applyDueDate={action('applyDueDate')}
           removeDueDate={action('removeDueDate')}
@@ -71,24 +64,14 @@ storiesOf('Components', module)
   ))
   .add('DueDateLabel', () => (
     <div>
-      <StoryItem title="Due date label" description="No date">
-        <DueDateLabel clickHandler={() => {}} />
+      <StoryItem title="Due date label (no date)">
+        <DueDateLabel />
       </StoryItem>
-      <StoryItem title="Due date label" description="+1 Day">
-        <DueDateLabel
-          clickHandler={() => {}}
-          dueDate={{
-            date: moment()
-              .add(1, 'day')
-              .set({ hours: 14, minutes: 15 })
-          }}
-        />
+      <StoryItem title="Due date label (with date)">
+        <DueDateLabel>3 days ago</DueDateLabel>
       </StoryItem>
-      <StoryItem title="Due date label" description="-2 Days">
-        <DueDateLabel
-          clickHandler={() => {}}
-          dueDate={{ date: moment().subtract(2, 'day'), overdue: true }}
-        />
+      <StoryItem title="Due date label (overdue)">
+        <DueDateLabel overdue>2 days ago</DueDateLabel>
       </StoryItem>
     </div>
   ));

--- a/tests/DueDatePicker/DueDateLabel.js
+++ b/tests/DueDatePicker/DueDateLabel.js
@@ -7,11 +7,7 @@ describe('DueDateLabel', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(
-      <DueDateLabel
-        dueDate={{ date: moment().add(2, 'day'), overdue: false }}
-      />
-    );
+    wrapper = shallow(<DueDateLabel>in 2 days</DueDateLabel>);
   });
 
   test('should render 1 <span />s component', () => {
@@ -26,18 +22,18 @@ describe('DueDateLabel', () => {
   });
 
   test('should not display date when not provided', () => {
-    wrapper.setProps({ dueDate: null });
+    wrapper.setProps({ children: '' });
     expect(wrapper.render().text()).toEqual('No due date set');
   });
 
   test('should add class and icon when date is overdue', () => {
     wrapper.setProps({
-      dueDate: { date: moment().subtract(3, 'day'), overdue: true }
+      overdue: true
     });
     expect(wrapper.hasClass('color-overdue')).toBe(true);
     expect(wrapper.find(Icon)).toHaveLength(1);
     expect(wrapper.find(Icon).prop('name')).toEqual('warning');
-    expect(wrapper.find('.duedate__label--button').contains('3 days ago')).toBe(
+    expect(wrapper.find('.duedate__label--button').contains('in 2 days')).toBe(
       true
     );
   });

--- a/tests/DueDatePicker/DueDateLabel.js
+++ b/tests/DueDatePicker/DueDateLabel.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { React, shallow } from '../setup';
 import DueDateLabel from '../../lib/DueDatePicker/DueDateLabel';
 import Icon from '../../lib/Icon';


### PR DESCRIPTION
This PR fixes the issue where `fromNow` being used in the `dueDateLabel` component causes issues due to the incorrect format being supplied.

To make the component easier to use the moment aspect has been removed. That element can be composed outside the component and inserted as a prop. Win win.