### PR TITLE
Search box drop shadow

### DIFF
--- a/lib/Search/styles.scss
+++ b/lib/Search/styles.scss
@@ -120,6 +120,7 @@ $search-min-width: 400px !default;
   display: flex;
   transition: width cubic-bezier(0.4, 0.0, 0.2, 1) 0.2s;
   margin-right: 0;
+  box-shadow: -25px 0 13px -5px #FFF;
   .search__input--input {
     display: block;
   }


### PR DESCRIPTION
Added a white left drop shadow to gracefully hide nav items when the expanded search bar covers nav items.