### PR TITLE
Add media only modal modifier

### DIFF
--- a/lib/ButtonGroup/ButtonGroup.js
+++ b/lib/ButtonGroup/ButtonGroup.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ButtonGroup = ({ children }) => (
+  <div className="button-group">{children}</div>
+);
+
+ButtonGroup.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired
+};
+
+export default ButtonGroup;

--- a/lib/ButtonGroup/README.md
+++ b/lib/ButtonGroup/README.md
@@ -1,0 +1,18 @@
+# ButtonGroup
+A group wrapper for buttons.
+
+## Usage
+
+### Props
+
+| Name                  | Type          | Default       | Required | Description                                         |
+| --------------------- |-------------- | ------------- | -------- |---------------------------------------------------- |
+| children              | node(s)       | n/a           | Yes      | All buttons relevant to the group.  |
+
+```
+<ButtonGroup>
+  <Button>...</Button>
+  <Button>...</Button>
+  <Button>...</Button>
+</ButtonGroup>
+```

--- a/lib/ButtonGroup/styles.scss
+++ b/lib/ButtonGroup/styles.scss
@@ -1,0 +1,37 @@
+/* ==========================================================================
+   Config
+   ========================================================================== */
+
+$button-group-default-background: $neutral-lightest;
+
+/* ==========================================================================
+   Styles
+   ========================================================================== */
+
+.button-group {
+  background: $button-group-default-background;
+  padding: 0 $layout-spacing-base/2;
+  border-radius: $btn-border-radius;
+
+  .button {
+    margin: 0;
+    border-radius: 0;
+    padding: $layout-spacing-base/1.5;
+  }
+
+  .button--icon-only {
+    &:hover path {
+      fill: $neutral-dark;
+    }
+
+    &:active path {
+      fill: $neutral-base;
+    }
+  }
+}
+
+/* ==========================================================================
+   Modifiers
+   ========================================================================== */
+
+

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -4,7 +4,15 @@ import BootstrapModal from 'react-bootstrap/lib/Modal';
 import cx from 'classnames';
 
 const Modal = props => {
-  const { size, highlight, overflow, overflowHalf, ...rest } = props;
+  const {
+    size,
+    highlight,
+    overflow,
+    overflowHalf,
+    mediaOnly,
+    collapse,
+    ...rest
+  } = props;
   const classNames = cx(props.className, {
     'modal--small': size === 'small',
     'modal--large': size === 'large',
@@ -12,7 +20,9 @@ const Modal = props => {
     'modal--full-screen': size === 'full-screen',
     'modal--highlight': highlight,
     'modal--overflow': overflow,
-    'modal--overflow-half': overflowHalf
+    'modal--overflow-half': overflowHalf,
+    'modal--media-only': mediaOnly,
+    'modal--collapse': collapse
   });
 
   return (
@@ -27,6 +37,8 @@ Modal.defaultProps = {
   className: '',
   overflow: false,
   overflowHalf: false,
+  mediaOnly: false,
+  collapse: false,
   highlight: false
 };
 
@@ -36,6 +48,8 @@ Modal.propTypes = {
   className: PropTypes.string,
   overflow: PropTypes.bool,
   overflowHalf: PropTypes.bool,
+  mediaOnly: PropTypes.bool,
+  collapse: PropTypes.bool,
   highlight: PropTypes.bool
 };
 

--- a/lib/Modal/styles.scss
+++ b/lib/Modal/styles.scss
@@ -188,3 +188,72 @@ $modal-column-padding: $modal-padding !default;
 	color: rgb(76, 88, 96);
 	border-right: 1px solid rgb(229, 233, 238);
 }
+
+.modal--collapse {
+	.modal-body {
+		padding: 0;
+	}
+}
+
+.modal--media-only {
+	.modal-dialog {
+		height: 100%;
+		width: 100%;
+		display: flex;
+		margin: 0;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.modal-header {
+		position: absolute;
+		right: 0;
+		border: 0;
+		background: $neutral-lightest;
+		z-index: 2;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 0 4px 0 4px;
+
+		.close {
+			position: relative;
+			top: 0;
+			right: 0;
+			transform: none;
+			width: 30px;
+			height: 30px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+
+			&:hover {
+				color: $neutral-dark;
+				opacity: 1;
+				outline: 0;
+			}
+		}
+
+		.modal-header-inner {
+			display: none;
+		}
+	}
+
+	.modal-footer {
+		position: absolute;
+		width: 100%;
+		display: flex;
+		justify-content: center;
+		background: none;
+		border: 0;
+	}
+
+	.modal-content,
+	.modal-body {
+		background: none;
+	}
+
+	img {
+		display: block;
+	}
+}

--- a/lib/Modal/styles.scss
+++ b/lib/Modal/styles.scss
@@ -10,6 +10,8 @@ $modal-padding: $layout-spacing-base !default;
 $modal-heading-font-size: $typo-size-large !default;
 $modal-column-padding: $modal-padding !default;
 
+$modal-media-close-dimensions: 30px;
+
 /* ==========================================================================
    Styles
    ========================================================================== */
@@ -221,8 +223,8 @@ $modal-column-padding: $modal-padding !default;
 			top: 0;
 			right: 0;
 			transform: none;
-			width: 30px;
-			height: 30px;
+			width: $modal-media-close-dimensions;
+			height: $modal-media-close-dimensions;
 			display: flex;
 			align-items: center;
 			justify-content: center;

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ export BoundaryClickWatcher from './BoundaryClickWatcher';
 export Button from './Button';
 export ButtonWithTooltip from './Button/ButtonWithTooltip';
 export ButtonWithIcon from './Button/ButtonWithIcon';
+export ButtonGroup from './ButtonGroup/ButtonGroup';
 export CheckToggle from './CheckToggle';
 export Notification from './Notification';
 export Dropdown from './Dropdown';

--- a/stories/components/Modals.js
+++ b/stories/components/Modals.js
@@ -8,10 +8,10 @@ import FormGroup from 'react-bootstrap/lib/FormGroup';
 import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import {
   Modal,
-  Button,
+  Button, ButtonGroup,
   ConfirmationModal,
   withModalTrigger,
-  FormModal, StatusIndicator, DueDatePicker
+  FormModal, StatusIndicator, DueDatePicker, Icon
 } from "../../lib";
 import StoryItem from '../styleguide/StoryItem';
 
@@ -388,6 +388,30 @@ storiesOf('Components', module).add('Modals', () => (
             <FormControl />
           </FormGroup>
         </StatefulFormModal>
+      </ModalTrigger>
+    </StoryItem>
+
+    <StoryItem
+      title="Media only modal"
+      description="A modal which is used for displaying larger formats of files such as images."
+    >
+      <ModalTrigger>
+        <Modal.Container collapse mediaOnly size="full-screen">
+          <Modal.Header />
+          <Modal.Body>
+            <img src="https://icelanddefrosted.files.wordpress.com/2013/09/20130926-144345.jpg?w=922" alt="A lovely pic!" />
+          </Modal.Body>
+          <Modal.Footer>
+            <ButtonGroup>
+              <Button onClick={() => {}} types={['icon-only']}>
+                <Icon name="download" />
+              </Button>
+              <Button onClick={() => {}} types={['icon-only']}>
+                <Icon name="trash" />
+              </Button>
+            </ButtonGroup>
+          </Modal.Footer>
+        </Modal.Container>
       </ModalTrigger>
     </StoryItem>
   </div>

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -2,6 +2,7 @@
 @import '../../lib/AvatarGroup/styles.scss';
 @import '../../lib/BoundaryClickWatcher/styles.scss';
 @import '../../lib/Button/styles.scss';
+@import '../../lib/ButtonGroup/styles.scss';
 @import '../../lib/ConfirmationOverlay/styles.scss';
 @import '../../lib/Avatar/styles.scss';
 @import '../../lib/CheckToggle/styles.scss';


### PR DESCRIPTION
This PR adds some additional modifiers to the modal component. The new modifier allows us to present media (images mainly) without the need for the surrounding modal bootstrapping UI.