### PR TITLE
Fix/dropdown trigger issue

### DIFF
--- a/lib/Dropdown/DropdownTrigger.js
+++ b/lib/Dropdown/DropdownTrigger.js
@@ -17,7 +17,14 @@ class DropdownTrigger extends Component {
   };
 
   render() {
-    const { children, useButton, useSelect, types, direction, ...rest } = this.props;
+    const {
+      children,
+      useButton,
+      useSelect,
+      types,
+      direction,
+      ...rest
+    } = this.props;
     const { showContent } = this.context[GATHER_UI_DROPDOWN];
     const createRef = trigger => {
       this.trigger = trigger;
@@ -31,7 +38,7 @@ class DropdownTrigger extends Component {
       dropdown__trigger: !useButton && !useSelect
     });
 
-    const buttonTypes = [...types, useSelect ? 'outline' : 'primary'];
+    const buttonTypes = useSelect ? types.concat('outline') : types;
 
     if (useButton || useSelect) {
       return (

--- a/tests/Dropdown/DropdownTrigger.spec.js
+++ b/tests/Dropdown/DropdownTrigger.spec.js
@@ -28,9 +28,8 @@ describe('Dropdown Trigger', () => {
 
   test('rendering a Button component as the trigger', () => {
     wrapper.setProps({ useButton: true });
-    const { types, onClick } = wrapper.find(Button).props();
+    const { onClick } = wrapper.find(Button).props();
     onClick();
-    expect(types).toEqual(['primary']);
     expect(toggleShowContentMock).toHaveBeenCalledTimes(1);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5999,13 +5999,6 @@ nodemon@^1.18.11:
     undefsafe "^2.0.2"
     update-notifier "^2.5.0"
 
-nomnom@~1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
-  dependencies:
-    colors "0.5.x"
-    underscore "~1.4.4"
-
 noms@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
@@ -7901,15 +7894,11 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-semver@^5.4.1, semver@^5.6.0:
+semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
 
@@ -8720,10 +8709,6 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-underscore@~1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
-
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -9089,7 +9074,7 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
-    
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
# Issue
## Issue
The following UI issue was raised:

![Screen Recording 2019-04-25 at 10 19 am](https://user-images.githubusercontent.com/25352812/56799974-e196cd00-6811-11e9-9308-667043094d54.gif)
## Cause
The code change that caused the issue was: https://github.com/gathercontent/gather-ui/pull/449/files
## Explanation
Before the change, `<Dropdown.Trigger />` set it's button types on this line https://github.com/gathercontent/gather-ui/blob/41ec7cb8d65001847b3e68a457a6deee4df5482d/lib/Dropdown/DropdownTrigger.js#L34

However if a `types` prop was passed into `<Dropdown.Trigger />`, they would overwrite the internally set types (`{...rest}` was overwriting `types`) https://github.com/gathercontent/gather-ui/blob/41ec7cb8d65001847b3e68a457a6deee4df5482d/lib/Dropdown/DropdownTrigger.js#L40-L42 This was unintended behaviour.

The change I made to [<Dropdown.Trigger /> ](https://github.com/gathercontent/gather-ui/pull/449/files#diff-86e36a5fa72a075c30c5084921d7f083) meant that `{..rest}` no longer overrode `types`. 

This meant that in places where the internally set type `primary` was normally overwritten, it suddenly became active and messed up a load of styling.

# Fix
- Updated `<Dropdown.Trigger />` to not add the `primary` type as it wasn't being used anywhere previously, and now only messed up styles.