### PR TITLE
Fix react bootstrap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "pluralize": "^5.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.4.0",
-    "react-bootstrap": "^0.32.1",
+    "react-bootstrap": "0.32.1",
     "react-day-picker": "^7.1.1",
     "react-dom": "^16.0.0",
     "react-mentions": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6370,7 +6370,7 @@ react-addons-test-utils@^15.4.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
 
-react-bootstrap@^0.32.1:
+react-bootstrap@0.32.1:
   version "0.32.1"
   resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.32.1.tgz#60624c1b48a39d773ef6cce6421a4f33ecc166bb"
   dependencies:


### PR DESCRIPTION
`react-bootstrap` is breaking CI. For more information: https://github.com/react-bootstrap/react-bootstrap/issues/3231