### PR TITLE
remove unnecessary margin-right

### DIFF
--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -74,7 +74,6 @@ $field-data-color: $neutral-base !default;
   border-radius: 4px;
   padding: $layout-spacing-base*1.5;
   font-size: $typo-size-lead;
-  margin-right: $field-aside-width/4;
   transition: all 0.2s ease;
 
   .field:not(.is-disabled) &:hover,

--- a/lib/FileCard/styles.scss
+++ b/lib/FileCard/styles.scss
@@ -25,12 +25,13 @@ $file-card-border-radius: 3px !default;
    Styles
    ========================================================================== */
 .file-card {
-  display: inline-flex;
+  display: flex;
   border-radius: $file-card-border-radius;
   width: $file-card-size;
   height: 0;
   padding-bottom: $file-card-size;
   position: relative;
+  margin: 0 0 $layout-spacing-base/2;
 
   &:hover,
   .file-card__action:focus {


### PR DESCRIPTION
Fields have an addition margin right against the content but they also have padding from the grid system. Removing this additional margin means they sit where we expect them to sit.