### PR TITLE
Dropdown.Trigger useSelect prop

### DIFF
--- a/lib/Button/styles.scss
+++ b/lib/Button/styles.scss
@@ -261,9 +261,20 @@ $btn-border-radius: 3px !default;
 .button--outline {
   border: 1px solid $color-border-base;
   outline: none;
-  &:hover, &:focus, &.is-active {
+
+  &:focus {
+    background: $neutral-lightest;
+    border-color: $neutral-base;
+  }
+
+  &:hover, &.is-active {
+    background: none;
     border-color:  $primary-blue;
     color: $primary-blue;
+
+    path {
+      fill: $primary-blue;
+    }
   }
 }
 

--- a/lib/Dropdown/DropdownTrigger.js
+++ b/lib/Dropdown/DropdownTrigger.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '../index';
+import cx from 'classnames';
+import { Button, Icon } from '../index';
 import { GATHER_UI_DROPDOWN } from './index';
 
 class DropdownTrigger extends Component {
@@ -16,27 +17,44 @@ class DropdownTrigger extends Component {
   };
 
   render() {
-    const { children, useButton, ...rest } = this.props;
-    return useButton ? (
-      <div
-        ref={trigger => {
-          this.trigger = trigger;
-        }}
-        className="dropdown__trigger-wrapper"
-      >
-        <Button {...this.props} clickHandler={this.handleClick}>
-          {children}
-        </Button>
-      </div>
-    ) : (
+    const { children, useButton, useSelect, ...rest } = this.props;
+    const { showContent } = this.context[GATHER_UI_DROPDOWN];
+    const createRef = trigger => {
+      this.trigger = trigger;
+    };
+    const wrapperClassNames = cx({
+      'dropdown__trigger-wrapper': useButton,
+      'dropdown__trigger-wrapper--select': useSelect
+    });
+    const buttonClassNames = cx({
+      'is-active': showContent,
+      dropdown__trigger: !useButton && !useSelect
+    });
+    const buttonTypes = useSelect ? ['outline'] : ['primary'];
+
+    if (useButton || useSelect) {
+      return (
+        <div ref={createRef} className={wrapperClassNames}>
+          <Button
+            types={buttonTypes}
+            className={buttonClassNames}
+            {...rest}
+            onClick={this.handleClick}
+          >
+            {children}
+            {useSelect && <Icon name="down" />}
+          </Button>
+        </div>
+      );
+    }
+
+    return (
       <button
         type="button"
         {...rest}
-        className="dropdown__trigger"
+        className={buttonClassNames}
         onClick={this.handleClick}
-        ref={trigger => {
-          this.trigger = trigger;
-        }}
+        ref={createRef}
       >
         {children}
       </button>
@@ -50,11 +68,13 @@ DropdownTrigger.contextTypes = {
 
 DropdownTrigger.propTypes = {
   children: PropTypes.node.isRequired,
-  useButton: PropTypes.bool
+  useButton: PropTypes.bool,
+  useSelect: PropTypes.bool
 };
 
 DropdownTrigger.defaultProps = {
-  useButton: false
+  useButton: false,
+  useSelect: false
 };
 
 export default DropdownTrigger;

--- a/lib/Dropdown/README.md
+++ b/lib/Dropdown/README.md
@@ -10,6 +10,7 @@ A dropdown component with compounded components to render triggers and the conte
 | id                  | String        | N/A       | Yes      | ID of the dropdown.                                                                  |
 | children            | Node          | N/A       | Yes      | A child node.                                                           |
 | onToggle            | Func          | () => {}  | No       | A function which is called each time the visibility is toggled.               |
+| block                | Bool          | false     | No       | Makes the dropdown container block like.                                                                  |
 
 ### Context (GATHER_UI_DROPDOWN)
 
@@ -61,6 +62,7 @@ A dropdown component with compounded components to render triggers and the conte
 | Name               | Type          | Default   | Required | Description                                                                   |
 | ------------------ |-------------- | --------- | -------- |------------------------------------------------------------------------------ |
 | useButton          | String        | false        | No       | Use a Button component as the trigger.                                            |
+| useSelect          | String        | false        | No       | Enables the look of a dropdown menu to simulate a select.                                            |
 | children           | Node or String or Function | N/A     | Yes       | The content of the trigger.                         |
 
 # Dropdown.Content

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -35,6 +35,7 @@ class Dropdown extends Component {
     className: PropTypes.string,
     ignoreClass: PropTypes.string,
     autoPosition: PropTypes.bool,
+    block: PropTypes.bool,
     persistShow: PropTypes.bool
   };
 
@@ -44,6 +45,7 @@ class Dropdown extends Component {
     className: '',
     ignoreClass: null,
     autoPosition: false,
+    block: false,
     persistShow: false
   };
 
@@ -108,7 +110,8 @@ class Dropdown extends Component {
   render() {
     const classNames = cx(`dropdown-gc ${this.props.className}`, {
       'is-active': this.state.showContent,
-      'auto-top': this.props.autoPosition
+      'auto-top': this.props.autoPosition,
+      'dropdown-gc--block': this.props.block
     });
 
     return (

--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -119,6 +119,9 @@ $dropdown-hover-background: $neutral-lightest !default;
 /* ==========================================================================
    Modifiers
    ========================================================================== */
+.dropdown-gc--block {
+  width: 100%;
+}
 
 .dropdown__content--collapse {
   padding: 0;
@@ -225,4 +228,22 @@ $dropdown-hover-background: $neutral-lightest !default;
 
 .dropdown__action--disabled {
   opacity: 0.5;
+}
+
+.dropdown__trigger-wrapper--select {
+  width: 100%;
+
+  .button {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+
+  .icon {
+    margin-left: auto;
+  }
+
+  .is-active & .icon {
+    transform: rotateX(180deg);
+  }
 }

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -266,6 +266,21 @@ storiesOf('Components', module)
             <Icon name="trash" />
           </ConfirmationDropdown>
         </StoryItem>
+
+        <StoryItem
+          title="Dropdown Menu"
+          description="DropdownMenu is being phased out. You can achieve the same outcome by composing Dropdown components."
+        >
+          <div style={{ maxWidth: '300px' }}>
+            <Dropdown id="dropdown-menu" autoPosition block>
+              <Dropdown.Trigger useSelect>
+                Select an option...
+              </Dropdown.Trigger>
+
+              {createContentWithItems()}
+            </Dropdown>
+          </div>
+        </StoryItem>
       </div>
     );
   });

--- a/tests/Dropdown/DropdownTrigger.spec.js
+++ b/tests/Dropdown/DropdownTrigger.spec.js
@@ -3,15 +3,17 @@ import { Dropdown, Button } from '../../lib';
 import { GATHER_UI_DROPDOWN } from '../../lib/Dropdown';
 
 describe('Dropdown Trigger', () => {
-  const toggleShowContentMock = jest.fn();
-  const context = {
-    [GATHER_UI_DROPDOWN]: {
-      toggleShowContent: toggleShowContentMock
-    }
-  };
+  let toggleShowContentMock;
   let wrapper;
 
   beforeEach(() => {
+    toggleShowContentMock = jest.fn();
+    const context = {
+      [GATHER_UI_DROPDOWN]: {
+        toggleShowContent: toggleShowContentMock
+      }
+    };
+
     wrapper = shallow(<Dropdown.Trigger>Trigger text</Dropdown.Trigger>, {
       context
     });
@@ -26,9 +28,15 @@ describe('Dropdown Trigger', () => {
 
   test('rendering a Button component as the trigger', () => {
     wrapper.setProps({ useButton: true });
-    const button = wrapper.find(Button);
-    expect(button).toHaveLength(1);
-    button.prop('clickHandler')();
-    expect(toggleShowContentMock).toBeCalled();
+    const { types, onClick } = wrapper.find(Button).props();
+    onClick();
+    expect(types).toEqual(['primary']);
+    expect(toggleShowContentMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('rendering a select like trigger', () => {
+    wrapper.setProps({ useSelect: true });
+    const { types } = wrapper.find(Button).props();
+    expect(types).toEqual(['outline']);
   });
 });


### PR DESCRIPTION
We added the latest `Dropdown` components to be able to compose dropdowns at will in many forms. However, at times we still want to achieve the same look that is provided by `DropdownMenu`, especially the trigger.

This PR adds the ability to add a menu modifier to `<Dropdown.Trigger />` .

--------

I've called the prop `useSelect` as it is a pipe dream of mine to utilise native selects a little more in our `Dropdown` components for accessibility and to increase our progressive nature.