### PR TITLE
Stop conversation ui from being unaccessible

### DIFF
--- a/lib/Conversation/CommentForm/styles.scss
+++ b/lib/Conversation/CommentForm/styles.scss
@@ -96,6 +96,7 @@ $mention-suggestions-max-height: 500px;
     border-radius: $conversation-border-radius;
     background-color: white;
     border: 1px solid $color-border-base;
+    margin-bottom: $layout-spacing-base*3 !important; // have to override inline styles from react-mentions package :(
     &:before {
       color: $neutral-base;
       content: 'Mention...';

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -214,6 +214,7 @@ $conversation-meta-text-color: $neutral-base !default;
   background-color: $conversation-active-background-color;
   box-shadow: $shadow-shallow;
   cursor: default;
+  margin-bottom: $layout-spacing-base*3;
 }
 
 .is-active .conversation__resolve {


### PR DESCRIPTION
Sometimes the bottom bar covers the mentions/actions in conversations - this gives it some more breathing room