### PR TITLE
Fix clicking conversation reply count with boundary click watcher

### DIFF
--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -114,20 +114,16 @@ class Conversation extends Component {
             </div>
           )}
 
-        {!showComments &&
-          comments.length > 1 && (
-            <div className="conversation__reply-count">
-              <Button
-                types={['size-sm', 'link-default']}
-                clickHandler={() => {}}
-              >
-                {`View ${comments.length - 1} ${pluralize(
-                  'reply',
-                  comments.length - 1
-                )}`}
-              </Button>
-            </div>
-          )}
+        {comments.length > 1 && (
+          <div className="conversation__reply-count">
+            <Button types={['size-sm', 'link-default']} clickHandler={() => {}}>
+              {`View ${comments.length - 1} ${pluralize(
+                'reply',
+                comments.length - 1
+              )}`}
+            </Button>
+          </div>
+        )}
 
         {this.props.userCanComment && (
           <div className="conversation__foot">

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -75,6 +75,9 @@ $conversation-meta-text-color: $neutral-base !default;
   padding: 0 0 $conversation-padding $layout-spacing-base*2;
   margin: -$conversation-padding 0 0;
   font-size: $conversation-meta-text-size;
+  .is-active & {
+    display: none;
+  }
 }
 
 .conversation__comment-body {

--- a/tests/Conversation/Conversation.js
+++ b/tests/Conversation/Conversation.js
@@ -98,10 +98,6 @@ describe('Conversation', () => {
     expect(commentList.prop('onCommentCancel')).toEqual(props.onCommentCancel);
   });
 
-  test('does not render the reply count text', () => {
-    expect(wrapper.find('.conversation__reply-count')).toHaveLength(0);
-  });
-
   test('does not render the reply count text (when there is only 1 comment)', () => {
     wrapper.setProps({ showComments: false });
     wrapper.setProps({ comments: [props.comments[0]] });
@@ -159,9 +155,9 @@ describe('Conversation', () => {
   });
 
   test('does not render the resolve button', () => {
-    expect(wrapper.find(Button)).toHaveLength(1);
+    expect(wrapper.find(Button)).toHaveLength(2);
     wrapper.setProps({ userCanResolve: false });
-    expect(wrapper.find(Button)).toHaveLength(0);
+    expect(wrapper.find(Button)).toHaveLength(1);
   });
 
   test('does not render a resolveConversation button or a CommentList', () => {


### PR DESCRIPTION
This fixes an issue where using Conversation with BoundaryClickWatcher wont work properly if the reply count is clicked to activate the conversation, directly after clicking the 'cancel' button to deactivate the conversation. 

We don't render the reply count if the conversation is active, so when the boundary watcher checks if event.target is inside the container, it doesn't think it is, because it wasn't or wont be rendered. Hiding it with some css instead achieves the same result, but without this weird bug!