### PR TITLE
ItemRow styling fixes

### DIFF
--- a/lib/ItemRow/styles.scss
+++ b/lib/ItemRow/styles.scss
@@ -37,6 +37,17 @@ $item-row-stacked-margin: $typo-size-slight/3;
 /* ==========================================================================
    Modifiers
    ========================================================================== */
+.item-row:not(item-row--stacked).has-indicator {
+  display: flex;
+  align-items: baseline;
+  white-space: nowrap;
+
+  .item-row__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
 .item-row--stacked {
   display: flex;
   flex-wrap: wrap;

--- a/stories/components/List.js
+++ b/stories/components/List.js
@@ -95,7 +95,6 @@ storiesOf('Components', module).add('List', () => (
           <a href="/#">
             <ItemRow
               indicator={statusWithTooltip('green', 'bottom', 'id-896727', 'Research')}
-              label="entry parent"
             >
               Item name 1
             </ItemRow>
@@ -106,7 +105,6 @@ storiesOf('Components', module).add('List', () => (
               <a href="/#">
                 <ItemRow
                   indicator={statusWithTooltip('blue', 'bottom', 'id-12376887', 'Review')}
-                  label="entry"
                 >
                   Item name 2
                 </ItemRow>
@@ -116,7 +114,6 @@ storiesOf('Components', module).add('List', () => (
             <ListItem collapse>
               <a href="/#">
                 <ItemRow
-                  label="entry"
                   indicator={statusWithTooltip('orange', 'bottom', 'id-9356342', 'Publish')}
                 >
                   {overdueTitle('Item name 3', 'id-78978984224')}
@@ -127,7 +124,6 @@ storiesOf('Components', module).add('List', () => (
                 <ListItem collapse>
                   <a href="/#">
                     <ItemRow
-                      label="entry"
                       indicator={statusWithTooltip('blue', 'bottom', 'id-7858757', 'Review')}
                     >
                       Item name 4
@@ -138,7 +134,6 @@ storiesOf('Components', module).add('List', () => (
                 <ListItem collapse>
                   <a href="/#">
                     <ItemRow
-                      label="entry"
                       indicator={statusWithTooltip('orange', 'bottom', 'id-4444234', 'Publish')}
                     >
                       {overdueTitle('Item name 5', 'id-24288448')}


### PR DESCRIPTION
We wasn't dealing with item rows with status indicators. Maybe this was handled else where and was then removed. It also deals with long item names 👍 