### PR TITLE
onHide for ConfirmationDropdown

### DIFF
--- a/lib/ConfirmationDropdown/README.md
+++ b/lib/ConfirmationDropdown/README.md
@@ -14,6 +14,7 @@ A component which renders a confirmation dropdown.
 | isDanger              | bool          | false         | No       | Gives the confirmation button a danger style.              |
 | confirmationText      | string        | 'Confirm'     | No       | Text to display in confirmation button.  |
 | className             | string        | ''            | No       | Additional classes for the container.  |
+| onHide                | func          | () => {}      | No       | Trigger each time the dropdown is canceled or the confirmation promise resolves.  |
 
 ```
 <ConfirmationDropdown

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -12,7 +12,7 @@ class ConfirmationDropdown extends Component {
   state = initialState;
 
   resetState = () => {
-    this.setState(initialState, () => this.props.onHide);
+    this.setState(initialState, this.props.onHide);
   };
 
   onConfirm = () => {

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -11,7 +11,9 @@ const initialState = {
 class ConfirmationDropdown extends Component {
   state = initialState;
 
-  resetState = () => this.setState(initialState);
+  resetState = () => {
+    this.setState(initialState, () => this.props.onHide);
+  };
 
   onConfirm = () => {
     if (this.state.promiseIsPending) {
@@ -86,6 +88,7 @@ ConfirmationDropdown.propTypes = {
   children: PropTypes.node.isRequired,
   dropdownContent: PropTypes.node.isRequired,
   confirmationPromise: PropTypes.func.isRequired,
+  onHide: PropTypes.func,
   className: PropTypes.string,
   isDanger: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -96,7 +99,8 @@ ConfirmationDropdown.defaultProps = {
   className: '',
   isDanger: false,
   disabled: false,
-  confirmationText: 'Confirm'
+  confirmationText: 'Confirm',
+  onHide: () => {}
 };
 
 export default ConfirmationDropdown;

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -1,7 +1,7 @@
-import React, { Fragment } from "react";
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { Dropdown, Avatar, AvatarInformation, Icon, ConfirmationDropdown, Button } from "../../lib/";
+import { Dropdown, Avatar, AvatarInformation, Icon, ConfirmationDropdown } from '../../lib/';
 import StoryItem from '../styleguide/StoryItem';
 
 const createDelayedPromise = (timeout = 2000) =>

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -5,6 +5,7 @@ describe('Confirmation Dropdown', () => {
   let wrapper;
   let onConfirmSpy;
   let onCancelSpy;
+  let onHideSpy;
 
   const dropdownContent = (
     <div className="dropdown-content">Dropdown content!</div>
@@ -19,12 +20,14 @@ describe('Confirmation Dropdown', () => {
   beforeEach(() => {
     onConfirmSpy = jest.fn();
     onCancelSpy = jest.fn();
+    onHideSpy = jest.fn();
 
     wrapper = shallow(
       <ConfirmationDropdown
         id="id"
         confirmationPromise={mockPromise}
         onCancel={onCancelSpy}
+        onHide={onHideSpy}
         dropdownContent={dropdownContent}
       >
         <button>open confirmation</button>
@@ -137,5 +140,6 @@ describe('Confirmation Dropdown', () => {
       promiseIsPending: false,
       forceHide: false
     });
+    expect(onHideSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Whilst using the component I found that at times I unmount the component completely after the promise has resolved. Currently, we try to set the state on the component (to reset it) and when it's unmounted this causes a leak.

Adding an `onHide` prop gives us the ability to trigger the logic which would unmount the component resolving the leak on our side 👍 