### PR TITLE
fix button backgrounds on safari

### DIFF
--- a/lib/Button/styles.scss
+++ b/lib/Button/styles.scss
@@ -263,7 +263,7 @@ $btn-border-radius: 3px !default;
 .button--outline {
   border: 1px solid $color-border-base;
   outline: none;
-
+  background: none;
   &:focus {
     background: $neutral-lightest;
     border-color: $neutral-base;

--- a/lib/ConfirmationDropdown/styles.scss
+++ b/lib/ConfirmationDropdown/styles.scss
@@ -20,7 +20,7 @@
 
 .confirmation-dropdown__cancel {
   color: $neutral-base;
-
+  background: none;
   &:hover {
     color: $neutral-dark;
   }
@@ -28,6 +28,7 @@
 
 .confirmation-dropdown__confirm-trigger {
   position: relative;
+  background: none;
   z-index: 1;
   &:disabled {
     background: none;


### PR DESCRIPTION
As the title says, this should stop this:

<img width="375" alt="Screen Shot 2019-05-02 at 10 24 14" src="https://user-images.githubusercontent.com/12775966/57066612-8e66c380-6cc4-11e9-9701-5f39808a1b09.png">
