### PR TITLE
decreasing space between label and toggle in CheckToggle

### DIFF
--- a/lib/CheckToggle/styles.scss
+++ b/lib/CheckToggle/styles.scss
@@ -109,7 +109,7 @@ $borderColour: #F8FBFC;
     margin-left: $layout-spacing-base/2;
   }
   .toggle-wrapper__label {
-    margin: 0 0 0 $layout-spacing-base/2;
+    margin: 0 0 0 $layout-spacing-base/4;
   }
   .toggle-wrapper__inner {
     max-height: $layout-spacing-base;


### PR DESCRIPTION
It also decreases margin to the label left, however we don't use that anywhere so it doesn't effect anything.