### PR TITLE
Add a failure state to comments

### DIFF
--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Linkify from 'linkifyjs/react';
 import Button from '../Button';
+import Icon from '../Icon';
 import CommentForm from './CommentForm';
 import Person from '../Person';
 import ConfirmationOverlay from '../ConfirmationOverlay';
@@ -23,12 +24,15 @@ class Comment extends Component {
     onCommentCancel: PropTypes.func.isRequired,
     onRowCountChange: PropTypes.func.isRequired,
     index: PropTypes.number.isRequired,
-    userCanComment: PropTypes.bool.isRequired
+    userCanComment: PropTypes.bool.isRequired,
+    retryComment: PropTypes.func.isRequired,
+    hasFailed: PropTypes.bool
   };
 
   static defaultProps = {
     user: {},
-    onRowCountChange() {}
+    onRowCountChange() {},
+    hasFailed: false
   };
 
   state = {
@@ -68,6 +72,8 @@ class Comment extends Component {
     return this.props.removeComment(this.props.id, this.props.conversationId);
   };
 
+  retryComment = () => this.props.retryComment(this.props.id, this.props.body);
+
   highlightMentions() {
     const pattern = /(\B@\w+)+/gi;
     const strArr = this.props.body.split(pattern);
@@ -97,12 +103,14 @@ class Comment extends Component {
       author,
       user,
       index,
-      userCanComment
+      userCanComment,
+      hasFailed
     } = this.props;
     const removalText = index === 0 ? 'Delete thread' : 'Delete comment';
     const userCanEdit = createdBy === user.id && userCanComment;
     const className = cx('conversation__comment', {
-      'is-disabled': this.state.confirmRemoval
+      'is-disabled': this.state.confirmRemoval,
+      'has-failed': this.props.hasFailed
     });
 
     return (
@@ -135,14 +143,29 @@ class Comment extends Component {
             )}
 
           <div className="conversation__meta-wrapper">
-            {!this.state.showEditForm && (
-              <span className="conversation__meta conversation__date-text">
-                {createdAt}
+            {hasFailed && (
+              <span className="conversation__failed-text">
+                <Icon name="warning" className="conversation__failed--icon" />
+                Comment failed.
+                <Button
+                  className="conversation__meta conversation__failed--button"
+                  types={['link', 'link-default', 'collapse']}
+                  clickHandler={this.retryComment}
+                >
+                  Retry?
+                </Button>
               </span>
             )}
+            {!this.state.showEditForm &&
+              !hasFailed && (
+                <span className="conversation__meta conversation__date-text">
+                  {createdAt}
+                </span>
+              )}
 
             {userCanEdit &&
-              !this.state.showEditForm && (
+              !this.state.showEditForm &&
+              !hasFailed && (
                 <span className="conversation__actions">
                   <Button
                     className="conversation__meta conversation__edit-link"

--- a/lib/Conversation/README.md
+++ b/lib/Conversation/README.md
@@ -12,6 +12,7 @@ A collection of components used to render conversations
 | user                | Object        | N/A       | Yes      | The user who is submitting the comment.                                       |
 | comments            | Array         | `[]`      | No       | An array of comments that are in the conversation.                            |
 | removeComment       | Function      | `() {}`   | No       | Executes when the comment is removed.                                         |
+| retryComment       | Function      | `() {}`   | No       | Executes when the "Retry" button is clicked on the comment failed state.                                         |
 | editComment         | Function      | `() {}`   | No       | Executes when the comment is edited.                                          |
 | onCommentChange     | Function      | `() {}`   | No       | Executes when a comment value changes.                                        |
 | onCommentCancel     | Function      | `() {}`   | No       | Executes when a comment edit has been canceled.                               |

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -29,7 +29,8 @@ class Conversation extends Component {
     hasError: PropTypes.bool,
     className: PropTypes.string,
     users: PropTypes.arrayOf(PropTypes.shape()),
-    resolved: PropTypes.bool
+    resolved: PropTypes.bool,
+    retryComment: PropTypes.func
   };
 
   static defaultProps = {
@@ -45,6 +46,7 @@ class Conversation extends Component {
     onCommentChange() {},
     onCommentCancel() {},
     onRowCountChange() {},
+    retryComment() {},
     comments: [],
     placeholder: 'Reply...',
     className: '',
@@ -107,6 +109,7 @@ class Conversation extends Component {
                 onCommentChange={this.props.onCommentChange}
                 onCommentCancel={this.props.onCommentCancel}
                 userCanComment={this.props.userCanComment}
+                retryComment={this.props.retryComment}
               />
             </div>
           )}

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -144,12 +144,26 @@ $conversation-meta-text-color: $neutral-base !default;
   left: -999em;
 }
 
-.conversation__date-text {
+.conversation__date-text,
+.conversation__failed-text {
   color: $conversation-meta-text-color;
+  font-size: $conversation-meta-text-size;
 }
 
 .conversation__meta-wrapper {
   margin-bottom: $conversation-padding;
+}
+
+.conversation__failed--icon,
+.is-active .conversation__failed--icon {
+  margin-right: 5px;
+  vertical-align: sub;
+  path {
+    fill: $primary-red;
+  }
+}
+.conversation__failed--button {
+  margin-left: $layout-spacing-base/4
 }
 
 .conversation__confirmation-overlay {

--- a/stories/components/Conversation.js
+++ b/stories/components/Conversation.js
@@ -59,6 +59,15 @@ const mockComments = [{
   createdBy: 2
 }];
 
+const mockFailedComment = [{
+  id: 'comment-id-1',
+  body: 'Here is a decent size comment that was created by someone who wanted to comment.',
+  createdAt: '2017-06-08 09:56:41',
+  author: mockUser,
+  createdBy: 2,
+  hasFailed: true
+}];
+
 const mockConversation = {
   id: '1234567',
   comments: mockComments,
@@ -190,6 +199,30 @@ storiesOf('Components', module)
             resolved={false}
             userCanResolve={false}
           />
+        </StoryItem>
+
+        <StoryItem
+          title="Conversation"
+          description="Conversation with failed comment"
+        >
+          <BoundaryClickWatcher>
+            {boundaryIsActive => (
+              <Conversation
+                id="1234567"
+                comments={mockFailedComment}
+                resolveConversation={mockActions.resolveConversation}
+                unresolveConversation={mockActions.unresolveConversation}
+                removeComment={mockActions.removeComment}
+                addComment={mockActions.addComment}
+                editComment={mockActions.editComment}
+                user={mockUser}
+                users={mockUsers}
+                userCanComment={false}
+                focusOnMount
+                showComments={boundaryIsActive}
+              />
+            )}
+          </BoundaryClickWatcher>
         </StoryItem>
       </div>
     );

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -11,6 +11,7 @@ describe('Comment', () => {
   const onCommentCancelSpy = jest.fn();
   const editCommentSpy = jest.fn();
   const removeCommentSpy = jest.fn();
+  const retryCommentSpy = jest.fn();
   const mockUsers = [
     {
       id: 2,
@@ -46,7 +47,8 @@ describe('Comment', () => {
     onRowCountChange() {},
     focusFallback: document.createElement('input'),
     users: mockUsers,
-    userCanComment: true
+    userCanComment: true,
+    retryComment: retryCommentSpy
   };
 
   beforeEach(() => {
@@ -183,5 +185,20 @@ describe('Comment', () => {
     wrapper.setState({ showEditForm: true });
     expect(wrapper.find(Linkify)).toHaveLength(0);
     expect(wrapper.find(CommentForm)).toHaveLength(1);
+  });
+
+  test('renders a failed state', () => {
+    wrapper.setProps({ hasFailed: true });
+    const failed = wrapper.find('.conversation__failed-text');
+    expect(failed).toHaveLength(1);
+    expect(failed.find(Button)).toHaveLength(1);
+    expect(failed.find(Button).prop('clickHandler')).toEqual(
+      wrapper.instance().retryComment
+    );
+  });
+
+  test('retryComment passes the comment id and body', () => {
+    wrapper.instance().retryComment();
+    expect(retryCommentSpy).toHaveBeenCalledWith('123', 'comment body text');
   });
 });


### PR DESCRIPTION
As the title says.

Comments can have a `hasFailed` property which will display a little failure message and retry button (which will call our brand new retryComment prop) 