### PR TITLE
stop un-mounting sub lists

### DIFF
--- a/lib/List/ListItem.js
+++ b/lib/List/ListItem.js
@@ -98,7 +98,7 @@ class ListItem extends Component {
           </span>
         </div>
 
-        {this.state.showSubList && subListChildren}
+        {subListChildren}
       </div>
     );
   }

--- a/tests/List/ListItem.spec.js
+++ b/tests/List/ListItem.spec.js
@@ -68,11 +68,6 @@ describe('List Item', () => {
     );
   });
 
-  test('not rendering sub list', () => {
-    expect(wrapper.find('.list__item-content').find(List)).toHaveLength(0);
-    expect(wrapper.find(List)).toHaveLength(0);
-  });
-
   test('rendering sub lists outside of the content container', () => {
     wrapper.setState({ showSubList: true });
     expect(wrapper.find('.list__item-content').find(List)).toHaveLength(0);


### PR DESCRIPTION
A simple PR that stops un-mounting sub lists so we retain the open hierarchy until the users refreshes the page of course 😄 