### PR TITLE
Confirmation Dropdown Updates

### DIFF
--- a/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
+++ b/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
@@ -25,10 +25,10 @@ const ConfirmationDropdownContent = (
     : [...sharedButtonProps, 'link'];
 
   return (
-    <Dropdown.Content {...props} className="confirmation-dropdown__content">
+    <Dropdown.Content {...props}>
       {children}
 
-      <div className="confirmation-dropdown__footer">
+      <Dropdown.Footer>
         <Icon
           name="loader"
           className="confirmation-dropdown__loader"
@@ -61,7 +61,7 @@ const ConfirmationDropdownContent = (
         >
           Cancel
         </Button>
-      </div>
+      </Dropdown.Footer>
     </Dropdown.Content>
   );
 };

--- a/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
+++ b/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
@@ -12,7 +12,8 @@ const ConfirmationDropdownContent = (
     disabled,
     confirmationText,
     onHide,
-    hideOnCompletion
+    hideOnCompletion,
+    ...props
   },
   context
 ) => {
@@ -24,7 +25,7 @@ const ConfirmationDropdownContent = (
     : [...sharedButtonProps, 'link'];
 
   return (
-    <Dropdown.Content>
+    <Dropdown.Content {...props} className="confirmation-dropdown__content">
       {children}
 
       <div className="confirmation-dropdown__footer">

--- a/lib/ConfirmationDropdown/README.md
+++ b/lib/ConfirmationDropdown/README.md
@@ -16,6 +16,7 @@ A component which renders a confirmation dropdown.
 | className             | string        | ''            | No       | Additional classes for the container.  |
 | onHide                | func          | () => {}      | No       | Function that triggers each time the dropdown is canceled or closed.  |
 | hideOnCompletion      | bool          | true          | No       | Hides the dropdown when the promise has completed.  |
+| position              | object        | `{ autoPosition: true }` | No       | An object containing dropdown positions. Look at Dropdown docs for more information.  |
 
 ```
 <ConfirmationDropdown
@@ -24,6 +25,10 @@ A component which renders a confirmation dropdown.
   confirmationText="Archive"
   dropdownContent={(<div>Some content</div>)}
   className="class-for-content"
+  position={{
+    top: true,
+    right: true,
+  }}
   isDanger
 >
   Click me to show dropdown

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -30,8 +30,11 @@ class ConfirmationDropdown extends Component {
 
   render() {
     const classNames = cx(`confirmation-dropdown ${this.props.className}`, {
-      'is-pending': this.state.promiseIsPending
+      'is-pending': this.state.promiseIsPending,
+      'confirmation-dropdown--is-dangerous': this.props.isDanger
     });
+
+    const { autoPosition, ...position } = this.props.position;
 
     return (
       <Dropdown
@@ -39,11 +42,12 @@ class ConfirmationDropdown extends Component {
         className={classNames}
         persistShow={this.state.promiseIsPending}
         onHide={this.hide}
-        autoPosition
+        autoPosition={autoPosition}
       >
         <ConfirmationDropdownContent
           {...this.props}
           {...this.state}
+          {...position}
           onConfirm={this.onConfirm}
         >
           {this.props.dropdownContent}
@@ -64,7 +68,8 @@ ConfirmationDropdown.propTypes = {
   className: PropTypes.string,
   isDanger: PropTypes.bool,
   disabled: PropTypes.bool,
-  confirmationText: PropTypes.string
+  confirmationText: PropTypes.string,
+  position: PropTypes.shape()
 };
 
 ConfirmationDropdown.defaultProps = {
@@ -73,7 +78,10 @@ ConfirmationDropdown.defaultProps = {
   disabled: false,
   hideOnCompletion: true,
   confirmationText: 'Confirm',
-  onHide: () => {}
+  onHide: () => {},
+  position: {
+    autoPosition: true
+  }
 };
 
 export default ConfirmationDropdown;

--- a/lib/ConfirmationDropdown/styles.scss
+++ b/lib/ConfirmationDropdown/styles.scss
@@ -6,11 +6,11 @@
    Styles
    ========================================================================== */
 
-.confirmation-dropdown__content {
+.confirmation-dropdown .dropdown__content {
   width: 300px;
 }
 
-.confirmation-dropdown__footer {
+.confirmation-dropdown .dropdown__footer {
   position: relative;
   display: flex;
   align-items: center;

--- a/lib/ConfirmationDropdown/styles.scss
+++ b/lib/ConfirmationDropdown/styles.scss
@@ -5,6 +5,11 @@
 /* ==========================================================================
    Styles
    ========================================================================== */
+
+.confirmation-dropdown__content {
+  width: 300px;
+}
+
 .confirmation-dropdown__footer {
   position: relative;
   display: flex;
@@ -39,4 +44,12 @@
 
 .confirmation-dropdown.is-pending .confirmation-dropdown__loader {
   opacity: 1;
+}
+
+/* ==========================================================================
+   Modifiers
+   ========================================================================== */
+
+.confirmation-dropdown--is-dangerous > .dropdown__trigger {
+  @extend .button--link-danger;
 }

--- a/lib/Dropdown/DropdownFooter.js
+++ b/lib/Dropdown/DropdownFooter.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DropdownFooter = ({ children }) => {
+  return <footer className="dropdown__footer">{children}</footer>;
+};
+
+DropdownFooter.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export default DropdownFooter;

--- a/lib/Dropdown/DropdownHeader.js
+++ b/lib/Dropdown/DropdownHeader.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DropdownHeader = ({ children }) => {
+  return <header className="dropdown__header">{children}</header>;
+};
+
+DropdownHeader.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export default DropdownHeader;

--- a/lib/Dropdown/DropdownSection.js
+++ b/lib/Dropdown/DropdownSection.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DropdownSection = ({ children }) => {
+  return <div className="dropdown__section">{children}</div>;
+};
+
+DropdownSection.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export default DropdownSection;

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -4,9 +4,11 @@ import cx from 'classnames';
 import DropdownAction from './DropdownAction';
 import DropdownActionGroup from './DropdownActionGroup';
 import DropdownContent from './DropdownContent';
-import DropdownHeader from './DropdownHeader';
+import DropdownSection from './DropdownSection';
 import DropdownTrigger from './DropdownTrigger';
 import BoundaryClickWatcher from '../BoundaryClickWatcher';
+import DropdownHeader from './DropdownHeader';
+import DropdownFooter from './DropdownFooter';
 
 export const GATHER_UI_DROPDOWN = 'GATHER_UI_DROPDOWN';
 
@@ -18,6 +20,10 @@ class Dropdown extends Component {
   static Content = DropdownContent;
 
   static Header = DropdownHeader;
+
+  static Footer = DropdownFooter;
+
+  static Section = DropdownSection;
 
   static Trigger = DropdownTrigger;
 

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import DropdownAction from './DropdownAction';
 import DropdownActionGroup from './DropdownActionGroup';
 import DropdownContent from './DropdownContent';
+import DropdownHeader from './DropdownHeader';
 import DropdownTrigger from './DropdownTrigger';
 import BoundaryClickWatcher from '../BoundaryClickWatcher';
 
@@ -15,6 +16,8 @@ class Dropdown extends Component {
   static ActionGroup = DropdownActionGroup;
 
   static Content = DropdownContent;
+
+  static Header = DropdownHeader;
 
   static Trigger = DropdownTrigger;
 

--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -1,7 +1,8 @@
 /* ==========================================================================
    Config
    ========================================================================== */
-$dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
+$dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base !default;
+$dropdown-section-padding: $layout-spacing-base * .75 !default;
 
 /* ==========================================================================
    Styles
@@ -16,14 +17,12 @@ $dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
     margin-left: $layout-spacing-base;
   }
 
-  h1, h2, h3, h4, h5, h6 {
-    &:first-child {
-      margin-top: 0;
-    }
+  *:first-child {
+    margin-top: 0;
+  }
 
-    &:last-child {
-      margin-bottom: 0;
-    }
+  *:last-child {
+    margin-bottom: 0;
   }
 }
 
@@ -174,6 +173,18 @@ $dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
 
 .dropdown__content--collapse {
   padding: 0;
+
+  .dropdown__header,
+  .dropdown__section,
+  .dropdown__footer {
+    padding: $dropdown-section-padding;
+
+    + .dropdown__header,
+    + .dropdown__section,
+    + .dropdown__footer {
+      padding-top: 0;
+    }
+  }
 }
 
 .dropdown__trigger-wrapper {

--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -44,6 +44,15 @@ $dropdown-item-padding: $layout-spacing-base/3 $layout-spacing-base/1 !default;
   outline: none;
 }
 
+.dropdown__header {
+  display: flex;
+  align-items: center;
+
+  h3 {
+    margin: 0 auto 0 0;
+  }
+}
+
 .dropdown__content {
   position: absolute;
   top: -999em;

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from "react";
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Dropdown, Avatar, AvatarInformation, Icon, ConfirmationDropdown } from '../../lib/';
@@ -179,11 +179,31 @@ storiesOf('Components', module)
             confirmationText="Archive"
             confirmationPromise={createDelayedPromise}
             dropdownContent={(
-              <div style={{ maxWidth: '300px' }}>
-                <h3>Archive 1 item</h3>
+              <Fragment>
+                <Dropdown.Header>
+                  <h3>Archive 1 item</h3>
+                  <ConfirmationDropdown
+                    id="confirm-sub-dropdown"
+                    confirmationText="Archive all"
+                    dropdownContent={(
+                      <div>
+                        <h3>Remove all items</h3>
+                        <p>Do you wish to archive all items?</p>
+                      </div>
+                    )}
+                    confirmationPromise={createDelayedPromise}
+                    position={{
+                      bottom: true,
+                      left: true,
+                    }}
+                    isDanger
+                  >
+                    Archive all items
+                  </ConfirmationDropdown>
+                </Dropdown.Header>
                 <p>The selected item(s) will be moved to your project's archived items section.</p>
                 <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
-              </div>
+              </Fragment>
             )}
             isDanger
           >

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -182,14 +182,39 @@ storiesOf('Components', module)
               <Fragment>
                 <Dropdown.Header>
                   <h3>Archive 1 item</h3>
+                </Dropdown.Header>
+                <Dropdown.Section>
+                  <p>The selected item(s) will be moved to your project's archived items section.</p>
+                  <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
+                </Dropdown.Section>
+              </Fragment>
+            )}
+            isDanger
+            collapse
+          >
+            <Icon name="archive" />
+          </ConfirmationDropdown>
+
+          <ConfirmationDropdown
+            id="trash-dropdown-2"
+            confirmationText="Archive"
+            confirmationPromise={createDelayedPromise}
+            dropdownContent={(
+              <Fragment>
+                <Dropdown.Header>
+                  <h3>Archive 1 item</h3>
                   <ConfirmationDropdown
                     id="confirm-sub-dropdown"
                     confirmationText="Archive all"
                     dropdownContent={(
-                      <div>
-                        <h3>Remove all items</h3>
-                        <p>Do you wish to archive all items?</p>
-                      </div>
+                      <Fragment>
+                        <Dropdown.Header>
+                          <h3>Remove all items</h3>
+                        </Dropdown.Header>
+                        <Dropdown.Section>
+                          <p>Do you wish to archive all items?</p>
+                        </Dropdown.Section>
+                      </Fragment>
                     )}
                     confirmationPromise={createDelayedPromise}
                     position={{
@@ -197,17 +222,21 @@ storiesOf('Components', module)
                       left: true,
                     }}
                     isDanger
+                    collapse
                   >
                     Archive all items
                   </ConfirmationDropdown>
                 </Dropdown.Header>
-                <p>The selected item(s) will be moved to your project's archived items section.</p>
-                <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
+                <Dropdown.Section>
+                  <p>The selected item(s) will be moved to your project's archived items section.</p>
+                  <p>Arching items will disconnect any applied templates, and also remove assignees and due-dates.</p>
+                </Dropdown.Section>
               </Fragment>
             )}
             isDanger
+            collapse
           >
-            <Icon name="archive" />
+            <Icon name="trash" />
           </ConfirmationDropdown>
         </StoryItem>
       </div>

--- a/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
+++ b/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
@@ -24,6 +24,7 @@ describe('Confirmation Dropdown Content', () => {
       <ConfirmationDropdownContent
         onConfirm={mockConfirmPromise}
         onHide={onHideSpy}
+        top
       >
         {dropdownContent}
       </ConfirmationDropdownContent>,
@@ -90,5 +91,9 @@ describe('Confirmation Dropdown Content', () => {
     expect(wrapper.find(Icon).prop('name')).toEqual('loader');
     wrapper.setProps({ promiseIsPending: true });
     expect(wrapper.find(Icon).prop('name')).toEqual('loader');
+  });
+
+  test('spreading props over the content', () => {
+    expect(wrapper.find(Dropdown.Content).prop('top')).toEqual(true);
   });
 });

--- a/tests/ConfirmationDropdown/index.spec.js
+++ b/tests/ConfirmationDropdown/index.spec.js
@@ -50,6 +50,22 @@ describe('Confirmation Dropdown', () => {
     expect(autoPosition).toBe(true);
   });
 
+  test('spreading position props', () => {
+    const { autoPosition } = wrapper.find(Dropdown).props();
+    expect(autoPosition).toBe(true);
+
+    wrapper.setProps({
+      position: {
+        right: true,
+        top: true
+      }
+    });
+    const { top, right } = wrapper.find(ConfirmationDropdownContent).props();
+    expect(wrapper.find(Dropdown).prop('autoPosition')).toBe(false);
+    expect(top).toBe(true);
+    expect(right).toBe(true);
+  });
+
   test('rendering dropdown content', () => {
     expect(wrapper.find(ConfirmationDropdownContent)).toHaveLength(1);
   });


### PR DESCRIPTION
The confirmation dropdown has instances where it contains another dropdown but it didn't allow for manual positions to override issues with `autoPosition` on top of `autoPosition`.

As well as that I thought it'd be worthwhile having a component to render a dropdown header which is a new requirement seeing as we have headings and actions alongside each other.