### PR TITLE
Set default for due date picker to 5pm instead of midnight

### DIFF
--- a/lib/DueDatePicker/index.js
+++ b/lib/DueDatePicker/index.js
@@ -17,7 +17,7 @@ class DueDatePicker extends Component {
       selectedDay: props.dueDate ? props.dueDate.toDate() : null,
       selectedTime: props.dueDate
         ? moment(props.dueDate)
-        : moment().set({ hours: 12, minutes: 0 })
+        : moment().set({ hours: 17, minutes: 0 })
     };
     this.state = this.initialState;
   }


### PR DESCRIPTION
Whilst paring with @jamesdarracott we changed the time default for the due date picker component so this starts at 17:00 rather than 00:00. 

Makes sense for deadlines 👍 