### PR TITLE
Add onBlur to Tabs.Form

### DIFF
--- a/lib/Tabs/TabsForm.js
+++ b/lib/Tabs/TabsForm.js
@@ -5,12 +5,20 @@ import Form from '../Form';
 import Icon from '../Icon';
 import Button from '../Button';
 
-const TabForm = ({ onSubmit, onCancel, value, placeholder, onInputChange }) => {
+const TabForm = ({
+  onSubmit,
+  onCancel,
+  value,
+  placeholder,
+  onInputChange,
+  submitOnBlur
+}) => {
   const handleOnSubmit = e => onSubmit(e.target[0].value);
   const handleOnCancel = () => {
     onInputChange('');
     onCancel();
   };
+  const handleOnBlur = e => (submitOnBlur ? onSubmit(e.target.value) : null);
   return (
     <Form
       onSubmit={handleOnSubmit}
@@ -24,6 +32,7 @@ const TabForm = ({ onSubmit, onCancel, value, placeholder, onInputChange }) => {
         placeholder={placeholder}
         focusOnMount
         onInputChange={onInputChange}
+        onBlur={handleOnBlur}
       />
       <Button
         className="tabs__cancel"
@@ -41,14 +50,16 @@ TabForm.propTypes = {
   placeholder: PropTypes.string,
   onCancel: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
-  onInputChange: PropTypes.func
+  onInputChange: PropTypes.func,
+  submitOnBlur: PropTypes.bool
 };
 
 TabForm.defaultProps = {
   value: '',
   placeholder: '',
   onCancel() {},
-  onInputChange() {}
+  onInputChange() {},
+  submitOnBlur: true
 };
 
 export default TabForm;

--- a/tests/Tabs/TabsForm.spec.js
+++ b/tests/Tabs/TabsForm.spec.js
@@ -42,4 +42,19 @@ describe('Tabs Form', () => {
     wrapper.find(Form).prop('onSubmit')({ target: [{ value: 'test value' }] });
     expect(onSubmitSpy).toHaveBeenCalledWith('test value');
   });
+
+  test('submits onBlur', () => {
+    wrapper.find(FormInput).prop('onBlur')({
+      target: { value: 'woofle waffle' }
+    });
+    expect(onSubmitSpy).toHaveBeenCalledWith('woofle waffle');
+  });
+
+  test('doesnt submit onBlur', () => {
+    wrapper.setProps({ submitOnBlur: false });
+    wrapper.find(FormInput).prop('onBlur')({
+      target: { value: 'woofle waffle' }
+    });
+    expect(onSubmitSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
A new UI pattern we use is to submit small forms onBlur, this PR adds a `submitOnBlur` prop to Tabs.Form which allows us to do just that.