### PR TITLE
Progress button updates & utility classes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["react", "es2015", "stage-0"],
-  "plugins": ["inline-react-svg"]
+  "plugins": ["babel-polyfill", "inline-react-svg"]
 }

--- a/lib/ProgressButton/index.js
+++ b/lib/ProgressButton/index.js
@@ -9,7 +9,8 @@ class ProgressButton extends Component {
     callbackCanExecute: true,
     showSpinner: false,
     useShowSpinnerProp: false,
-    disabled: false
+    disabled: false,
+    autoSpinner: false
   };
 
   static propTypes = {
@@ -20,7 +21,8 @@ class ProgressButton extends Component {
     callbackCanExecute: PropTypes.bool,
     showSpinner: PropTypes.bool,
     useShowSpinnerProp: PropTypes.bool,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+    autoSpinner: PropTypes.bool
   };
 
   constructor(props) {
@@ -29,8 +31,6 @@ class ProgressButton extends Component {
     this.state = {
       showSpinner: false
     };
-
-    this.clickHandler = this.clickHandler.bind(this);
   }
 
   getSpinningState() {
@@ -50,12 +50,15 @@ class ProgressButton extends Component {
     this.setState({ showSpinner: true });
   }
 
-  clickHandler(e) {
+  clickHandler = async e => {
     if (this.props.callbackCanExecute) {
       this.showSpinner();
-      this.props.clickHandler(e);
+      await this.props.clickHandler(e);
+      if (this.props.autoSpinner) {
+        this.setState({ showSpinner: false });
+      }
     }
-  }
+  };
 
   render() {
     let content = null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill';
+
 export * as constants from './constants';
 export Avatar from './Avatar';
 export AvatarGroup from './AvatarGroup';

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "bootstrap": "3.4.1",
     "bootstrap-sass": "^3.3.7",
     "classnames": "^2.2.5",

--- a/styles/helpers/_text.scss
+++ b/styles/helpers/_text.scss
@@ -15,3 +15,29 @@
     text-decoration: underline;
   }
 }
+
+.danger-text {
+  color: $primary-red-darker;
+}
+
+.typo-size-xlarge {
+  font-size: $typo-size-xlarge;
+}
+.typo-size-large {
+  font-size: $typo-size-large;
+}
+.typo-size-lead {
+  font-size: $typo-size-lead;
+}
+.typo-size-base {
+  font-size: $typo-size-base;
+}
+.typo-size-slight {
+  font-size: $typo-size-slight;
+}
+.typo-size-small {
+  font-size: $typo-size-small;
+}
+.typo-size-micro {
+  font-size: $typo-size-micro;
+}

--- a/tests/ProgressButton/index.js
+++ b/tests/ProgressButton/index.js
@@ -32,6 +32,14 @@ describe('ProgressButton', () => {
     expect(wrapper.find('.progress-button__icon')).toHaveLength(1);
   });
 
+  test('sets the showSpinner state back to false if autoSpinner is true', async () => {
+    const clickHandlerSpy = jest.fn();
+    wrapper.setProps({ clickHandler: clickHandlerSpy, autoSpinner: true });
+    await wrapper.instance().clickHandler();
+    wrapper.update();
+    expect(wrapper.state().showSpinner).toBe(false);
+  });
+
   test('sets a disabled state', () => {
     wrapper.setProps({ disabled: true });
     expect(wrapper.find(Button).prop('disabled')).toEqual(true);


### PR DESCRIPTION
Added an autoSpinner prop to ProgressButton so the spinner stops displaying if the clickHandler has resolved.

Because I'm using async await I've had to add in babel-polyfill, if this isnt agreeable I can just use boring old `.then` 

Also I've added some utility classes, let me know what you think, I dont think we should have a utility class for everything or use these everywhere, but some font sizes and possibly colours will save us a load of custom override styles :) 