### PR TITLE
Firefox style fix for PricingPlan component

### DIFF
--- a/lib/Pricing/PricingText.js
+++ b/lib/Pricing/PricingText.js
@@ -1,3 +1,0 @@
-const PricingText = ({ children }) => `$${children.toLocaleString()}`;
-
-export default PricingText;

--- a/lib/PricingPlan/styles.scss
+++ b/lib/PricingPlan/styles.scss
@@ -40,6 +40,7 @@
   font-size: $typo-size-large*4;
   line-height: 1em;
   position: relative;
+  width: 100%;
 
   &::first-letter {
     font-size: $typo-size-large*2;

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,6 @@ export SelectionBar from './SelectionBar';
 export FormModal from './FormModal';
 export FinderNavigation from './FinderNavigation';
 export PricingWrapper from './Pricing/PricingWrapper';
-export PricingText from './Pricing/PricingText';
 export PricingPlan from './PricingPlan/PricingPlan';
 export FeatureList from './FeatureList/FeatureList';
 export FeatureListItem from './FeatureList/FeatureListItem';

--- a/stories/components/Pricing.js
+++ b/stories/components/Pricing.js
@@ -130,7 +130,7 @@ storiesOf('Components', module)
                 </Col>
 
                 <Col xs={12} md={6}>
-                  <PricingPlan price={<PricingText>{price}</PricingText>} smallPrint="$1,250 per month" priceDesc="per seat per month" title="Advanced" upgradeButton={upgradeButton} savings="Save $360">
+                  <PricingPlan price={`$${price}`} smallPrint="$1,250 per month" priceDesc="per seat per month" title="Advanced" upgradeButton={upgradeButton} savings="Save $360">
                     <div className="pricing__plan-person">
                       <PersonSVG />
                     </div>


### PR DESCRIPTION
A very small fix for the `PricingPlan` styles. I've also removed the `PricingText` component because we don't handle internationalisation so our test env blows up.