### PR TITLE
CheckToggle will now also look at its props to see whether it is checked

### DIFF
--- a/lib/CheckToggle/README.md
+++ b/lib/CheckToggle/README.md
@@ -3,26 +3,6 @@ Represents a toggle, can be true or false.
 
 ## Usage
 
-
-    className: PropTypes.string,
-    id: PropTypes.string.isRequired,
-    checked: PropTypes.bool,
-    clickHandler: PropTypes.func,
-    labelLeft: PropTypes.string,
-    labelRight: PropTypes.string,
-    displaySmall: PropTypes.bool,
-    displayChecked: PropTypes.bool,
-    autoToggle: PropTypes.bool
-
-    labelLeft: null,
-    labelRight: null,
-    clickHandler() {},
-    checked: false,
-    className: '',
-    displaySmall: false,
-    displayChecked: false,
-    autoToggle: true
-
 ### Props
 
 | Name                  | Type          | Default       | Required | Description                                         |

--- a/lib/CheckToggle/README.md
+++ b/lib/CheckToggle/README.md
@@ -1,0 +1,46 @@
+# CheckToggle
+Represents a toggle, can be true or false.
+
+## Usage
+
+
+    className: PropTypes.string,
+    id: PropTypes.string.isRequired,
+    checked: PropTypes.bool,
+    clickHandler: PropTypes.func,
+    labelLeft: PropTypes.string,
+    labelRight: PropTypes.string,
+    displaySmall: PropTypes.bool,
+    displayChecked: PropTypes.bool,
+    autoToggle: PropTypes.bool
+
+    labelLeft: null,
+    labelRight: null,
+    clickHandler() {},
+    checked: false,
+    className: '',
+    displaySmall: false,
+    displayChecked: false,
+    autoToggle: true
+
+### Props
+
+| Name                  | Type          | Default       | Required | Description                                         |
+| --------------------- |-------------- | ------------- | -------- |---------------------------------------------------- |
+| className             | string        | ''            | No       | Any extra CSS classes                               |
+| id                    | string        | n/a           | Yes      | The id attribute for the input.                     |
+| checked               | bool          | false         | No       | Whether the toggle is on or off                     |
+| clickHandler          | func          | () => {}      | No       | Handler for when the toggle is clicked              |
+| labelLeft             | string        | null          | No       | Label to the left of the toggle                     |
+| labelRight            | string        | null          | No       | Label to the right of the toggle                    |
+| displaySmall          | bool          | false         | No       | Whether to use the small version of the toggle      |
+| displayChecked        | bool          | false         | No       | Whether to apply the green styling when checked     |
+| autoToggle            | bool          | true          | No       | True for controlled component, false to use props   |
+
+```
+<CheckToggle 
+    labelLeft="Label left" 
+    id="test" 
+    labelRight="Label right" 
+/>
+```

--- a/lib/CheckToggle/index.js
+++ b/lib/CheckToggle/index.js
@@ -11,7 +11,8 @@ class CheckToggle extends Component {
     labelLeft: PropTypes.string,
     labelRight: PropTypes.string,
     displaySmall: PropTypes.bool,
-    displayChecked: PropTypes.bool
+    displayChecked: PropTypes.bool,
+    autoToggle: PropTypes.bool
   };
 
   static defaultProps = {
@@ -21,7 +22,8 @@ class CheckToggle extends Component {
     checked: false,
     className: '',
     displaySmall: false,
-    displayChecked: false
+    displayChecked: false,
+    autoToggle: true
   };
 
   constructor(props) {
@@ -49,9 +51,13 @@ class CheckToggle extends Component {
       displayChecked
     } = this.props;
 
+    const checked = this.props.autoToggle
+      ? this.state.checked
+      : this.props.checked;
+
     const additionalClasses = cx(`toggle-wrapper ${className}`, {
       'size-small': displaySmall,
-      'is-checked': displayChecked && (this.props.checked || this.state.checked)
+      'is-checked': displayChecked && checked
     });
 
     return (
@@ -60,7 +66,7 @@ class CheckToggle extends Component {
         <span className="toggle-wrapper__inner">
           <input
             onChange={this.onClickHandler}
-            checked={this.props.checked || this.state.checked}
+            checked={checked}
             type="checkbox"
             id={id}
             className="toggle-switch toggle-switch--inline"

--- a/lib/CheckToggle/index.js
+++ b/lib/CheckToggle/index.js
@@ -51,7 +51,7 @@ class CheckToggle extends Component {
 
     const additionalClasses = cx(`toggle-wrapper ${className}`, {
       'size-small': displaySmall,
-      'is-checked': displayChecked && this.state.checked
+      'is-checked': displayChecked && (this.props.checked || this.state.checked)
     });
 
     return (
@@ -60,7 +60,7 @@ class CheckToggle extends Component {
         <span className="toggle-wrapper__inner">
           <input
             onChange={this.onClickHandler}
-            checked={this.state.checked}
+            checked={this.props.checked || this.state.checked}
             type="checkbox"
             id={id}
             className="toggle-switch toggle-switch--inline"

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -100,6 +100,7 @@ class Conversation extends Component {
                     clickHandler={this.props.onSubscribeChange}
                     checked={this.props.isSubscribed}
                     id={`${id}-subscribe`}
+                    autoToggle={false}
                   />
                 )}
                 <div className="conversation__resolve">


### PR DESCRIPTION
The checked prop was only used in the constructor, meaning that when the prop changes the checked state doesn't reflect it. 