### PR TITLE
ConfirmationDropdown alterations

### DIFF
--- a/lib/Button/index.js
+++ b/lib/Button/index.js
@@ -18,12 +18,15 @@ class Button extends Component {
     disabled: false,
     className: '',
     isSubmit: false,
-    title: ''
+    title: '',
+    clickHandler: () => {},
+    onClick: null
   };
 
   static propTypes = {
     children: PropTypes.node.isRequired,
-    clickHandler: PropTypes.func.isRequired,
+    clickHandler: PropTypes.func,
+    onClick: PropTypes.func,
     types: PropTypes.arrayOf(PropTypes.string),
     disabled: PropTypes.bool,
     disableOnClick: PropTypes.bool,
@@ -52,7 +55,12 @@ class Button extends Component {
 
   handleOnClick(e) {
     this.setState({ disabled: this.props.disableOnClick });
-    this.props.clickHandler(e);
+
+    if (this.props.onClick) {
+      return this.props.onClick(e);
+    }
+
+    return this.props.clickHandler(e);
   }
 
   render() {

--- a/lib/Button/styles.scss
+++ b/lib/Button/styles.scss
@@ -313,10 +313,23 @@ $btn-border-radius: 3px !default;
   background: $color-btn-primary--disabled;
   color: $color-btn-primary--disabled-text;
   box-shadow: none;
+
   .icon path {
     fill: $color-btn-primary--disabled-text;
   }
+
   &:hover {
     text-decoration: none;
+  }
+
+  &.button--link,
+  &.button--link-danger {
+    cursor: not-allowed;
+    background: transparent;
+    color: $color-btn-primary--disabled;
+
+    &:hover {
+      color: $color-btn-primary--disabled;
+    }
   }
 }

--- a/lib/ConfirmationDropdown/README.md
+++ b/lib/ConfirmationDropdown/README.md
@@ -7,21 +7,23 @@ A component which renders a confirmation dropdown.
 
 | Name                  | Type          | Default       | Required | Description                                         |
 | --------------------- |-------------- | ------------- | -------- |---------------------------------------------------- |
-| iconName              | string        | n/a           | Yes      | The icon to display in the trigger.                 |
-| children              | node          | n/a           | Yes      | What will display above the confirmation buttons.   |
-| onConfirm             | func          | n/a           | Yes      | The function that will fire when the confirm button is clicked.  |
-| onCancel              | func          | () => {}      | No       | The function that will fire when the cancel button is clicked.  |
-| isDanger              | bool          | false         | No       | Gives the icon trigger danger styling.              |
-| confirmText           | string        | 'Delete'      | No       | Text to display in confirmation button.  |
+| id                    | string        | n/a           | Yes      | The ID for the dropdown.   |
+| children              | node/string   | n/a           | Yes      | The trigger for showing the confirmation dropdown.   |
+| confirmationPromise   | func          | n/a           | Yes      | The function that will fire when the confirm button is clicked. Must be a promise.  |
+| dropdownContent       | node          | n/a           | Yes      | The contents of the dropdown itself.  |
+| isDanger              | bool          | false         | No       | Gives the confirmation button a danger style.              |
+| confirmationText      | string        | 'Confirm'     | No       | Text to display in confirmation button.  |
+| className             | string        | ''            | No       | Additional classes for the container.  |
 
 ```
 <ConfirmationDropdown
-  iconName="string"
-  onConfirm={() => {}}
-  onCancel={() => {}}
-  isDanger={false}
-  confirmText="string"
+  id="id-1"
+  confirmationPromise={() => new Promise(resolve => resolve('complete'))}
+  confirmationText="Archive"
+  dropdownContent={(<div>Some content</div>)}
+  className="class-for-content"
+  isDanger
 >
-  <div>Some content</div>
+  Click me to show dropdown
 </ConfirmationDropdown>
 ```

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -3,10 +3,15 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Button, Icon, Dropdown } from '../';
 
+const initialState = {
+  promiseIsPending: false,
+  forceHide: false
+};
+
 class ConfirmationDropdown extends Component {
-  state = {
-    promiseIsPending: false
-  };
+  state = initialState;
+
+  resetState = () => this.setState(initialState);
 
   onConfirm = () => {
     if (this.state.promiseIsPending) {
@@ -14,11 +19,11 @@ class ConfirmationDropdown extends Component {
     }
 
     this.setState({ promiseIsPending: true });
-    return this.props.confirmationPromise().then(() => {
-      this.setState({
-        promiseIsPending: false
-      });
-    });
+    return this.props.confirmationPromise().then(this.resetState);
+  };
+
+  onCancel = () => {
+    this.setState({ forceHide: true }, this.resetState);
   };
 
   render() {
@@ -26,15 +31,18 @@ class ConfirmationDropdown extends Component {
       'is-pending': this.state.promiseIsPending
     });
 
+    const sharedButtonProps = ['slim', 'collapse'];
+
     const confirmButtonTypes = this.props.isDanger
-      ? ['link-danger', 'slim', 'collapse']
-      : ['slim', 'collapse'];
+      ? [...sharedButtonProps, 'link-danger']
+      : sharedButtonProps;
 
     return (
       <Dropdown
         id={this.props.id}
         className={classNames}
         show={this.state.promiseIsPending}
+        hide={this.state.forceHide}
         autoPosition
       >
         <Dropdown.Content>
@@ -54,6 +62,14 @@ class ConfirmationDropdown extends Component {
               aria-hidden={this.state.promiseIsPending}
             >
               {this.props.confirmationText}
+            </Button>
+
+            <Button
+              types={sharedButtonProps}
+              clickHandler={this.onCancel}
+              className="confirmation-dropdown__cancel"
+            >
+              Cancel
             </Button>
           </div>
         </Dropdown.Content>

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -1,28 +1,43 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Button, Icon, BoundaryClickWatcher } from '../';
+import { Button, BoundaryClickWatcher, Icon } from '../';
 
 class ConfirmationDropdown extends Component {
   state = {
-    showConfirmation: false
+    showConfirmation: false,
+    promiseIsPending: false
   };
 
   toggleConfirmation = () =>
     this.setState({ showConfirmation: !this.state.showConfirmation });
+
   onCancel = () => {
-    this.props.onCancel();
-    this.setState({ showConfirmation: false });
+    if (!this.state.promiseIsPending) {
+      this.props.onCancel();
+      this.setState({ showConfirmation: false });
+    }
   };
+
   onConfirm = () => {
-    this.props.onConfirm();
-    this.setState({ showConfirmation: false });
+    this.setState({ promiseIsPending: true });
+    return this.props.confirmationPromise().then(() => {
+      this.setState({
+        showConfirmation: false,
+        promiseIsPending: false
+      });
+    });
   };
+
   render() {
     const classNames = cx(`confirmation-dropdown ${this.props.className}`, {
       'is-active': this.state.showConfirmation,
       'is-danger': this.props.isDanger
     });
+
+    const childrenWithProps = React.Children.map(this.props.children, child =>
+      React.cloneElement(child, { onClick: this.toggleConfirmation })
+    );
 
     return (
       <BoundaryClickWatcher
@@ -31,22 +46,22 @@ class ConfirmationDropdown extends Component {
       >
         <div className="confirmation-dropdown__content">
           <div className="confirmation-dropdown__content-child">
-            {this.props.children}
+            {this.props.dropdownContent}
           </div>
-          <Button types={['link-default', 'slim']} clickHandler={this.onCancel}>
-            Cancel
-          </Button>
-          <Button types={['link-danger', 'slim']} clickHandler={this.onConfirm}>
-            {this.props.confirmText}
-          </Button>
+
+          {this.state.promiseIsPending ? (
+            <Icon name="loader" />
+          ) : (
+            <Button
+              types={['link-danger', 'slim']}
+              clickHandler={this.onConfirm}
+            >
+              {this.props.confirmText}
+            </Button>
+          )}
         </div>
-        <Button
-          className="confirmation-dropdown__trigger"
-          clickHandler={this.toggleConfirmation}
-          types={['icon-only']}
-        >
-          <Icon name={this.props.iconName} />
-        </Button>
+
+        {childrenWithProps}
       </BoundaryClickWatcher>
     );
   }
@@ -54,8 +69,8 @@ class ConfirmationDropdown extends Component {
 
 ConfirmationDropdown.propTypes = {
   children: PropTypes.node.isRequired,
-  iconName: PropTypes.string.isRequired,
-  onConfirm: PropTypes.func.isRequired,
+  dropdownContent: PropTypes.node.isRequired,
+  confirmationPromise: PropTypes.func.isRequired,
   onCancel: PropTypes.func,
   className: PropTypes.string,
   isDanger: PropTypes.bool,

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -35,7 +35,7 @@ class ConfirmationDropdown extends Component {
 
     const confirmButtonTypes = this.props.isDanger
       ? [...sharedButtonProps, 'link-danger']
-      : sharedButtonProps;
+      : [...sharedButtonProps, 'link'];
 
     return (
       <Dropdown
@@ -60,6 +60,7 @@ class ConfirmationDropdown extends Component {
               clickHandler={this.onConfirm}
               className="confirmation-dropdown__confirm-trigger"
               aria-hidden={this.state.promiseIsPending}
+              disabled={this.props.disabled}
             >
               {this.props.confirmationText}
             </Button>
@@ -87,12 +88,14 @@ ConfirmationDropdown.propTypes = {
   confirmationPromise: PropTypes.func.isRequired,
   className: PropTypes.string,
   isDanger: PropTypes.bool,
+  disabled: PropTypes.bool,
   confirmationText: PropTypes.string
 };
 
 ConfirmationDropdown.defaultProps = {
   className: '',
   isDanger: false,
+  disabled: false,
   confirmationText: 'Confirm'
 };
 

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -26,7 +26,9 @@ class ConfirmationDropdown extends Component {
       'is-pending': this.state.promiseIsPending
     });
 
-    const confirmButtonTypes = (this.props.isDanger) ? ['link-danger', 'slim', 'collapse'] : ['slim', 'collapse'];
+    const confirmButtonTypes = this.props.isDanger
+      ? ['link-danger', 'slim', 'collapse']
+      : ['slim', 'collapse'];
 
     return (
       <Dropdown

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -1,29 +1,21 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Button, BoundaryClickWatcher, Icon } from '../';
+import { Button, Icon, Dropdown } from '../';
 
 class ConfirmationDropdown extends Component {
   state = {
-    showConfirmation: false,
     promiseIsPending: false
   };
 
-  toggleConfirmation = () =>
-    this.setState({ showConfirmation: !this.state.showConfirmation });
-
-  onCancel = () => {
-    if (!this.state.promiseIsPending) {
-      this.props.onCancel();
-      this.setState({ showConfirmation: false });
-    }
-  };
-
   onConfirm = () => {
+    if (this.state.promiseIsPending) {
+      return this;
+    }
+
     this.setState({ promiseIsPending: true });
     return this.props.confirmationPromise().then(() => {
       this.setState({
-        showConfirmation: false,
         promiseIsPending: false
       });
     });
@@ -31,57 +23,57 @@ class ConfirmationDropdown extends Component {
 
   render() {
     const classNames = cx(`confirmation-dropdown ${this.props.className}`, {
-      'is-active': this.state.showConfirmation,
-      'is-danger': this.props.isDanger
+      'is-pending': this.state.promiseIsPending
     });
 
-    const childrenWithProps = React.Children.map(this.props.children, child =>
-      React.cloneElement(child, { onClick: this.toggleConfirmation })
-    );
+    const confirmButtonTypes = (this.props.isDanger) ? ['link-danger', 'slim', 'collapse'] : ['slim', 'collapse'];
 
     return (
-      <BoundaryClickWatcher
+      <Dropdown
+        id={this.props.id}
         className={classNames}
-        outsideClickHandler={this.onCancel}
+        show={this.state.promiseIsPending}
+        autoPosition
       >
-        <div className="confirmation-dropdown__content">
-          <div className="confirmation-dropdown__content-child">
-            {this.props.dropdownContent}
-          </div>
+        <Dropdown.Content>
+          {this.props.dropdownContent}
 
-          {this.state.promiseIsPending ? (
-            <Icon name="loader" />
-          ) : (
-            <Button
-              types={['link-danger', 'slim']}
-              clickHandler={this.onConfirm}
-            >
-              {this.props.confirmText}
-            </Button>
-          )}
-        </div>
+          <Icon
+            name="loader"
+            className="confirmation-dropdown__loader"
+            aria-hidden={!this.state.promiseIsPending}
+          />
 
-        {childrenWithProps}
-      </BoundaryClickWatcher>
+          <Button
+            types={confirmButtonTypes}
+            clickHandler={this.onConfirm}
+            className="confirmation-dropdown__confirm-trigger"
+            aria-hidden={this.state.promiseIsPending}
+          >
+            {this.props.confirmationText}
+          </Button>
+        </Dropdown.Content>
+
+        <Dropdown.Trigger>{this.props.children}</Dropdown.Trigger>
+      </Dropdown>
     );
   }
 }
 
 ConfirmationDropdown.propTypes = {
+  id: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   dropdownContent: PropTypes.node.isRequired,
   confirmationPromise: PropTypes.func.isRequired,
-  onCancel: PropTypes.func,
   className: PropTypes.string,
   isDanger: PropTypes.bool,
-  confirmText: PropTypes.string
+  confirmationText: PropTypes.string
 };
 
 ConfirmationDropdown.defaultProps = {
-  onCancel: () => {},
   className: '',
   isDanger: false,
-  confirmText: 'Delete'
+  confirmationText: 'Confirm'
 };
 
 export default ConfirmationDropdown;

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -40,20 +40,22 @@ class ConfirmationDropdown extends Component {
         <Dropdown.Content>
           {this.props.dropdownContent}
 
-          <Icon
-            name="loader"
-            className="confirmation-dropdown__loader"
-            aria-hidden={!this.state.promiseIsPending}
-          />
+          <div className="confirmation-dropdown__footer">
+            <Icon
+              name="loader"
+              className="confirmation-dropdown__loader"
+              aria-hidden={!this.state.promiseIsPending}
+            />
 
-          <Button
-            types={confirmButtonTypes}
-            clickHandler={this.onConfirm}
-            className="confirmation-dropdown__confirm-trigger"
-            aria-hidden={this.state.promiseIsPending}
-          >
-            {this.props.confirmationText}
-          </Button>
+            <Button
+              types={confirmButtonTypes}
+              clickHandler={this.onConfirm}
+              className="confirmation-dropdown__confirm-trigger"
+              aria-hidden={this.state.promiseIsPending}
+            >
+              {this.props.confirmationText}
+            </Button>
+          </div>
         </Dropdown.Content>
 
         <Dropdown.Trigger>{this.props.children}</Dropdown.Trigger>

--- a/lib/ConfirmationDropdown/styles.scss
+++ b/lib/ConfirmationDropdown/styles.scss
@@ -9,7 +9,16 @@
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
+  flex-direction: row-reverse;
+}
+
+.confirmation-dropdown__cancel {
+  color: $neutral-base;
+
+  &:hover {
+    color: $neutral-dark;
+  }
 }
 
 .confirmation-dropdown__confirm-trigger {

--- a/lib/ConfirmationDropdown/styles.scss
+++ b/lib/ConfirmationDropdown/styles.scss
@@ -5,8 +5,14 @@
 /* ==========================================================================
    Styles
    ========================================================================== */
+.confirmation-dropdown__footer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
 .confirmation-dropdown__confirm-trigger {
-  margin: 0 0 $layout-spacing-base/2;
   position: relative;
   z-index: 1;
 }

--- a/lib/ConfirmationDropdown/styles.scss
+++ b/lib/ConfirmationDropdown/styles.scss
@@ -1,41 +1,27 @@
-.confirmation-dropdown {
+/* ==========================================================================
+   Config
+   ========================================================================== */
+
+/* ==========================================================================
+   Styles
+   ========================================================================== */
+.confirmation-dropdown__confirm-trigger {
+  margin: 0 0 $layout-spacing-base/2;
   position: relative;
-  display: inline-flex;
-  overflow: hidden;
-  &.is-active {
-    overflow: visible;
-  }
-}
-.confirmation-dropdown__content {
-  position: absolute;
-  top: auto;
-  bottom: -999em;
-  background: white;
-  box-shadow: $shadow-base;
-  border: 1px solid $neutral-light;
-  z-index: 2;
-  padding: $layout-spacing-base/2;
-  left: 50%;
-  transform: translateX(-50%);
-  border-radius: 4px;
-  margin-bottom: $layout-spacing-base/2;
-  min-width: $layout-spacing-base*10;
-  text-align: center;
-  .is-active & {
-    bottom: 100%;
-    animation: dropdownCentreAnimation 750ms;
-    animation-fill-mode: forwards;
-  }
-}
-.confirmation-dropdown__content-child {
-  margin-bottom: $layout-spacing-base/2;
-  color: $neutral-dark;
+  z-index: 1;
 }
 
-.confirmation-dropdown__trigger {
-  .is-active.is-danger & {
-    .icon path {
-      fill: $primary-red;
-    }
-  }
+.confirmation-dropdown__loader {
+  position: absolute;
+  transform: scale(.5);
+  transition: opacity $animation-time-micro ease-in $animation-time-micro;
+}
+
+.confirmation-dropdown__loader,
+.confirmation-dropdown.is-pending .confirmation-dropdown__confirm-trigger {
+  opacity: 0;
+}
+
+.confirmation-dropdown.is-pending .confirmation-dropdown__loader {
+  opacity: 1;
 }

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -70,7 +70,7 @@ class Dropdown extends Component {
 
   dispatchToggle = contentWillShow => {
     const { id, onToggle, show } = this.props;
-    const type = (contentWillShow || show) ? 'ACTIVE' : 'UNACTIVE';
+    const type = contentWillShow || show ? 'ACTIVE' : 'UNACTIVE';
 
     onToggle({
       type,

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -22,7 +22,8 @@ class Dropdown extends Component {
     className: PropTypes.string,
     ignoreClass: PropTypes.string,
     autoPosition: PropTypes.bool,
-    show: PropTypes.bool
+    show: PropTypes.bool,
+    hide: PropTypes.bool
   };
 
   static defaultProps = {
@@ -30,7 +31,8 @@ class Dropdown extends Component {
     className: '',
     ignoreClass: null,
     autoPosition: false,
-    show: false
+    show: false,
+    hide: false
   };
 
   static childContextTypes = {
@@ -56,7 +58,10 @@ class Dropdown extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.show && !this.props.show) {
+    if (
+      (prevProps.show && !this.props.show) ||
+      (!prevProps.hide && this.props.hide)
+    ) {
       this.setShowContent(false);
     }
   }

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -21,14 +21,16 @@ class Dropdown extends Component {
     onToggle: PropTypes.func,
     className: PropTypes.string,
     ignoreClass: PropTypes.string,
-    autoPosition: PropTypes.bool
+    autoPosition: PropTypes.bool,
+    show: PropTypes.bool
   };
 
   static defaultProps = {
     onToggle: () => {},
     className: '',
     ignoreClass: null,
-    autoPosition: false
+    autoPosition: false,
+    show: false
   };
 
   static childContextTypes = {
@@ -53,6 +55,12 @@ class Dropdown extends Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.show && !this.props.show) {
+      this.setShowContent(false);
+    }
+  }
+
   setShowContent = show => {
     this.dispatchToggle(show);
     this.setState({
@@ -61,8 +69,8 @@ class Dropdown extends Component {
   };
 
   dispatchToggle = contentWillShow => {
-    const { id, onToggle } = this.props;
-    const type = contentWillShow ? 'ACTIVE' : 'UNACTIVE';
+    const { id, onToggle, show } = this.props;
+    const type = (contentWillShow || show) ? 'ACTIVE' : 'UNACTIVE';
 
     onToggle({
       type,

--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -51,7 +51,7 @@ $dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
   box-shadow: $shadow-base;
   border: 1px solid $neutral-light;
   z-index: 2;
-  padding: $layout-spacing-base/2;
+  padding: $layout-spacing-base * .75;
 }
 
 .dropdown__content--noborder {

--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -6,7 +6,6 @@ $dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
 /* ==========================================================================
    Styles
    ========================================================================== */
-
 .dropdown-gc,
 .dropdown__wrapper {
   position: relative;
@@ -15,6 +14,12 @@ $dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
 
   + .dropdown-gc {
     margin-left: $layout-spacing-base;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    &:first-child {
+      margin-top: 0;
+    }
   }
 }
 

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -174,21 +174,21 @@ storiesOf('Components', module)
           title="Confirmation Dropdown"
           description="A dropdown like component that renders a confirmation dropdown."
         >
-          <div style={{marginLeft: '100px'}}>
-            <ConfirmationDropdown
-              confirmText="Archive"
-              confirmationPromise={createDelayedPromise}
-              dropdownContent={(
-                <Fragment>
-                  <h3>Archive 1 item</h3>
-                  <p>The selected item(s) will be moved to your project's archived items section.</p>
-                  <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
-                </Fragment>
-              )}
-            >
-              <Button>Test button</Button>
-            </ConfirmationDropdown>
-          </div>
+          <ConfirmationDropdown
+            id="confirm-dropdown"
+            confirmationText="Archive"
+            confirmationPromise={createDelayedPromise}
+            dropdownContent={(
+              <div style={{ maxWidth: '300px' }}>
+                <h3>Archive 1 item</h3>
+                <p>The selected item(s) will be moved to your project's archived items section.</p>
+                <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
+              </div>
+            )}
+            isDanger
+          >
+            <Icon name="trash" />
+          </ConfirmationDropdown>
         </StoryItem>
       </div>
     );

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { Fragment } from "react";
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { Dropdown, Avatar, AvatarInformation, Icon, ConfirmationDropdown } from '../../lib/';
+import { Dropdown, Avatar, AvatarInformation, Icon, ConfirmationDropdown, Button } from "../../lib/";
 import StoryItem from '../styleguide/StoryItem';
+
+const createDelayedPromise = (timeout = 2000) =>
+  new Promise(resolve => setTimeout(resolve, timeout));
 
 const createContentWithItems = props => (
   <Dropdown.Content {...props} collapse>
@@ -171,13 +174,19 @@ storiesOf('Components', module)
           title="Confirmation Dropdown"
           description="A dropdown like component that renders a confirmation dropdown."
         >
-          <div style={{marginLeft: '200px'}}>
+          <div style={{marginLeft: '100px'}}>
             <ConfirmationDropdown
-              iconName="trash"
-              onConfirm={() => action('action clicked')}
-              isDanger
+              confirmText="Archive"
+              confirmationPromise={createDelayedPromise}
+              dropdownContent={(
+                <Fragment>
+                  <h3>Archive 1 item</h3>
+                  <p>The selected item(s) will be moved to your project's archived items section.</p>
+                  <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
+                </Fragment>
+              )}
             >
-              Are you sure?
+              <Button>Test button</Button>
             </ConfirmationDropdown>
           </div>
         </StoryItem>

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -189,6 +189,22 @@ storiesOf('Components', module)
           >
             <Icon name="trash" />
           </ConfirmationDropdown>
+          <ConfirmationDropdown
+            id="confirm-dropdown"
+            confirmationText="Archive"
+            confirmationPromise={createDelayedPromise}
+            dropdownContent={(
+              <div style={{ maxWidth: '300px' }}>
+                <h3>Archive 1 item</h3>
+                <p>The selected item(s) will be moved to your project's archived items section.</p>
+                <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
+              </div>
+            )}
+            disabled
+            isDanger
+          >
+            <Icon name="trash" />
+          </ConfirmationDropdown>
         </StoryItem>
       </div>
     );

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -37,12 +37,13 @@ describe('Confirmation Dropdown', () => {
   });
 
   test('rendering a <Dropdown> component', () => {
-    const { id, className, show, autoPosition } = wrapper
+    const { id, className, show, hide, autoPosition } = wrapper
       .find(Dropdown)
       .props();
     expect(id).toBe('id');
     expect(className).toBe('confirmation-dropdown ');
     expect(show).toBe(false);
+    expect(hide).toBe(false);
     expect(autoPosition).toBe(true);
   });
 
@@ -57,21 +58,31 @@ describe('Confirmation Dropdown', () => {
       wrapper
         .find(Dropdown.Content)
         .find(Button)
+        .first()
         .prop('types')
     ).toEqual(['slim', 'collapse']);
     wrapper.setProps({ isDanger: true });
+
     expect(
       wrapper
         .find(Dropdown.Content)
         .find(Button)
+        .first()
         .prop('types')
-    ).toEqual(['link-danger', 'slim', 'collapse']);
+    ).toEqual(['slim', 'collapse', 'link-danger']);
   });
 
-  test('renders a confirmation button', () => {
-    const { clickHandler, children } = wrapper.find(Button).props();
+  test('rendering a confirmation button', () => {
+    const { clickHandler, children } = wrapper.find(Button).first().props();
     expect(clickHandler).toEqual(wrapper.instance().onConfirm);
     expect(children).toEqual('Confirm');
+  });
+
+  test('rendering a cancel button', () => {
+    const { types, clickHandler, children } = wrapper.find(Button).last().props();
+    expect(types).toEqual(['slim', 'collapse']);
+    expect(clickHandler).toEqual(wrapper.instance().onCancel);
+    expect(children).toEqual('Cancel');
   });
 
   test('wraps children with the trigger props', () => {
@@ -87,7 +98,8 @@ describe('Confirmation Dropdown', () => {
     return promise.then(() => {
       expect(onConfirmSpy).toHaveBeenCalledTimes(1);
       expect(wrapper.state()).toEqual({
-        promiseIsPending: false
+        promiseIsPending: false,
+        forceHide: false
       });
     });
   });
@@ -102,5 +114,22 @@ describe('Confirmation Dropdown', () => {
     wrapper.setState({ promiseIsPending: true });
     expect(wrapper.find(Dropdown).prop('show')).toBe(true);
     expect(wrapper.hasClass('is-pending')).toBe(true);
+  });
+
+  test('adds props to components when canceling', () => {
+    wrapper.setState({ forceHide: true });
+    expect(wrapper.find(Dropdown).prop('hide')).toBe(true);
+  });
+
+  test('resetting state when canceling', () => {
+    wrapper.setState({
+      promiseIsPending: true,
+      forceHide: true
+    });
+    wrapper.instance().onCancel();
+    expect(wrapper.state()).toEqual({
+      promiseIsPending: false,
+      forceHide: false
+    });
   });
 });

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -1,10 +1,5 @@
 import { React, shallow } from '../setup';
-import {
-  ConfirmationDropdown,
-  Button,
-  Icon,
-  Dropdown,
-} from '../../lib';
+import { ConfirmationDropdown, Button, Icon, Dropdown } from '../../lib';
 
 describe('Confirmation Dropdown', () => {
   let wrapper;
@@ -42,7 +37,9 @@ describe('Confirmation Dropdown', () => {
   });
 
   test('rendering a <Dropdown> component', () => {
-    const { id, className, show, autoPosition } = wrapper.find(Dropdown).props();
+    const { id, className, show, autoPosition } = wrapper
+      .find(Dropdown)
+      .props();
     expect(id).toBe('id');
     expect(className).toBe('confirmation-dropdown ');
     expect(show).toBe(false);
@@ -50,13 +47,25 @@ describe('Confirmation Dropdown', () => {
   });
 
   test('rendering dropdown content', () => {
-    expect(wrapper.find(Dropdown.Content).find('.dropdown-content')).toHaveLength(1);
+    expect(
+      wrapper.find(Dropdown.Content).find('.dropdown-content')
+    ).toHaveLength(1);
   });
 
   test('adds an is-danger type to the confirm button', () => {
-    expect(wrapper.find(Dropdown.Content).find(Button).prop('types')).toEqual(['slim', 'collapse']);
+    expect(
+      wrapper
+        .find(Dropdown.Content)
+        .find(Button)
+        .prop('types')
+    ).toEqual(['slim', 'collapse']);
     wrapper.setProps({ isDanger: true });
-    expect(wrapper.find(Dropdown.Content).find(Button).prop('types')).toEqual(['link-danger', 'slim', 'collapse']);
+    expect(
+      wrapper
+        .find(Dropdown.Content)
+        .find(Button)
+        .prop('types')
+    ).toEqual(['link-danger', 'slim', 'collapse']);
   });
 
   test('renders a confirmation button', () => {

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -3,7 +3,7 @@ import {
   ConfirmationDropdown,
   Button,
   Icon,
-  BoundaryClickWatcher
+  Dropdown,
 } from '../../lib';
 
 describe('Confirmation Dropdown', () => {
@@ -27,6 +27,7 @@ describe('Confirmation Dropdown', () => {
 
     wrapper = shallow(
       <ConfirmationDropdown
+        id="id"
         confirmationPromise={mockPromise}
         onCancel={onCancelSpy}
         dropdownContent={dropdownContent}
@@ -40,74 +41,57 @@ describe('Confirmation Dropdown', () => {
     expect(wrapper.contains('open confirmation')).toEqual(true);
   });
 
+  test('rendering a <Dropdown> component', () => {
+    const { id, className, show, autoPosition } = wrapper.find(Dropdown).props();
+    expect(id).toBe('id');
+    expect(className).toBe('confirmation-dropdown ');
+    expect(show).toBe(false);
+    expect(autoPosition).toBe(true);
+  });
+
   test('rendering dropdown content', () => {
-    expect(wrapper.find('.confirmation-dropdown__content-child').find('.dropdown-content')).toHaveLength(1);
+    expect(wrapper.find(Dropdown.Content).find('.dropdown-content')).toHaveLength(1);
   });
 
-  test('adds an is-danger class', () => {
-    expect(wrapper.hasClass('is-danger')).toBe(false);
+  test('adds an is-danger type to the confirm button', () => {
+    expect(wrapper.find(Dropdown.Content).find(Button).prop('types')).toEqual(['slim', 'collapse']);
     wrapper.setProps({ isDanger: true });
-    expect(wrapper.hasClass('is-danger')).toBe(true);
-  });
-
-  test('renders a BoundaryClickWatcher', () => {
-    expect(wrapper.find(BoundaryClickWatcher)).toHaveLength(1);
-    expect(
-      wrapper.find(BoundaryClickWatcher).prop('outsideClickHandler')
-    ).toEqual(wrapper.instance().onCancel);
+    expect(wrapper.find(Dropdown.Content).find(Button).prop('types')).toEqual(['link-danger', 'slim', 'collapse']);
   });
 
   test('renders a confirmation button', () => {
-    expect(
-      wrapper
-        .find(Button)
-        .prop('types')
-    ).toEqual(['link-danger', 'slim']);
-
-    expect(
-      wrapper
-        .find(Button)
-        .prop('clickHandler')
-    ).toEqual(wrapper.instance().onConfirm);
+    const { clickHandler, children } = wrapper.find(Button).props();
+    expect(clickHandler).toEqual(wrapper.instance().onConfirm);
+    expect(children).toEqual('Confirm');
   });
 
   test('wraps children with the trigger props', () => {
-    expect(
-      wrapper
-        .find('button')
-        .last()
-        .prop('onClick')
-    ).toEqual(wrapper.instance().toggleConfirmation);
+    const { onClick } = wrapper.find('button').props();
+    expect(onClick).toEqual(wrapper.instance().toggleConfirmation);
   });
 
   test('calls the confirmation promise and sets the correct state whilst pending', () => {
     const promise = wrapper.instance().onConfirm();
+    wrapper.instance().onConfirm();
+    wrapper.instance().onConfirm();
     expect(wrapper.state('promiseIsPending')).toEqual(true);
     return promise.then(() => {
       expect(onConfirmSpy).toHaveBeenCalledTimes(1);
       expect(wrapper.state()).toEqual({
-        showConfirmation: false,
         promiseIsPending: false
       });
     });
   });
 
   test('renders a loader whilst the promise is pending', () => {
-    expect(wrapper.find(Icon)).toHaveLength(0);
+    expect(wrapper.find(Icon).prop('name')).toEqual('loader');
     wrapper.setState({ promiseIsPending: true });
     expect(wrapper.find(Icon).prop('name')).toEqual('loader');
   });
 
-  test('calls the onCancel prop', () => {
-    wrapper.instance().onCancel();
-    expect(onCancelSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test('toggles the confirmation', () => {
-    expect(wrapper.state('showConfirmation')).toEqual(false);
-    expect(wrapper.hasClass('is-active')).toBe(false);
-    wrapper.instance().toggleConfirmation();
-    expect(wrapper.state('showConfirmation')).toEqual(true);
-    expect(wrapper.hasClass('is-active')).toBe(true);
+  test('adds props to components when promise is pending', () => {
+    wrapper.setState({ promiseIsPending: true });
+    expect(wrapper.find(Dropdown).prop('show')).toBe(true);
+    expect(wrapper.hasClass('is-pending')).toBe(true);
   });
 });

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -73,13 +73,19 @@ describe('Confirmation Dropdown', () => {
   });
 
   test('rendering a confirmation button', () => {
-    const { clickHandler, children } = wrapper.find(Button).first().props();
+    const { clickHandler, children } = wrapper
+      .find(Button)
+      .first()
+      .props();
     expect(clickHandler).toEqual(wrapper.instance().onConfirm);
     expect(children).toEqual('Confirm');
   });
 
   test('rendering a cancel button', () => {
-    const { types, clickHandler, children } = wrapper.find(Button).last().props();
+    const { types, clickHandler, children } = wrapper
+      .find(Button)
+      .last()
+      .props();
     expect(types).toEqual(['slim', 'collapse']);
     expect(clickHandler).toEqual(wrapper.instance().onCancel);
     expect(children).toEqual('Cancel');

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -60,7 +60,7 @@ describe('Confirmation Dropdown', () => {
         .find(Button)
         .first()
         .prop('types')
-    ).toEqual(['slim', 'collapse']);
+    ).toEqual(['slim', 'collapse', 'link']);
     wrapper.setProps({ isDanger: true });
 
     expect(

--- a/tests/Dropdown/Dropdown.spec.js
+++ b/tests/Dropdown/Dropdown.spec.js
@@ -127,4 +127,15 @@ describe('Dropdown', () => {
       }
     });
   });
+
+  test('hiding the content when the external hide prop is set', () => {
+    wrapper.setProps({ hide: true });
+
+    expect(onToggleMock).toHaveBeenLastCalledWith({
+      type: 'UNACTIVE',
+      payload: {
+        id: 'id-1'
+      }
+    });
+  });
 });

--- a/tests/Dropdown/Dropdown.spec.js
+++ b/tests/Dropdown/Dropdown.spec.js
@@ -115,4 +115,16 @@ describe('Dropdown', () => {
       }
     });
   });
+
+  test('persists the active state when the external show prop is true', () => {
+    wrapper.setProps({ show: true });
+    wrapper.instance().setShowContent(false);
+
+    expect(onToggleMock).toHaveBeenLastCalledWith({
+      type: 'ACTIVE',
+      payload: {
+        id: 'id-1'
+      }
+    });
+  });
 });


### PR DESCRIPTION
To make the `ConfirmationDropdown` more re-usable I have changed it quite a bit;

- we now use the `Dropdown` components rather than re-creating logic we already have
- we allow consumers to define their own dropdown trigger (via props.children)
- we handle the promise process itself within the component showing a loader!