### PR TITLE
Fix right aligned dropdowns

### DIFF
--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -94,10 +94,9 @@ $dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
 }
 
 .dropdown__content--fix-right {
-  margin: 0;
+  margin: 0 0 0 $layout-spacing-base/2;
   padding: 0 $layout-spacing-base/2;
   left: 100%;
-  transform: translateY(-50%);
 }
 
 .dropdown__content--top {
@@ -122,7 +121,7 @@ $dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
 }
 
 .dropdown__content--fix-right.is-active {
-  top: 50%;
+  top: 0;
 }
 
 .dropdown__content--centre.is-active {


### PR DESCRIPTION
We used transform to vertically position right aligned dropdowns which caused a clash with our new animations that also uses it. Should be back to normal now