### PR TITLE
Declare text sizes here as they differ from our styleguide

### DIFF
--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -11,6 +11,27 @@ $field-label-weight: $typo-weight-semi-bold !default;
 $field-data-size: $typo-size-small !default;
 $field-data-color: $neutral-base !default;
 
+$field-data-h1-size: 2.25rem !default;
+$field-data-h1-line-height: 2.875rem !default;
+
+$field-data-h2-size: 2rem !default;
+$field-data-h2-line-height: 2.375rem !default;
+
+$field-data-h3-size: 1.75rem !default;
+$field-data-h3-line-height: 2.125rem !default;
+
+$field-data-h4-size: 1.5rem !default;
+$field-data-h4-line-height: 1.875rem !default;
+
+$field-data-h5-size: 1.375rem !default;
+$field-data-h5-line-height: 1.75rem !default;
+
+$field-data-h6-size: 1.25rem !default;
+$field-data-h6-line-height: 1.5rem !default;
+
+$field-data-p-size: 1.125rem !default;
+$field-data-p-line-height: 1.688rem !default;
+
 /* ==========================================================================
    Styles
    ========================================================================== */
@@ -297,56 +318,56 @@ $field-data-color: $neutral-base !default;
   }
 
   h1 {
-    font-size: $typo-size-lead * 2.5;
-    line-height: $typo-line-height-base * 2.4;
+    font-size: $field-data-h1-size;
+    line-height: $field-data-h1-line-height;
     font-weight: $typo-weight-roman;
     margin-top: $layout-spacing-base * 1.5;
     margin-bottom: $layout-spacing-base;
   }
 
   h2 {
-    font-size: $typo-size-lead * 2;
-    line-height: $typo-line-height-base * 1.9;
+    font-size: $field-data-h2-size;
+    line-height: $field-data-h2-line-height;
     font-weight: $typo-weight-roman;
     margin-top: $layout-spacing-base * 1.5;
     margin-bottom: $layout-spacing-base * 0.5;
   }
 
   h3 {
-    font-size: $typo-size-lead * 1.75;
-    line-height: $typo-line-height-base * 1.7;
+    font-size: $field-data-h3-size;
+    line-height: $field-data-h3-line-height;
     font-weight: $typo-weight-roman;
     margin-top: $layout-spacing-base * 1.5;
     margin-bottom: $layout-spacing-base * 0.5;
   }
 
   h4 {
-    font-size: $typo-size-lead * 1.5;
-    line-height: $typo-line-height-base * 1.5;
+    font-size: $field-data-h4-size;
+    line-height: $field-data-h4-line-height;
     font-weight: $typo-weight-roman;
     margin-top: $layout-spacing-base * 0.5;
     margin-bottom: $layout-spacing-base * 0.5;
   }
 
   h5 {
-    font-size: $typo-size-lead * 1.25;
-    line-height: $typo-line-height-base * 1.3;
+    font-size: $field-data-h5-size;
+    line-height: $field-data-h5-line-height;
     font-weight: $typo-weight-semi-bold;
     margin-top: $layout-spacing-base * 0.5;
     margin-bottom: $layout-spacing-base * 0.5;
   }
 
   h6 {
-    font-size: $typo-size-lead;
-    line-height: $typo-line-height-base * 1.2;
+    font-size: $field-data-h6-size;
+    line-height: $field-data-h6-line-height;
     font-weight: $typo-weight-bold;
     margin-top: $layout-spacing-base * 0.5;
     margin-bottom: $layout-spacing-base * 0.5;
   }
 
   p {
-    font-size: $typo-size-lead;
-    line-height: $typo-line-height-base * 1.35;
+    font-size: $field-data-p-size;
+    line-height: $field-data-p-line-height;
     font-weight: $typo-weight-roman;
     margin-top: $layout-spacing-base * 0.5;
     margin-bottom: $layout-spacing-base;


### PR DESCRIPTION
We need to have different sizes for our headers and text in the editor than what is in our declared typography settings. 

I have set defaults at the top of the file. I'm wondering if I should use the specific px value rather than the rem values. @kyleharper what are your thoughts on this?