### PR TITLE
Confirmation dropdown promise handlers 

### DIFF
--- a/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
+++ b/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
@@ -10,7 +10,8 @@ const ConfirmationDropdownContent = (
     promiseIsPending,
     onConfirm,
     disabled,
-    confirmationText
+    confirmationText,
+    onHide
   },
   context
 ) => {
@@ -44,7 +45,10 @@ const ConfirmationDropdownContent = (
 
         <Button
           types={sharedButtonProps}
-          clickHandler={() => setShowContent(false)}
+          clickHandler={() => {
+            onHide();
+            setShowContent(false);
+          }}
           className="confirmation-dropdown__cancel"
         >
           Cancel
@@ -61,6 +65,7 @@ ConfirmationDropdownContent.contextTypes = {
 ConfirmationDropdownContent.propTypes = {
   children: PropTypes.node.isRequired,
   onConfirm: PropTypes.func.isRequired,
+  onHide: PropTypes.func,
   isDanger: PropTypes.bool,
   disabled: PropTypes.bool,
   promiseIsPending: PropTypes.bool,
@@ -71,7 +76,8 @@ ConfirmationDropdownContent.defaultProps = {
   isDanger: false,
   disabled: false,
   promiseIsPending: false,
-  confirmationText: 'Confirm'
+  confirmationText: 'Confirm',
+  onHide: () => {}
 };
 
 export default ConfirmationDropdownContent;

--- a/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
+++ b/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
@@ -11,7 +11,8 @@ const ConfirmationDropdownContent = (
     onConfirm,
     disabled,
     confirmationText,
-    onHide
+    onHide,
+    hideOnCompletion
   },
   context
 ) => {
@@ -35,7 +36,13 @@ const ConfirmationDropdownContent = (
 
         <Button
           types={confirmButtonTypes}
-          clickHandler={() => onConfirm().then(() => setShowContent(false))}
+          clickHandler={() =>
+            onConfirm().then(() => {
+              if (hideOnCompletion) {
+                setShowContent(false);
+              }
+            })
+          }
           className="confirmation-dropdown__confirm-trigger"
           aria-hidden={promiseIsPending}
           disabled={disabled}
@@ -68,6 +75,7 @@ ConfirmationDropdownContent.propTypes = {
   onHide: PropTypes.func,
   isDanger: PropTypes.bool,
   disabled: PropTypes.bool,
+  hideOnCompletion: PropTypes.bool,
   promiseIsPending: PropTypes.bool,
   confirmationText: PropTypes.string
 };
@@ -76,6 +84,7 @@ ConfirmationDropdownContent.defaultProps = {
   isDanger: false,
   disabled: false,
   promiseIsPending: false,
+  hideOnCompletion: true,
   confirmationText: 'Confirm',
   onHide: () => {}
 };

--- a/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
+++ b/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Dropdown, Icon } from '../index';
+import { GATHER_UI_DROPDOWN } from '../Dropdown';
+
+const ConfirmationDropdownContent = (
+  {
+    isDanger,
+    children,
+    promiseIsPending,
+    onConfirm,
+    disabled,
+    confirmationText
+  },
+  context
+) => {
+  const { setShowContent } = context[GATHER_UI_DROPDOWN];
+  const sharedButtonProps = ['slim', 'collapse'];
+
+  const confirmButtonTypes = isDanger
+    ? [...sharedButtonProps, 'link-danger']
+    : [...sharedButtonProps, 'link'];
+
+  return (
+    <Dropdown.Content>
+      {children}
+
+      <div className="confirmation-dropdown__footer">
+        <Icon
+          name="loader"
+          className="confirmation-dropdown__loader"
+          aria-hidden={!promiseIsPending}
+        />
+
+        <Button
+          types={confirmButtonTypes}
+          clickHandler={() => onConfirm().then(() => setShowContent(false))}
+          className="confirmation-dropdown__confirm-trigger"
+          aria-hidden={promiseIsPending}
+          disabled={disabled}
+        >
+          {confirmationText}
+        </Button>
+
+        <Button
+          types={sharedButtonProps}
+          clickHandler={() => setShowContent(false)}
+          className="confirmation-dropdown__cancel"
+        >
+          Cancel
+        </Button>
+      </div>
+    </Dropdown.Content>
+  );
+};
+
+ConfirmationDropdownContent.contextTypes = {
+  [GATHER_UI_DROPDOWN]: PropTypes.shape().isRequired
+};
+
+ConfirmationDropdownContent.propTypes = {
+  children: PropTypes.node.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  isDanger: PropTypes.bool,
+  disabled: PropTypes.bool,
+  promiseIsPending: PropTypes.bool,
+  confirmationText: PropTypes.string
+};
+
+ConfirmationDropdownContent.defaultProps = {
+  isDanger: false,
+  disabled: false,
+  promiseIsPending: false,
+  confirmationText: 'Confirm'
+};
+
+export default ConfirmationDropdownContent;

--- a/lib/ConfirmationDropdown/README.md
+++ b/lib/ConfirmationDropdown/README.md
@@ -14,7 +14,9 @@ A component which renders a confirmation dropdown.
 | isDanger              | bool          | false         | No       | Gives the confirmation button a danger style.              |
 | confirmationText      | string        | 'Confirm'     | No       | Text to display in confirmation button.  |
 | className             | string        | ''            | No       | Additional classes for the container.  |
-| onHide                | func          | () => {}      | No       | Trigger each time the dropdown is canceled or the confirmation promise resolves.  |
+| onHide                | func          | () => {}      | No       | Function that triggers each time the dropdown is canceled or closed.  |
+| onPromiseResolve      | func          | () => {}      | No       | Function that triggers when the confirmation promise resolved successfully.  |
+| onPromiseReject       | func          | () => {}      | No       | Function that triggers when the confirmation promise is rejected.  |
 
 ```
 <ConfirmationDropdown

--- a/lib/ConfirmationDropdown/README.md
+++ b/lib/ConfirmationDropdown/README.md
@@ -15,8 +15,7 @@ A component which renders a confirmation dropdown.
 | confirmationText      | string        | 'Confirm'     | No       | Text to display in confirmation button.  |
 | className             | string        | ''            | No       | Additional classes for the container.  |
 | onHide                | func          | () => {}      | No       | Function that triggers each time the dropdown is canceled or closed.  |
-| onPromiseResolve      | func          | () => {}      | No       | Function that triggers when the confirmation promise resolved successfully.  |
-| onPromiseReject       | func          | () => {}      | No       | Function that triggers when the confirmation promise is rejected.  |
+| hideOnCompletion      | bool          | true          | No       | Hides the dropdown when the promise has completed.  |
 
 ```
 <ConfirmationDropdown

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -9,6 +9,13 @@ class ConfirmationDropdown extends Component {
     promiseIsPending: false
   };
 
+  hide = () => {
+    if (this.props.hideOnCompletion) {
+      this.setState({ promiseIsPending: false });
+      this.props.onHide();
+    }
+  };
+
   onConfirm = () => {
     if (this.state.promiseIsPending) {
       return this;
@@ -17,12 +24,8 @@ class ConfirmationDropdown extends Component {
     this.setState({ promiseIsPending: true });
     return this.props
       .confirmationPromise()
-      .then(() => {
-        this.setState({ promiseIsPending: false }, this.props.onPromiseResolve);
-      })
-      .catch(() => {
-        this.setState({ promiseIsPending: false }, this.props.onPromiseReject);
-      });
+      .then(this.hide)
+      .catch(this.hide);
   };
 
   render() {
@@ -35,7 +38,7 @@ class ConfirmationDropdown extends Component {
         id={this.props.id}
         className={classNames}
         persistShow={this.state.promiseIsPending}
-        onHide={this.props.onHide}
+        onHide={this.hide}
         autoPosition
       >
         <ConfirmationDropdownContent
@@ -57,8 +60,7 @@ ConfirmationDropdown.propTypes = {
   dropdownContent: PropTypes.node.isRequired,
   confirmationPromise: PropTypes.func.isRequired,
   onHide: PropTypes.func,
-  onPromiseResolve: PropTypes.func,
-  onPromiseReject: PropTypes.func,
+  hideOnCompletion: PropTypes.bool,
   className: PropTypes.string,
   isDanger: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -69,10 +71,9 @@ ConfirmationDropdown.defaultProps = {
   className: '',
   isDanger: false,
   disabled: false,
+  hideOnCompletion: true,
   confirmationText: 'Confirm',
-  onHide: () => {},
-  onPromiseResolve: () => {},
-  onPromiseReject: () => {}
+  onHide: () => {}
 };
 
 export default ConfirmationDropdown;

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -35,6 +35,7 @@ class ConfirmationDropdown extends Component {
         id={this.props.id}
         className={classNames}
         persistShow={this.state.promiseIsPending}
+        onHide={this.props.onHide}
         autoPosition
       >
         <ConfirmationDropdownContent
@@ -55,9 +56,9 @@ ConfirmationDropdown.propTypes = {
   children: PropTypes.node.isRequired,
   dropdownContent: PropTypes.node.isRequired,
   confirmationPromise: PropTypes.func.isRequired,
+  onHide: PropTypes.func,
   onPromiseResolve: PropTypes.func,
   onPromiseReject: PropTypes.func,
-  onHide: PropTypes.func,
   className: PropTypes.string,
   isDanger: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -1,18 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Button, Icon, Dropdown } from '../';
-
-const initialState = {
-  promiseIsPending: false,
-  forceHide: false
-};
+import { Dropdown } from '../';
+import ConfirmationDropdownContent from './ConfirmationDropdownContent';
 
 class ConfirmationDropdown extends Component {
-  state = initialState;
-
-  resetState = () => {
-    this.setState(initialState, this.props.onHide);
+  state = {
+    promiseIsPending: false
   };
 
   onConfirm = () => {
@@ -21,11 +15,14 @@ class ConfirmationDropdown extends Component {
     }
 
     this.setState({ promiseIsPending: true });
-    return this.props.confirmationPromise().then(this.resetState);
-  };
-
-  onCancel = () => {
-    this.setState({ forceHide: true }, this.resetState);
+    return this.props
+      .confirmationPromise()
+      .then(() => {
+        this.setState({ promiseIsPending: false }, this.props.onPromiseResolve);
+      })
+      .catch(() => {
+        this.setState({ promiseIsPending: false }, this.props.onPromiseReject);
+      });
   };
 
   render() {
@@ -33,50 +30,20 @@ class ConfirmationDropdown extends Component {
       'is-pending': this.state.promiseIsPending
     });
 
-    const sharedButtonProps = ['slim', 'collapse'];
-
-    const confirmButtonTypes = this.props.isDanger
-      ? [...sharedButtonProps, 'link-danger']
-      : [...sharedButtonProps, 'link'];
-
     return (
       <Dropdown
         id={this.props.id}
         className={classNames}
-        show={this.state.promiseIsPending}
-        hide={this.state.forceHide}
+        persistShow={this.state.promiseIsPending}
         autoPosition
       >
-        <Dropdown.Content>
+        <ConfirmationDropdownContent
+          {...this.props}
+          {...this.state}
+          onConfirm={this.onConfirm}
+        >
           {this.props.dropdownContent}
-
-          <div className="confirmation-dropdown__footer">
-            <Icon
-              name="loader"
-              className="confirmation-dropdown__loader"
-              aria-hidden={!this.state.promiseIsPending}
-            />
-
-            <Button
-              types={confirmButtonTypes}
-              clickHandler={this.onConfirm}
-              className="confirmation-dropdown__confirm-trigger"
-              aria-hidden={this.state.promiseIsPending}
-              disabled={this.props.disabled}
-            >
-              {this.props.confirmationText}
-            </Button>
-
-            <Button
-              types={sharedButtonProps}
-              clickHandler={this.onCancel}
-              className="confirmation-dropdown__cancel"
-            >
-              Cancel
-            </Button>
-          </div>
-        </Dropdown.Content>
-
+        </ConfirmationDropdownContent>
         <Dropdown.Trigger>{this.props.children}</Dropdown.Trigger>
       </Dropdown>
     );
@@ -88,6 +55,8 @@ ConfirmationDropdown.propTypes = {
   children: PropTypes.node.isRequired,
   dropdownContent: PropTypes.node.isRequired,
   confirmationPromise: PropTypes.func.isRequired,
+  onPromiseResolve: PropTypes.func,
+  onPromiseReject: PropTypes.func,
   onHide: PropTypes.func,
   className: PropTypes.string,
   isDanger: PropTypes.bool,
@@ -100,7 +69,9 @@ ConfirmationDropdown.defaultProps = {
   isDanger: false,
   disabled: false,
   confirmationText: 'Confirm',
-  onHide: () => {}
+  onHide: () => {},
+  onPromiseResolve: () => {},
+  onPromiseReject: () => {}
 };
 
 export default ConfirmationDropdown;

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -22,8 +22,7 @@ class Dropdown extends Component {
     className: PropTypes.string,
     ignoreClass: PropTypes.string,
     autoPosition: PropTypes.bool,
-    show: PropTypes.bool,
-    hide: PropTypes.bool
+    persistShow: PropTypes.bool
   };
 
   static defaultProps = {
@@ -31,8 +30,7 @@ class Dropdown extends Component {
     className: '',
     ignoreClass: null,
     autoPosition: false,
-    show: false,
-    hide: false
+    persistShow: false
   };
 
   static childContextTypes = {
@@ -51,19 +49,11 @@ class Dropdown extends Component {
       [GATHER_UI_DROPDOWN]: {
         showContent: this.state.showContent,
         toggleShowContent: this.toggleShowContent,
+        setShowContent: this.setShowContent,
         autoPosition: this.props.autoPosition,
         bounds: this.state.bounds
       }
     };
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-      (prevProps.show && !this.props.show) ||
-      (!prevProps.hide && this.props.hide)
-    ) {
-      this.setShowContent(false);
-    }
   }
 
   setShowContent = show => {
@@ -74,8 +64,8 @@ class Dropdown extends Component {
   };
 
   dispatchToggle = contentWillShow => {
-    const { id, onToggle, show } = this.props;
-    const type = contentWillShow || show ? 'ACTIVE' : 'UNACTIVE';
+    const { id, onToggle, persistShow } = this.props;
+    const type = contentWillShow || persistShow ? 'ACTIVE' : 'UNACTIVE';
 
     onToggle({
       type,
@@ -85,9 +75,11 @@ class Dropdown extends Component {
 
   toggleShowContent = (bounds = null) => {
     this.dispatchToggle(!this.state.showContent);
+
     this.setState({
-      showContent: !this.state.showContent
+      showContent: this.props.persistShow ? true : !this.state.showContent
     });
+
     if (bounds) {
       this.setState({
         bounds: {

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -19,6 +19,7 @@ class Dropdown extends Component {
     children: PropTypes.node.isRequired,
     id: PropTypes.string.isRequired,
     onToggle: PropTypes.func,
+    onHide: PropTypes.func,
     className: PropTypes.string,
     ignoreClass: PropTypes.string,
     autoPosition: PropTypes.bool,
@@ -27,6 +28,7 @@ class Dropdown extends Component {
 
   static defaultProps = {
     onToggle: () => {},
+    onHide: () => {},
     className: '',
     ignoreClass: null,
     autoPosition: false,
@@ -100,7 +102,10 @@ class Dropdown extends Component {
     return (
       <BoundaryClickWatcher
         className={classNames}
-        outsideClickHandler={() => this.setShowContent(false)}
+        outsideClickHandler={() => {
+          this.setShowContent(false);
+          this.props.onHide();
+        }}
         ignoreClass={this.props.ignoreClass}
       >
         {this.props.children}

--- a/lib/SelectionBar/index.js
+++ b/lib/SelectionBar/index.js
@@ -60,7 +60,9 @@ SelectionBar.Action = SelectionBarAction;
 
 SelectionBar.propTypes = {
   type: PropTypes.string.isRequired,
-  selectedIds: PropTypes.arrayOf(PropTypes.number, PropTypes.string).isRequired,
+  selectedIds: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ).isRequired,
   children: PropTypes.node.isRequired,
   clearSelection: PropTypes.func.isRequired,
   selectAll: PropTypes.func.isRequired,

--- a/lib/SelectionBar/index.js
+++ b/lib/SelectionBar/index.js
@@ -60,7 +60,7 @@ SelectionBar.Action = SelectionBarAction;
 
 SelectionBar.propTypes = {
   type: PropTypes.string.isRequired,
-  selectedIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  selectedIds: PropTypes.arrayOf(PropTypes.number, PropTypes.string).isRequired,
   children: PropTypes.node.isRequired,
   clearSelection: PropTypes.func.isRequired,
   selectAll: PropTypes.func.isRequired,

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -162,7 +162,7 @@ storiesOf('Components', module)
           title="Dropdown with auto positioning"
           description="The dropdown content have auto positioning based on where the trigger is."
         >
-          <Dropdown id="id-3" autoPosition>
+          <Dropdown id="id-3" autoPosition persistShow>
             <Dropdown.Trigger useButton>
               Auto Position
             </Dropdown.Trigger>
@@ -187,23 +187,7 @@ storiesOf('Components', module)
             )}
             isDanger
           >
-            <Icon name="trash" />
-          </ConfirmationDropdown>
-          <ConfirmationDropdown
-            id="confirm-dropdown"
-            confirmationText="Archive"
-            confirmationPromise={createDelayedPromise}
-            dropdownContent={(
-              <div style={{ maxWidth: '300px' }}>
-                <h3>Archive 1 item</h3>
-                <p>The selected item(s) will be moved to your project's archived items section.</p>
-                <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
-              </div>
-            )}
-            disabled
-            isDanger
-          >
-            <Icon name="trash" />
+            <Icon name="archive" />
           </ConfirmationDropdown>
         </StoryItem>
       </div>

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -162,7 +162,7 @@ storiesOf('Components', module)
           title="Dropdown with auto positioning"
           description="The dropdown content have auto positioning based on where the trigger is."
         >
-          <Dropdown id="id-3" autoPosition persistShow>
+          <Dropdown id="id-3" autoPosition>
             <Dropdown.Trigger useButton>
               Auto Position
             </Dropdown.Trigger>

--- a/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
+++ b/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
@@ -21,7 +21,10 @@ describe('Confirmation Dropdown Content', () => {
 
   beforeEach(() => {
     wrapper = shallow(
-      <ConfirmationDropdownContent onConfirm={mockConfirmPromise} onHide={onHideSpy}>
+      <ConfirmationDropdownContent
+        onConfirm={mockConfirmPromise}
+        onHide={onHideSpy}
+      >
         {dropdownContent}
       </ConfirmationDropdownContent>,
       {

--- a/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
+++ b/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
@@ -5,8 +5,9 @@ import { GATHER_UI_DROPDOWN } from '../../lib/Dropdown';
 
 describe('Confirmation Dropdown Content', () => {
   let wrapper;
-  let onConfirmSpy;
-  let setShowContentSpy;
+  const onConfirmSpy = jest.fn();
+  const setShowContentSpy = jest.fn();
+  const onHideSpy = jest.fn();
 
   const dropdownContent = (
     <div className="dropdown-content">Dropdown content!</div>
@@ -19,11 +20,8 @@ describe('Confirmation Dropdown Content', () => {
     });
 
   beforeEach(() => {
-    onConfirmSpy = jest.fn();
-    setShowContentSpy = jest.fn();
-
     wrapper = shallow(
-      <ConfirmationDropdownContent onConfirm={mockConfirmPromise}>
+      <ConfirmationDropdownContent onConfirm={mockConfirmPromise} onHide={onHideSpy}>
         {dropdownContent}
       </ConfirmationDropdownContent>,
       {
@@ -82,6 +80,7 @@ describe('Confirmation Dropdown Content', () => {
     expect(children).toEqual('Cancel');
     clickHandler();
     expect(setShowContentSpy).toHaveBeenCalledWith(false);
+    expect(onHideSpy).toHaveBeenCalledTimes(1);
   });
 
   test('renders a loader whilst the promise is pending', () => {

--- a/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
+++ b/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
@@ -1,0 +1,92 @@
+import { React, shallow } from '../setup';
+import { Button, Icon, Dropdown } from '../../lib';
+import ConfirmationDropdownContent from '../../lib/ConfirmationDropdown/ConfirmationDropdownContent';
+import { GATHER_UI_DROPDOWN } from '../../lib/Dropdown';
+
+describe('Confirmation Dropdown Content', () => {
+  let wrapper;
+  let onConfirmSpy;
+  let setShowContentSpy;
+
+  const dropdownContent = (
+    <div className="dropdown-content">Dropdown content!</div>
+  );
+
+  const mockConfirmPromise = () =>
+    new Promise(resolve => {
+      resolve();
+      onConfirmSpy();
+    });
+
+  beforeEach(() => {
+    onConfirmSpy = jest.fn();
+    setShowContentSpy = jest.fn();
+
+    wrapper = shallow(
+      <ConfirmationDropdownContent onConfirm={mockConfirmPromise}>
+        {dropdownContent}
+      </ConfirmationDropdownContent>,
+      {
+        context: {
+          [GATHER_UI_DROPDOWN]: {
+            setShowContent: setShowContentSpy
+          }
+        }
+      }
+    );
+  });
+
+  test('rendering dropdown content', () => {
+    expect(
+      wrapper.find(Dropdown.Content).find('.dropdown-content')
+    ).toHaveLength(1);
+  });
+
+  test('adds an is-danger type to the confirm button', () => {
+    expect(
+      wrapper
+        .find(Dropdown.Content)
+        .find(Button)
+        .first()
+        .prop('types')
+    ).toEqual(['slim', 'collapse', 'link']);
+    wrapper.setProps({ isDanger: true });
+
+    expect(
+      wrapper
+        .find(Dropdown.Content)
+        .find(Button)
+        .first()
+        .prop('types')
+    ).toEqual(['slim', 'collapse', 'link-danger']);
+  });
+
+  test('rendering a confirmation button', () => {
+    const { clickHandler, children } = wrapper
+      .find(Button)
+      .first()
+      .props();
+    expect(children).toEqual('Confirm');
+    return clickHandler().then(() => {
+      expect(onConfirmSpy).toHaveBeenCalledTimes(1);
+      expect(setShowContentSpy).toHaveBeenCalledWith(false);
+    });
+  });
+
+  test('rendering a cancel button', () => {
+    const { types, clickHandler, children } = wrapper
+      .find(Button)
+      .last()
+      .props();
+    expect(types).toEqual(['slim', 'collapse']);
+    expect(children).toEqual('Cancel');
+    clickHandler();
+    expect(setShowContentSpy).toHaveBeenCalledWith(false);
+  });
+
+  test('renders a loader whilst the promise is pending', () => {
+    expect(wrapper.find(Icon).prop('name')).toEqual('loader');
+    wrapper.setProps({ promiseIsPending: true });
+    expect(wrapper.find(Icon).prop('name')).toEqual('loader');
+  });
+});

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -67,7 +67,6 @@ describe('Confirmation Dropdown', () => {
     return promise.then(() => {
       expect(onConfirmSpy).toHaveBeenCalledTimes(1);
       expect(wrapper.state()).toEqual({ promiseIsPending: false });
-      expect(onPromiseResolveSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -75,25 +74,5 @@ describe('Confirmation Dropdown', () => {
     wrapper.setState({ promiseIsPending: true });
     expect(wrapper.find(Dropdown).prop('persistShow')).toBe(true);
     expect(wrapper.hasClass('is-pending')).toBe(true);
-  });
-
-  test('calling onPromiseReject when the confirmation promise has resolved', () => {
-    const rejectedPromise = () =>
-      new Promise((resolve, reject) => {
-        reject();
-      });
-
-    wrapper.setProps({
-      confirmationPromise: rejectedPromise
-    });
-
-    wrapper
-      .instance()
-      .onConfirm()
-      .then(() => {
-        expect(onConfirmSpy).toHaveBeenCalledTimes(1);
-        expect(wrapper.state()).toEqual({ promiseIsPending: false });
-        expect(onPromiseRejectSpy).toHaveBeenCalledTimes(1);
-      });
   });
 });

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -1,11 +1,14 @@
 import { React, shallow } from '../setup';
-import { ConfirmationDropdown, Button, Icon, Dropdown } from '../../lib';
+import { ConfirmationDropdown, Dropdown } from '../../lib';
+import ConfirmationDropdownContent from '../../lib/ConfirmationDropdown/ConfirmationDropdownContent';
 
 describe('Confirmation Dropdown', () => {
   let wrapper;
-  let onConfirmSpy;
-  let onCancelSpy;
-  let onHideSpy;
+  const onConfirmSpy = jest.fn();
+  const onCancelSpy = jest.fn();
+  const onHideSpy = jest.fn();
+  const onPromiseResolveSpy = jest.fn();
+  const onPromiseRejectSpy = jest.fn();
 
   const dropdownContent = (
     <div className="dropdown-content">Dropdown content!</div>
@@ -18,14 +21,12 @@ describe('Confirmation Dropdown', () => {
     });
 
   beforeEach(() => {
-    onConfirmSpy = jest.fn();
-    onCancelSpy = jest.fn();
-    onHideSpy = jest.fn();
-
     wrapper = shallow(
       <ConfirmationDropdown
         id="id"
         confirmationPromise={mockPromise}
+        onPromiseResolve={onPromiseResolveSpy}
+        onPromiseReject={onPromiseRejectSpy}
         onCancel={onCancelSpy}
         onHide={onHideSpy}
         dropdownContent={dropdownContent}
@@ -40,58 +41,17 @@ describe('Confirmation Dropdown', () => {
   });
 
   test('rendering a <Dropdown> component', () => {
-    const { id, className, show, hide, autoPosition } = wrapper
+    const { id, className, persistShow, autoPosition } = wrapper
       .find(Dropdown)
       .props();
     expect(id).toBe('id');
     expect(className).toBe('confirmation-dropdown ');
-    expect(show).toBe(false);
-    expect(hide).toBe(false);
+    expect(persistShow).toBe(false);
     expect(autoPosition).toBe(true);
   });
 
   test('rendering dropdown content', () => {
-    expect(
-      wrapper.find(Dropdown.Content).find('.dropdown-content')
-    ).toHaveLength(1);
-  });
-
-  test('adds an is-danger type to the confirm button', () => {
-    expect(
-      wrapper
-        .find(Dropdown.Content)
-        .find(Button)
-        .first()
-        .prop('types')
-    ).toEqual(['slim', 'collapse', 'link']);
-    wrapper.setProps({ isDanger: true });
-
-    expect(
-      wrapper
-        .find(Dropdown.Content)
-        .find(Button)
-        .first()
-        .prop('types')
-    ).toEqual(['slim', 'collapse', 'link-danger']);
-  });
-
-  test('rendering a confirmation button', () => {
-    const { clickHandler, children } = wrapper
-      .find(Button)
-      .first()
-      .props();
-    expect(clickHandler).toEqual(wrapper.instance().onConfirm);
-    expect(children).toEqual('Confirm');
-  });
-
-  test('rendering a cancel button', () => {
-    const { types, clickHandler, children } = wrapper
-      .find(Button)
-      .last()
-      .props();
-    expect(types).toEqual(['slim', 'collapse']);
-    expect(clickHandler).toEqual(wrapper.instance().onCancel);
-    expect(children).toEqual('Cancel');
+    expect(wrapper.find(ConfirmationDropdownContent)).toHaveLength(1);
   });
 
   test('wraps children with the trigger props', () => {
@@ -106,40 +66,34 @@ describe('Confirmation Dropdown', () => {
     expect(wrapper.state('promiseIsPending')).toEqual(true);
     return promise.then(() => {
       expect(onConfirmSpy).toHaveBeenCalledTimes(1);
-      expect(wrapper.state()).toEqual({
-        promiseIsPending: false,
-        forceHide: false
-      });
+      expect(wrapper.state()).toEqual({ promiseIsPending: false });
+      expect(onPromiseResolveSpy).toHaveBeenCalledTimes(1);
     });
-  });
-
-  test('renders a loader whilst the promise is pending', () => {
-    expect(wrapper.find(Icon).prop('name')).toEqual('loader');
-    wrapper.setState({ promiseIsPending: true });
-    expect(wrapper.find(Icon).prop('name')).toEqual('loader');
   });
 
   test('adds props to components when promise is pending', () => {
     wrapper.setState({ promiseIsPending: true });
-    expect(wrapper.find(Dropdown).prop('show')).toBe(true);
+    expect(wrapper.find(Dropdown).prop('persistShow')).toBe(true);
     expect(wrapper.hasClass('is-pending')).toBe(true);
   });
 
-  test('adds props to components when canceling', () => {
-    wrapper.setState({ forceHide: true });
-    expect(wrapper.find(Dropdown).prop('hide')).toBe(true);
-  });
+  test('calling onPromiseReject when the confirmation promise has resolved', () => {
+    const rejectedPromise = () =>
+      new Promise((resolve, reject) => {
+        reject();
+      });
 
-  test('resetting state when canceling', () => {
-    wrapper.setState({
-      promiseIsPending: true,
-      forceHide: true
+    wrapper.setProps({
+      confirmationPromise: rejectedPromise
     });
-    wrapper.instance().onCancel();
-    expect(wrapper.state()).toEqual({
-      promiseIsPending: false,
-      forceHide: false
-    });
-    expect(onHideSpy).toHaveBeenCalledTimes(1);
+
+    wrapper
+      .instance()
+      .onConfirm()
+      .then(() => {
+        expect(onConfirmSpy).toHaveBeenCalledTimes(1);
+        expect(wrapper.state()).toEqual({ promiseIsPending: false });
+        expect(onPromiseRejectSpy).toHaveBeenCalledTimes(1);
+      });
   });
 });

--- a/tests/Dropdown/Dropdown.spec.js
+++ b/tests/Dropdown/Dropdown.spec.js
@@ -33,6 +33,7 @@ describe('Dropdown', () => {
       [GATHER_UI_DROPDOWN]: {
         showContent: true,
         toggleShowContent: wrapper.instance().toggleShowContent,
+        setShowContent: wrapper.instance().setShowContent,
         bounds: { top: -9999 },
         autoPosition: false
       }
@@ -117,22 +118,11 @@ describe('Dropdown', () => {
   });
 
   test('persists the active state when the external show prop is true', () => {
-    wrapper.setProps({ show: true });
+    wrapper.setProps({ persistShow: true });
     wrapper.instance().setShowContent(false);
 
     expect(onToggleMock).toHaveBeenLastCalledWith({
       type: 'ACTIVE',
-      payload: {
-        id: 'id-1'
-      }
-    });
-  });
-
-  test('hiding the content when the external hide prop is set', () => {
-    wrapper.setProps({ hide: true });
-
-    expect(onToggleMock).toHaveBeenLastCalledWith({
-      type: 'UNACTIVE',
       payload: {
         id: 'id-1'
       }

--- a/tests/Dropdown/Dropdown.spec.js
+++ b/tests/Dropdown/Dropdown.spec.js
@@ -10,10 +10,11 @@ import BoundaryClickWatcher from '../../lib/BoundaryClickWatcher';
 describe('Dropdown', () => {
   let wrapper;
   const onToggleMock = jest.fn();
+  const onHideMock = jest.fn();
 
   beforeEach(() => {
     wrapper = shallow(
-      <Dropdown onToggle={onToggleMock} id="id-1">
+      <Dropdown onToggle={onToggleMock} onHide={onHideMock} id="id-1">
         <Dropdown.Trigger>Trigger 1</Dropdown.Trigger>
       </Dropdown>
     );
@@ -68,6 +69,7 @@ describe('Dropdown', () => {
     expect(wrapper.state('showContent')).toBe(true);
     wrapper.find(BoundaryClickWatcher).prop('outsideClickHandler')();
     expect(wrapper.state('showContent')).toBe(false);
+    expect(onHideMock).toHaveBeenCalledTimes(1);
   });
 
   test('rendering an active class', () => {


### PR DESCRIPTION
Our recent changes to the confirmation dropdown had some design flaws in them like not using the dropdown context supplied to close the dropdown, instead create new props to do something that context already provided us.

The PR also adds handlers for the confirmation promise so when we resolve or reject the confirmation promise we can execute some additional logic.