### PR TITLE
add onCancel to ConfirmationDropdown and avatar proptypes

### DIFF
--- a/lib/Avatar/AvatarInformation.js
+++ b/lib/Avatar/AvatarInformation.js
@@ -21,7 +21,7 @@ AvatarInformation.defaultProps = {
 
 AvatarInformation.propTypes = {
   className: PropTypes.string,
-  name: PropTypes.string,
+  name: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   email: PropTypes.string
 };
 

--- a/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
+++ b/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
@@ -13,6 +13,7 @@ const ConfirmationDropdownContent = (
     confirmationText,
     onHide,
     hideOnCompletion,
+    onCancel,
     ...props
   },
   context
@@ -55,6 +56,7 @@ const ConfirmationDropdownContent = (
           types={sharedButtonProps}
           clickHandler={() => {
             onHide();
+            onCancel();
             setShowContent(false);
           }}
           className="confirmation-dropdown__cancel"
@@ -78,7 +80,8 @@ ConfirmationDropdownContent.propTypes = {
   disabled: PropTypes.bool,
   hideOnCompletion: PropTypes.bool,
   promiseIsPending: PropTypes.bool,
-  confirmationText: PropTypes.string
+  confirmationText: PropTypes.string,
+  onCancel: PropTypes.func
 };
 
 ConfirmationDropdownContent.defaultProps = {
@@ -87,7 +90,8 @@ ConfirmationDropdownContent.defaultProps = {
   promiseIsPending: false,
   hideOnCompletion: true,
   confirmationText: 'Confirm',
-  onHide: () => {}
+  onHide: () => {},
+  onCancel: () => {}
 };
 
 export default ConfirmationDropdownContent;

--- a/lib/ConfirmationDropdown/README.md
+++ b/lib/ConfirmationDropdown/README.md
@@ -17,7 +17,7 @@ A component which renders a confirmation dropdown.
 | onHide                | func          | () => {}      | No       | Function that triggers each time the dropdown is canceled or closed.  |
 | hideOnCompletion      | bool          | true          | No       | Hides the dropdown when the promise has completed.  |
 | position              | object        | `{ autoPosition: true }` | No       | An object containing dropdown positions. Look at Dropdown docs for more information.  |
-
+| onCancel              | func          | () => {}      | No       | Function that triggers when the cancel button is clicked.  |
 ```
 <ConfirmationDropdown
   id="id-1"

--- a/lib/ConfirmationDropdown/index.js
+++ b/lib/ConfirmationDropdown/index.js
@@ -69,7 +69,8 @@ ConfirmationDropdown.propTypes = {
   isDanger: PropTypes.bool,
   disabled: PropTypes.bool,
   confirmationText: PropTypes.string,
-  position: PropTypes.shape()
+  position: PropTypes.shape(),
+  onCancel: PropTypes.func
 };
 
 ConfirmationDropdown.defaultProps = {
@@ -81,7 +82,8 @@ ConfirmationDropdown.defaultProps = {
   onHide: () => {},
   position: {
     autoPosition: true
-  }
+  },
+  onCancel: () => {}
 };
 
 export default ConfirmationDropdown;

--- a/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
+++ b/tests/ConfirmationDropdown/ConfirmationDropdownContent.spec.js
@@ -8,6 +8,7 @@ describe('Confirmation Dropdown Content', () => {
   const onConfirmSpy = jest.fn();
   const setShowContentSpy = jest.fn();
   const onHideSpy = jest.fn();
+  const onCancelSpy = jest.fn();
 
   const dropdownContent = (
     <div className="dropdown-content">Dropdown content!</div>
@@ -24,6 +25,7 @@ describe('Confirmation Dropdown Content', () => {
       <ConfirmationDropdownContent
         onConfirm={mockConfirmPromise}
         onHide={onHideSpy}
+        onCancel={onCancelSpy}
         top
       >
         {dropdownContent}
@@ -85,6 +87,7 @@ describe('Confirmation Dropdown Content', () => {
     clickHandler();
     expect(setShowContentSpy).toHaveBeenCalledWith(false);
     expect(onHideSpy).toHaveBeenCalledTimes(1);
+    expect(onCancelSpy).toHaveBeenCalledTimes(1);
   });
 
   test('renders a loader whilst the promise is pending', () => {


### PR DESCRIPTION
I needed to call something when I clicked cancel on a ConfirmationDropdown, and I needed to pass a node as an Avatar name

So I've added both in!