### PR TITLE
FormModal should use onHide prop, which is passed from withModalTrigger

### DIFF
--- a/lib/FormModal/README.md
+++ b/lib/FormModal/README.md
@@ -3,15 +3,15 @@ A form within a modal
 
 ### Props
 
-| Name             | Type    | Default    | Required | Description                                       |
-| ---------------- | ------- | ---------- | -------- |-------------------------------------------------- |
-| title            | String  |            | Yes      | Appears in the modal title bar.                   |
-| children         | Node    |            | Yes      | The form components/elements themselves.          |
-| submitText       | String  |            | Yes      | The copy for the submit button.                   |
-| submitHandler    | Func    |            | Yes      | This gets called when the form is submitted.      |
-| cancelText       | String  |            | Yes      | The copy for the cancel button.                   |
-| cancelHandler    | Func    | `() => {}` | No       | This is called when the cancel button is pressed. |
-| formIsSubmitting | Boolean | `false`    | No       | Should the progress button show the spinner?      |
+| Name             | Type    | Default    | Required | Description                                                                   |
+| ---------------- | ------- | ---------- | -------- |------------------------------------------------------------------------------ |
+| title            | String  |            | Yes      | Appears in the modal title bar.                                               |
+| children         | Node    |            | Yes      | The form components/elements themselves.                                      |
+| submitText       | String  |            | Yes      | The copy for the submit button.                                               |
+| submitHandler    | Func    |            | Yes      | This gets called when the form is submitted.                                  |
+| cancelText       | String  |            | Yes      | The copy for the cancel button.                                               |
+| onHide           | Func    |            | Yes      | If using `FormModal` inside with `withModalTrigger` this is ALWAYS OVERRIDDEN |
+| formIsSubmitting | Boolean | `false`    | No       | Should the progress button show the spinner?                                  |
 
 ### Usage
 ```
@@ -20,7 +20,7 @@ A form within a modal
   submitText="Submit"
   submitHandler={action('handle')}
   cancelText="Cancel"
-  cancelHandler={action('cancel')}
+  onHide={action('hide')}
 >
   <FormGroup>
     <ControlLabel>Field A</ControlLabel>

--- a/lib/FormModal/index.js
+++ b/lib/FormModal/index.js
@@ -8,7 +8,7 @@ const FormModal = ({
   submitText,
   submitHandler,
   cancelText,
-  cancelHandler,
+  onHide,
   formIsSubmitting,
   ...rest
 }) => (
@@ -17,7 +17,7 @@ const FormModal = ({
       <Modal.Header closeButton>{title}</Modal.Header>
       <Modal.Body>{children}</Modal.Body>
       <Modal.Footer>
-        <Button types={['link']} clickHandler={cancelHandler}>
+        <Button types={['link']} clickHandler={onHide}>
           {cancelText}
         </Button>
         <ProgressButton
@@ -39,13 +39,12 @@ FormModal.propTypes = {
   submitText: PropTypes.string.isRequired,
   submitHandler: PropTypes.func.isRequired,
   cancelText: PropTypes.string.isRequired,
-  cancelHandler: PropTypes.func,
+  onHide: PropTypes.func.isRequired,
   formIsSubmitting: PropTypes.bool
 };
 
 FormModal.defaultProps = {
-  formIsSubmitting: false,
-  cancelHandler: () => {}
+  formIsSubmitting: false
 };
 
 export default FormModal;

--- a/stories/components/Modals.js
+++ b/stories/components/Modals.js
@@ -314,7 +314,6 @@ storiesOf('Components', module).add('Modals', () => (
           title="FormModal example"
           submitText="Submit"
           cancelText="Cancel"
-          cancelHandler={action('cancel')}
         >
           <FormGroup>
             <ControlLabel>Field A</ControlLabel>


### PR DESCRIPTION
Ok, I didn't realise we had the onHide prop which is usually passed from the parent `withModalTrigger`... seems to be quite hidden, but I guess I'm just not used to it. So if we want to close the form modal by clicking the "cancel" button, we need to pass it the parent - parent - onHide prop! This will in tern, pass the `show` prop down all the layers and set it to `false`. I've also removed the `cancelHandler` prop, I don't think we'll usually need this?