### PR TITLE
Issue/fix user search

### DIFF
--- a/lib/MentionsForm/MentionsHelper.js
+++ b/lib/MentionsForm/MentionsHelper.js
@@ -1,12 +1,16 @@
-export const filterUsers = (users, term, searchByEmail = false) =>
-  users.filter(
+export const filterUsers = (users, term, searchByEmail = false) => {
+  const safeTerm = term.toLowerCase();
+  return users.filter(
     user =>
       user.name
         .toLowerCase()
         .split(' ')
-        .filter(subStr => subStr.lastIndexOf(term, 0) === 0).length > 0 ||
-      user.display.toLowerCase().lastIndexOf(term, 0) === 0 ||
-      (searchByEmail && user.email.toLowerCase().lastIndexOf(term, 0) === 0)
+        .filter(subStr => subStr.lastIndexOf(safeTerm, 0) === 0).length > 0 ||
+      user.name.toLowerCase().lastIndexOf(safeTerm, 0) === 0 ||
+      user.display.toLowerCase().lastIndexOf(safeTerm, 0) === 0 ||
+      (searchByEmail && user.email.toLowerCase().lastIndexOf(safeTerm, 0) === 0)
   );
+}
+
 
 export default filterUsers;

--- a/lib/MentionsForm/MentionsHelper.js
+++ b/lib/MentionsForm/MentionsHelper.js
@@ -10,7 +10,6 @@ export const filterUsers = (users, term, searchByEmail = false) => {
       user.display.toLowerCase().lastIndexOf(safeTerm, 0) === 0 ||
       (searchByEmail && user.email.toLowerCase().lastIndexOf(safeTerm, 0) === 0)
   );
-}
-
+};
 
 export default filterUsers;

--- a/tests/UserSearch/index.spec.js
+++ b/tests/UserSearch/index.spec.js
@@ -11,7 +11,7 @@ describe('User Search', () => {
       display: 'saulgoodman',
       name: 'Saul Goodman',
       initials: 'SG',
-      email: 'heythere@lol.com'
+      email: 'hellothere@lol.com'
     },
     {
       id: '456',
@@ -83,10 +83,25 @@ describe('User Search', () => {
   test('returns the correct filtered users', () => {
     wrapper.instance().searchForUsers({ target: { value: 'saul' } });
     expect(wrapper.state('users')).toEqual([users[0]]);
-    wrapper.instance().searchForUsers({ target: { value: 'jesse' } });
+    wrapper.instance().searchForUsers({ target: { value: 'gOo' } });
+    expect(wrapper.state('users')).toEqual([users[0]]);
+    wrapper.instance().searchForUsers({ target: { value: 'jessepi' } });
     expect(wrapper.state('users')).toEqual([users[1]]);
     wrapper.instance().searchForUsers({ target: { value: ' ' } });
     expect(wrapper.state('users')).toEqual(users);
+    wrapper.instance().searchForUsers({ target: { value: 'Jesse' } });
+    expect(wrapper.state('users')).toEqual([users[1]]);
+    wrapper.instance().searchForUsers({ target: { value: 'Jesse Pin' } });
+    expect(wrapper.state('users')).toEqual([users[1]]);
+    wrapper.instance().searchForUsers({ target: { value: 'he' } });
+    expect(wrapper.state('users')).toEqual([]);
+    wrapper.instance().searchForUsers({ target: { value: 'HEythere@l' } });
+    expect(wrapper.state('users')).toEqual([]);
+    wrapper.setProps({ displayEmail: true });
+    wrapper.instance().searchForUsers({ target: { value: 'he' } });
+    expect(wrapper.state('users')).toEqual(users);
+    wrapper.instance().searchForUsers({ target: { value: 'HEythere@l' } });
+    expect(wrapper.state('users')).toEqual([users[1]]);
   });
 
   test('renders a no results message', () => {


### PR DESCRIPTION
Making user search a bit more robust. 

We weren't making the search term lower case, so it was case sensitive. Durr.
We weren't letting people search for both first and last name (i.e. 'amee mo') only first and last name individually. 