### PR TITLE
Stop UserSearch submitting form bug

### DIFF
--- a/lib/Search/SearchInput.js
+++ b/lib/Search/SearchInput.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { Icon, Button } from '../';
+import { Icon, Button, ShortcutTrigger } from '../';
 
 class SearchInput extends Component {
   state = {
@@ -34,12 +34,21 @@ class SearchInput extends Component {
     this.setState({ isFocussed: true }, () => this.textinput.focus());
   };
 
+  handleEscape = () => {
+    this.props.hideBody();
+    this.setState({ isFocussed: false });
+  };
+
   render() {
     const classNames = cx(`search__input ${this.props.className}`, {
       'is-focus': this.props.showBody || this.state.isFocussed
     });
     return (
       <div className={classNames}>
+        <ShortcutTrigger
+          shortcutKey="Escape"
+          onShortcutTrigger={this.handleEscape}
+        />
         <input
           className="search__input--input"
           onChange={this.handleChange}
@@ -49,6 +58,7 @@ class SearchInput extends Component {
           ref={textinput => {
             this.textinput = textinput;
           }}
+          onKeyPress={this.handleKeyPress}
         />
         <Button
           className="search__input--clear"

--- a/lib/UserSearch/index.js
+++ b/lib/UserSearch/index.js
@@ -43,7 +43,7 @@ class UserSearch extends Component {
     if (e.key === 'Enter') {
       e.preventDefault();
     }
-  }
+  };
 
   render() {
     const users = this.state.users.map(user => (

--- a/lib/UserSearch/index.js
+++ b/lib/UserSearch/index.js
@@ -39,6 +39,12 @@ class UserSearch extends Component {
     }
   };
 
+  handleKeyPress = e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+    }
+  }
+
   render() {
     const users = this.state.users.map(user => (
       <Dropdown.Action
@@ -85,6 +91,7 @@ class UserSearch extends Component {
               ref={searchInput => {
                 this.searchInput = searchInput;
               }}
+              onKeyPress={this.handleKeyPress}
             />
           </Dropdown.ActionGroup>
           <Dropdown.ActionGroup className="user-search__search-results">

--- a/tests/Search/SearchInput.spec.js
+++ b/tests/Search/SearchInput.spec.js
@@ -1,5 +1,6 @@
 import { React, mount } from '../setup';
 import SearchInput from '../../lib/Search/SearchInput';
+import { ShortcutTrigger } from '../../lib';
 
 describe('SearchInput', () => {
   let wrapper;
@@ -70,5 +71,16 @@ describe('SearchInput', () => {
   test('handles focus', () => {
     wrapper.instance().handleFocus();
     expect(wrapper.state('isFocussed')).toEqual(true);
+  });
+
+  test('renders a ShortcutTrigger', () => {
+    const trigger = wrapper.find(ShortcutTrigger);
+    expect(trigger.prop('onShortcutTrigger')).toEqual(
+      wrapper.instance().handleEscape
+    );
+    expect(trigger.prop('shortcutKey')).toEqual('Escape');
+    wrapper.instance().handleEscape();
+    expect(hideBodySpy).toHaveBeenCalled();
+    expect(wrapper.state('isFocussed')).toEqual(false);
   });
 });


### PR DESCRIPTION
Small PR. Fixing a bug where if the UserSearch is wrapped in a form, hitting enter when the input is in focus will submit the form. 