### PR TITLE
Modal updates & a new ImageLoader component

### DIFF
--- a/lib/Modal/ModalHeader.js
+++ b/lib/Modal/ModalHeader.js
@@ -12,12 +12,13 @@ const ModalHeader = ({ children, text, ...props }) => (
 );
 
 ModalHeader.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   closeButton: PropTypes.bool,
   text: PropTypes.string
 };
 
 ModalHeader.defaultProps = {
+  children: null,
   closeButton: true,
   text: null
 };

--- a/lib/Modal/styles.scss
+++ b/lib/Modal/styles.scss
@@ -205,6 +205,7 @@ $modal-media-close-dimensions: 30px;
 		margin: 0;
 		justify-content: center;
 		align-items: center;
+		pointer-events: none;
 	}
 
 	.modal-header {
@@ -253,9 +254,12 @@ $modal-media-close-dimensions: 30px;
 	.modal-content,
 	.modal-body {
 		background: none;
+		pointer-events: auto;
 	}
 
 	img {
 		display: block;
+		max-width: 80vh;
+		max-height: 60vh;
 	}
 }

--- a/lib/images/ImageLoader/README.md
+++ b/lib/images/ImageLoader/README.md
@@ -7,17 +7,17 @@ A component which adds visual ques for loading, loaded and failing to load image
 | ---------------- | ------- | ---------- | -------- |------------------------------------------------------------------------------ |
 | alt              | String  |            | Yes      | The alt text of an image. |
 | src              | String  |            | Yes      | The src of an image. |
-| setLoadedDimensions | Bool | false      | No       | Sets the dimensions of the loaded image to the containing div. |
-| preLoadStyles     | Shape  | {}         | No       | Styles applied to the image when loading the image. Handy if you know the dimensions of the incoming image. |
-| onLoad            | Func   | () => {}   | No       | A function called onLoad. |
-| onError           | Func   | () => {}   | No       | A function called onError. |
+| setContainerToImageSize | Bool | false      | No       | Sets the dimensions of the loaded image to the containing div. |
+| preLoadedStyles  | Object | {}         | No       | Styles applied to the image when loading the image. Handy if you know the dimensions of the incoming image. |
+| onLoad           | Func   | () => {}   | No       | A function called onLoad. |
+| onError          | Func   | () => {}   | No       | A function called onError. |
 
 ### Usage
 ```
 <ImageLoader
   src="/src/of/image/100/100"
   alt="a 100x100 image"
-  preLoadStyles={{
+  preLoadedStyles={{
     minHeight: '100px'
   }}
 />

--- a/lib/images/ImageLoader/README.md
+++ b/lib/images/ImageLoader/README.md
@@ -1,0 +1,24 @@
+# ImageLoader
+A component which adds visual ques for loading, loaded and failing to load images.
+
+### Props
+
+| Name             | Type    | Default    | Required | Description                                                                   |
+| ---------------- | ------- | ---------- | -------- |------------------------------------------------------------------------------ |
+| alt              | String  |            | Yes      | The alt text of an image. |
+| src              | String  |            | Yes      | The src of an image. |
+| setLoadedDimensions | Bool | false      | No       | Sets the dimensions of the loaded image to the containing div. |
+| preLoadStyles     | Shape  | {}         | No       | Styles applied to the image when loading the image. Handy if you know the dimensions of the incoming image. |
+| onLoad            | Func   | () => {}   | No       | A function called onLoad. |
+| onError           | Func   | () => {}   | No       | A function called onError. |
+
+### Usage
+```
+<ImageLoader
+  src="/src/of/image/100/100"
+  alt="a 100x100 image"
+  preLoadStyles={{
+    minHeight: '100px'
+  }}
+/>
+```

--- a/lib/images/ImageLoader/index.js
+++ b/lib/images/ImageLoader/index.js
@@ -7,15 +7,15 @@ class ImageLoader extends PureComponent {
   static propTypes = {
     alt: PropTypes.string.isRequired,
     src: PropTypes.string.isRequired,
-    setLoadedDimensions: PropTypes.bool,
-    preLoadStyles: PropTypes.shape(),
+    setContainerToImageSize: PropTypes.bool,
+    preLoadedStyles: PropTypes.shape(),
     onLoad: PropTypes.func,
     onError: PropTypes.func
   };
 
   static defaultProps = {
-    setLoadedDimensions: false,
-    preLoadStyles: {},
+    setContainerToImageSize: false,
+    preLoadedStyles: {},
     onLoad: () => {},
     onError: () => {}
   };
@@ -43,8 +43,8 @@ class ImageLoader extends PureComponent {
     const {
       alt,
       src,
-      setLoadedDimensions,
-      preLoadStyles,
+      setContainerToImageSize,
+      preLoadedStyles,
       ...rest
     } = this.props;
     const { imageHasLoaded, imageHasErrored, showImage } = this.state;
@@ -56,20 +56,16 @@ class ImageLoader extends PureComponent {
     });
 
     const loadedStyles =
-      imageHasLoaded && setLoadedDimensions
+      imageHasLoaded && setContainerToImageSize
         ? {
             width: this.image.width,
             height: this.image.height
           }
         : {};
 
-    const containerStyles = !showImage
-      ? {
-          ...loadedStyles
-        }
-      : {};
+    const containerStyles = showImage ? {} : loadedStyles;
 
-    const imageStyles = !showImage || imageHasErrored ? preLoadStyles : {};
+    const imageStyles = !showImage || imageHasErrored ? preLoadedStyles : {};
 
     return (
       <div className={classNames} style={containerStyles}>

--- a/lib/images/ImageLoader/index.js
+++ b/lib/images/ImageLoader/index.js
@@ -27,7 +27,7 @@ class ImageLoader extends PureComponent {
   };
 
   showImage = () =>
-    window.requestAnimationFrame(this.setState({ showImage: true }));
+    window.requestAnimationFrame(() => this.setState({ showImage: true }));
 
   handleOnLoad = () => {
     this.props.onLoad();

--- a/lib/images/ImageLoader/index.js
+++ b/lib/images/ImageLoader/index.js
@@ -1,0 +1,98 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Icon } from '../..';
+
+class ImageLoader extends PureComponent {
+  static propTypes = {
+    alt: PropTypes.string.isRequired,
+    src: PropTypes.string.isRequired,
+    setLoadedDimensions: PropTypes.bool,
+    preLoadStyles: PropTypes.shape(),
+    onLoad: PropTypes.func,
+    onError: PropTypes.func
+  };
+
+  static defaultProps = {
+    setLoadedDimensions: false,
+    preLoadStyles: {},
+    onLoad: () => {},
+    onError: () => {}
+  };
+
+  state = {
+    imageHasLoaded: false,
+    showImage: false,
+    imageHasErrored: false
+  };
+
+  showImage = () =>
+    window.requestAnimationFrame(this.setState({ showImage: true }));
+
+  handleOnLoad = () => {
+    this.props.onLoad();
+    this.setState({ imageHasLoaded: true }, this.showImage);
+  };
+
+  handleOnError = () => {
+    this.props.onError();
+    this.setState({ imageHasErrored: true });
+  };
+
+  render() {
+    const {
+      alt,
+      src,
+      setLoadedDimensions,
+      preLoadStyles,
+      ...rest
+    } = this.props;
+    const { imageHasLoaded, imageHasErrored, showImage } = this.state;
+
+    const classNames = cx('image-loader', {
+      'image-loader--loaded': imageHasLoaded,
+      'image-loader--errored': imageHasErrored,
+      'image-loader--show': showImage
+    });
+
+    const loadedStyles =
+      imageHasLoaded && setLoadedDimensions
+        ? {
+            width: this.image.width,
+            height: this.image.height
+          }
+        : {};
+
+    const containerStyles = !showImage
+      ? {
+          ...loadedStyles
+        }
+      : {};
+
+    const imageStyles = !showImage || imageHasErrored ? preLoadStyles : {};
+
+    return (
+      <div className={classNames} style={containerStyles}>
+        <img
+          {...rest}
+          style={imageStyles}
+          onLoad={this.handleOnLoad}
+          onError={this.handleOnError}
+          alt={alt}
+          src={src}
+          ref={image => {
+            this.image = image;
+          }}
+        />
+
+        {!showImage && !imageHasErrored && <Icon name="loader" />}
+
+        {imageHasErrored && (
+          <Icon name="cross" text="Oops, this image seems to be missing." />
+        )}
+      </div>
+    );
+  }
+}
+
+export default ImageLoader;

--- a/lib/images/ImageLoader/index.js
+++ b/lib/images/ImageLoader/index.js
@@ -56,19 +56,19 @@ class ImageLoader extends PureComponent {
     });
 
     const loadedStyles =
-      imageHasLoaded && setContainerToImageSize
+      imageHasLoaded && !showImage && setContainerToImageSize
         ? {
             width: this.image.width,
             height: this.image.height
           }
         : {};
 
-    const containerStyles = showImage ? {} : loadedStyles;
+    // const containerStyles = showImage ? {} : loadedStyles;
 
     const imageStyles = !showImage || imageHasErrored ? preLoadedStyles : {};
 
     return (
-      <div className={classNames} style={containerStyles}>
+      <div className={classNames} style={loadedStyles}>
         <img
           {...rest}
           style={imageStyles}

--- a/lib/images/ImageLoader/styles.scss
+++ b/lib/images/ImageLoader/styles.scss
@@ -2,38 +2,43 @@
    Config
    ========================================================================== */
 
-$button-group-default-background: $neutral-lightest;
-
 /* ==========================================================================
    Styles
    ========================================================================== */
 
-.button-group {
-  background: $button-group-default-background;
-  padding: 0 $layout-spacing-base/2;
-  border-radius: $btn-border-radius;
+.image-loader {
+  background: $neutral-lightest;
+  transition: all $animation-time-micro;
   display: flex;
   align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  overflow: hidden;
 
-  .button {
-    margin: 0;
-    border-radius: 0;
-    padding: $layout-spacing-base/1.5;
+  img {
+    transition: all $animation-time-micro;
+    opacity: 0;
   }
+}
 
-  .button--icon-only {
-    &:hover path {
-      fill: $neutral-dark;
-    }
-
-    &:active path {
-      fill: $neutral-base;
-    }
-  }
+.icon {
+  position: absolute;
 }
 
 /* ==========================================================================
    Modifiers
    ========================================================================== */
 
+.image-loader--show {
+  background: none;
 
+  img {
+    opacity: 1;
+  }
+}
+
+.image-loader--errored {
+  path {
+    fill: $primary-red;
+  }
+}

--- a/lib/images/ImageLoader/styles.scss
+++ b/lib/images/ImageLoader/styles.scss
@@ -19,10 +19,10 @@
     transition: all $animation-time-micro;
     opacity: 0;
   }
-}
 
-.icon {
-  position: absolute;
+  .icon {
+    position: absolute;
+  }
 }
 
 /* ==========================================================================

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,3 +89,4 @@ export PricingToggle from './PricingToggle/PricingToggle';
 export PricingToggleItem from './PricingToggle/PricingToggleItem';
 export SectionFeature from './SectionFeature/SectionFeature';
 export UserSearch from './UserSearch';
+export ImageLoader from './images/ImageLoader';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gather-content-ui",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gather-content-ui",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "description": "GatherContent UI Library",
   "main": "dist/lib/index.js",
   "repository": {

--- a/stories/components/Modals.js
+++ b/stories/components/Modals.js
@@ -11,7 +11,7 @@ import {
   Button, ButtonGroup,
   ConfirmationModal,
   withModalTrigger,
-  FormModal, StatusIndicator, DueDatePicker, Icon
+  FormModal, StatusIndicator, DueDatePicker, Icon, ImageLoader
 } from "../../lib";
 import StoryItem from '../styleguide/StoryItem';
 
@@ -399,7 +399,14 @@ storiesOf('Components', module).add('Modals', () => (
         <Modal.Container collapse mediaOnly size="full-screen">
           <Modal.Header />
           <Modal.Body>
-            <img src="https://icelanddefrosted.files.wordpress.com/2013/09/20130926-144345.jpg?w=922" alt="A lovely pic!" />
+            <ImageLoader
+              src="https://fillmurray.com/g/500/500"
+              alt="A lovely pic!"
+              loadingStyle={{
+                width: 400,
+                height: 400
+              }}
+            />
           </Modal.Body>
           <Modal.Footer>
             <ButtonGroup>

--- a/stories/components/Modals.js
+++ b/stories/components/Modals.js
@@ -402,10 +402,11 @@ storiesOf('Components', module).add('Modals', () => (
             <ImageLoader
               src="https://fillmurray.com/g/500/500"
               alt="A lovely pic!"
-              loadingStyle={{
-                width: 400,
-                height: 400
+              preLoadStyles={{
+                width: '500px',
+                height: '500px'
               }}
+              setLoadedDimensions
             />
           </Modal.Body>
           <Modal.Footer>

--- a/stories/components/Modals.js
+++ b/stories/components/Modals.js
@@ -402,11 +402,11 @@ storiesOf('Components', module).add('Modals', () => (
             <ImageLoader
               src="https://fillmurray.com/g/500/500"
               alt="A lovely pic!"
-              preLoadStyles={{
+              preLoadedStyles={{
                 width: '500px',
                 height: '500px'
               }}
-              setLoadedDimensions
+              setContainerToImageSize
             />
           </Modal.Body>
           <Modal.Footer>

--- a/stories/components/images/ImageLoader.js
+++ b/stories/components/images/ImageLoader.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Col, Row } from "react-bootstrap";
+import { ImageLoader } from '../../../lib';
+import StoryItem from '../../styleguide/StoryItem';
+
+storiesOf('Components', module).add('ImageLoader', () => (
+  <div>
+    <StoryItem
+      title="Image loaders"
+      description="The image loader adds visual ques for states such as loading, loaded and failures for images."
+    >
+      <Row>
+        <Col xs={6}>
+          <ImageLoader src="https://fillmurray.com/g/400/400" alt="Fill Murray" preLoadStyles={{ minHeight: '400px' }} />
+        </Col>
+        <Col xs={6}>
+          <ImageLoader src="" alt="a failed image" preLoadStyles={{ minHeight: '400px' }} />
+        </Col>
+      </Row>
+    </StoryItem>
+  </div>
+));

--- a/stories/components/images/ImageLoader.js
+++ b/stories/components/images/ImageLoader.js
@@ -12,10 +12,10 @@ storiesOf('Components', module).add('ImageLoader', () => (
     >
       <Row>
         <Col xs={6}>
-          <ImageLoader src="https://fillmurray.com/g/400/400" alt="Fill Murray" preLoadStyles={{ minHeight: '400px' }} />
+          <ImageLoader src="https://fillmurray.com/g/400/400" alt="Fill Murray" preLoadedStyles={{ minHeight: '400px' }} />
         </Col>
         <Col xs={6}>
-          <ImageLoader src="" alt="a failed image" preLoadStyles={{ minHeight: '400px' }} />
+          <ImageLoader src="" alt="a failed image" preLoadedStyles={{ minHeight: '400px' }} />
         </Col>
       </Row>
     </StoryItem>

--- a/stories/index.js
+++ b/stories/index.js
@@ -54,3 +54,4 @@ import Breadcrumb from './components/Breadcrumb';
 import SelectionBar from './components/SelectionBar';
 import FinderNavigation from './components/FinderNavigation';
 import UserSearch from './components/UserSearch';
+import ImageLoader from './components/images/ImageLoader';

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -63,3 +63,4 @@
 @import '../../lib/SectionFeature/styles.scss';
 @import '../../lib/TooltipWrapper/styles.scss';
 @import '../../lib/UserSearch/styles.scss';
+@import '../../lib/images/ImageLoader/styles.scss';

--- a/tests/images/ImageLoader.spec.js
+++ b/tests/images/ImageLoader.spec.js
@@ -41,10 +41,4 @@ describe('ImageLoader', () => {
   test('spreads the rest of the props onto the image', () => {
     expect(wrapper.find('img').prop('title')).toBe('hello world');
   });
-
-  test('shows the image', () => {
-    wrapper.find('img').prop('onLoad')();
-    wrapper.update();
-    expect(wrapper.state('showImage')).toBe(true);
-  });
 });

--- a/tests/images/ImageLoader.spec.js
+++ b/tests/images/ImageLoader.spec.js
@@ -1,0 +1,50 @@
+import { React, shallow } from '../setup';
+import { ImageLoader } from '../../lib';
+
+describe('ImageLoader', () => {
+  let wrapper;
+  const onLoadSpy = jest.fn();
+  const onErrorSpy = jest.fn();
+
+  jest.useFakeTimers();
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <ImageLoader
+        alt="alt text"
+        src="/src/"
+        onLoad={onLoadSpy}
+        onError={onErrorSpy}
+        title="hello world"
+      />
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('sets the loaded state when the image loads', () => {
+    wrapper.find('img').prop('onLoad')();
+    wrapper.update();
+    expect(wrapper.state('imageHasLoaded')).toBe(true);
+    expect(onLoadSpy).toHaveBeenCalled();
+  });
+
+  test('sets the errored state when the image fails to load', () => {
+    wrapper.find('img').prop('onError')();
+    wrapper.update();
+    expect(wrapper.state('imageHasErrored')).toBe(true);
+    expect(onErrorSpy).toHaveBeenCalled();
+  });
+
+  test('spreads the rest of the props onto the image', () => {
+    expect(wrapper.find('img').prop('title')).toBe('hello world');
+  });
+
+  test('shows the image', () => {
+    wrapper.find('img').prop('onLoad')();
+    wrapper.update();
+    expect(wrapper.state('showImage')).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR adds some fixes to the media only modal styles so we can't exceed the screen when the image loads. We also add a new component for loading images as at times UI can look pretty shifty when a large chunk of the UI hasn't loaded yet.