### PR TITLE
Subscription toggle inside conversation now uses the conversation id

### DIFF
--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -99,6 +99,7 @@ class Conversation extends Component {
                     labelRight="Subscribe"
                     clickHandler={this.props.onSubscribeChange}
                     checked={this.props.isSubscribed}
+                    id={id}
                   />
                 )}
                 <div className="conversation__resolve">

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -99,7 +99,7 @@ class Conversation extends Component {
                     labelRight="Subscribe"
                     clickHandler={this.props.onSubscribeChange}
                     checked={this.props.isSubscribed}
-                    id={id}
+                    id={`${id}-subscribe`}
                   />
                 )}
                 <div className="conversation__resolve">


### PR DESCRIPTION
`Conversation` needs to provide `CheckToggle` with an id for it to be able to be clickable. It now passes the conversation id into it.