### PR TITLE
Fix overflow issues

### DIFF
--- a/lib/ItemRow/styles.scss
+++ b/lib/ItemRow/styles.scss
@@ -8,6 +8,10 @@ $item-row-stacked-margin: $typo-size-slight/3;
    ========================================================================== */
 .item-row {
   padding: $layout-spacing-base/2;
+
+  .has-action & {
+    padding-right: 0;
+  }
 }
 
 .item-row__indicator {

--- a/lib/List/ListItem.js
+++ b/lib/List/ListItem.js
@@ -47,7 +47,8 @@ class ListItem extends Component {
     const classNames = cx('list__item', {
       'list__item--collapse': collapse,
       'is-current': isCurrent,
-      'show-sub-list': this.state.showSubList
+      'show-sub-list': this.state.showSubList,
+      'has-action': action
     });
 
     const toggleClassNames = cx('list__button', {

--- a/lib/List/styles.scss
+++ b/lib/List/styles.scss
@@ -111,6 +111,7 @@ $list-border: 1px solid $color-border-base;
 
 .list__item-text {
   width: 100%;
+  overflow: hidden;
 
   > a {
     text-decoration: none;

--- a/tests/List/ListItem.spec.js
+++ b/tests/List/ListItem.spec.js
@@ -60,6 +60,8 @@ describe('List Item', () => {
         .first()
         .contains('test button')
     ).toEqual(true);
+
+    expect(wrapper.hasClass('has-action')).toEqual(true);
   });
 
   test('rendering children within the text container', () => {


### PR DESCRIPTION
Our list component has a regression when we moved to `List` and `ItemRow`. When a title is too long the actions are pushed out of the container.