### PR TITLE
Fix radio input group onTextChange bug

### DIFF
--- a/lib/Form/RadioButton/Group.js
+++ b/lib/Form/RadioButton/Group.js
@@ -67,7 +67,7 @@ export default class Group extends Component {
     choices[otherChoiceIndex] = otherChoiceNewValue;
     const selected = [otherChoiceNewValue];
     this.setState({ choices, selected }, () =>
-      this.props.onChangeHandler(this.state.selected)
+      this.props.onChangeHandler(this.state.selected[0])
     );
   }
 

--- a/tests/Form/RadioButtonGroup.js
+++ b/tests/Form/RadioButtonGroup.js
@@ -72,6 +72,6 @@ describe('RadioButtonGroup', () => {
 
     const expectedOptionChoice = assign({}, otherChoice, { value: 'Hello' });
 
-    expect(onChangeSpy).toHaveBeenCalledWith([expectedOptionChoice]);
+    expect(onChangeSpy).toHaveBeenCalledWith(expectedOptionChoice);
   });
 });


### PR DESCRIPTION
In #314 we altered input groups and we forgot to update the `onTextChangeHandler` method to match the `onChangeHandler`. This fixes that issue.