### PR TITLE
Adds noIndentation prop to finder item

### DIFF
--- a/lib/FinderNavigation/FinderItem.js
+++ b/lib/FinderNavigation/FinderItem.js
@@ -8,13 +8,20 @@ const FinderItem = ({
   hoverSettings,
   selected,
   children,
+  noIndentation,
   ...rest
 }) => {
-  const classNames = cx(`finder__item ${className}`, {
-    'is-active': active,
-    'finder__item--hover-settings': hoverSettings,
-    'finder__item--selected': selected
-  });
+  const classNames = cx(
+    `${
+      noIndentation ? 'finder__item-no-indentation' : 'finder__item'
+    } ${className}`,
+    {
+      'is-active': active,
+      'finder__item--hover-settings': hoverSettings,
+      'finder__item--selected': selected
+    }
+  );
+
   return (
     <div className={classNames} {...rest}>
       {children}
@@ -27,14 +34,16 @@ FinderItem.propTypes = {
   active: PropTypes.bool,
   className: PropTypes.string,
   hoverSettings: PropTypes.bool,
-  selected: PropTypes.bool
+  selected: PropTypes.bool,
+  noIndentation: PropTypes.bool
 };
 
 FinderItem.defaultProps = {
   active: false,
   className: '',
   hoverSettings: true,
-  selected: false
+  selected: false,
+  noIndentation: false
 };
 
 export default FinderItem;

--- a/lib/FinderNavigation/styles.scss
+++ b/lib/FinderNavigation/styles.scss
@@ -72,7 +72,7 @@ $finder-indent-level-support: 10 !default;
   }
 }
 
-.finder__item {
+.finder__item-no-indentation, .finder__item {
   color: $neutral-dark;
   font-size: $typo-size-base;
   &-link {


### PR DESCRIPTION
- Adds `noIndentation` prop to `<FinderItem />`
- This prop switches the main classname between 'finder__item' and 'finder__item-no-indentation'
- But when you look at the styles, they both apply the same thing, say WHUT!1!?

Take a look at this snippet: https://github.com/gathercontent/gather-ui/blob/master/lib/FinderNavigation/styles.scss#L184-L201

That bad boy basically means that the more parents with the classname `finder__item` a `<FinderItemContent />` component has, the more indented to the right it is (to signify folder structure)

By adding a prop to change the classname, but keep the same styles, we can stop a folder that is not shown from indenting it's children (used in "Archived Items")

Relates to: https://github.com/gathercontent/app/pull/1585