### PR TITLE
Feature/onblur tabs form

### DIFF
--- a/lib/Form/index.js
+++ b/lib/Form/index.js
@@ -22,10 +22,17 @@ class Form extends Component {
   };
 
   render() {
-    const { children, className } = this.props;
+    const {
+      children,
+      className,
+      onSubmit,
+      onCancel,
+      escToClose,
+      ...rest
+    } = this.props;
 
     return (
-      <form onSubmit={this.handleSubmit} className={className}>
+      <form onSubmit={this.handleSubmit} className={className} {...rest}>
         {children}
       </form>
     );

--- a/lib/Tabs/README.md
+++ b/lib/Tabs/README.md
@@ -57,3 +57,4 @@ A form which can be used when editing or creating a new tab.
 | value              | String        | ''        | No       | The initial value of the input.                                               |
 | onCancel           | Function      | () {}     | No       | A function which is called when pressing the Esc key.                         |
 | onSubmit           | Function      | N/A       | Yes      | A function which is called when the user submits the form.                    |
+| submitOnBlur       | bool          | true      | No       | Dictates whether to submit the form on blur.                    |

--- a/lib/Tabs/TabsForm.js
+++ b/lib/Tabs/TabsForm.js
@@ -18,13 +18,31 @@ const TabForm = ({
     onInputChange('');
     onCancel();
   };
-  const handleOnBlur = e => (submitOnBlur ? onSubmit(e.target.value) : null);
+  const handleOnBlur = e => {
+    if (submitOnBlur) {
+      if (e.relatedTarget) {
+        const targetIsTabForm = e.relatedTarget.classList.contains(
+          'tabs__item-form'
+        );
+        const targetIsCancel = e.relatedTarget.classList.contains(
+          'tabs__cancel'
+        );
+        if (targetIsTabForm || targetIsCancel) {
+          return null;
+        }
+      }
+      return onSubmit(e.target.value);
+    }
+    return null;
+  };
   return (
     <Form
       onSubmit={handleOnSubmit}
       onCancel={handleOnCancel}
-      className="tabs__item is-editing"
+      className="tabs__item is-editing tabs__item-form"
       escToClose
+      tabIndex={-1}
+      onBlur={handleOnBlur}
     >
       <FormInput
         value={value}
@@ -32,7 +50,6 @@ const TabForm = ({
         placeholder={placeholder}
         focusOnMount
         onInputChange={onInputChange}
-        onBlur={handleOnBlur}
       />
       <Button
         className="tabs__cancel"

--- a/lib/Tabs/TabsForm.js
+++ b/lib/Tabs/TabsForm.js
@@ -5,12 +5,20 @@ import Form from '../Form';
 import Icon from '../Icon';
 import Button from '../Button';
 
-const TabForm = ({ onSubmit, onCancel, value, placeholder, onInputChange }) => {
+const TabForm = ({
+  onSubmit,
+  onCancel,
+  value,
+  placeholder,
+  onInputChange,
+  submitOnBlur
+}) => {
   const handleOnSubmit = e => onSubmit(e.target[0].value);
   const handleOnCancel = () => {
     onInputChange('');
     onCancel();
   };
+  const handleOnBlur = e => (submitOnBlur ? onSubmit(e.target.value) : null);
   return (
     <Form
       onSubmit={handleOnSubmit}
@@ -24,6 +32,7 @@ const TabForm = ({ onSubmit, onCancel, value, placeholder, onInputChange }) => {
         placeholder={placeholder}
         focusOnMount
         onInputChange={onInputChange}
+        onBlur={handleOnBlur}
       />
       <Button
         className="tabs__cancel"
@@ -41,14 +50,16 @@ TabForm.propTypes = {
   placeholder: PropTypes.string,
   onCancel: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
-  onInputChange: PropTypes.func
+  onInputChange: PropTypes.func,
+  submitOnBlur: PropTypes.bool
 };
 
 TabForm.defaultProps = {
   value: '',
   placeholder: '',
   onCancel() {},
-  onInputChange() {}
+  onInputChange() {},
+  submitOnBlur: true
 };
 
 export default TabForm;

--- a/tests/Tabs/TabsForm.spec.js
+++ b/tests/Tabs/TabsForm.spec.js
@@ -42,4 +42,19 @@ describe('Tabs Form', () => {
     wrapper.find(Form).prop('onSubmit')({ target: [{ value: 'test value' }] });
     expect(onSubmitSpy).toHaveBeenCalledWith('test value');
   });
+
+  test('submits onBlur', () => {
+    wrapper.find(FormInput).prop('onBlur')({
+      target: { value: 'woofle waffle' }
+    });
+    expect(onSubmitSpy).toHaveBeenCalledWith('woofle waffle');
+  });
+
+  test('doesnt submit onBlur', () => {
+    wrapper.setProps({ submitOnBlur: false });
+    wrapper.find(FormInput).prop('onBlur')({
+      target: { value: 'woofle waffle' }
+    });
+    expect(onSubmitSpy).not.toHaveBeenCalled();
+  });
 });

--- a/tests/Tabs/TabsForm.spec.js
+++ b/tests/Tabs/TabsForm.spec.js
@@ -44,7 +44,7 @@ describe('Tabs Form', () => {
   });
 
   test('submits onBlur', () => {
-    wrapper.find(FormInput).prop('onBlur')({
+    wrapper.find(Form).prop('onBlur')({
       target: { value: 'woofle waffle' }
     });
     expect(onSubmitSpy).toHaveBeenCalledWith('woofle waffle');
@@ -52,7 +52,7 @@ describe('Tabs Form', () => {
 
   test('doesnt submit onBlur', () => {
     wrapper.setProps({ submitOnBlur: false });
-    wrapper.find(FormInput).prop('onBlur')({
+    wrapper.find(Form).prop('onBlur')({
       target: { value: 'woofle waffle' }
     });
     expect(onSubmitSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
Lets try this again...

Adding the option to submit the Tabs.Form on blur. The previous closed PR just had the onBlur event on the input, so would submit the form when clicking the cancel button, or the padding around the input. Now its on the Form itself and we double check that we're not still clicking inside.