### PR TITLE
Change icon for disabled fields

### DIFF
--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -111,7 +111,10 @@ $field-data-p-line-height: 1.688rem !default;
   }
 
   .is-disabled & {
-    cursor: not-allowed;
+    cursor: default;
+    mark.conversation-format {
+      cursor: pointer;
+    }
   }
 }
 


### PR DESCRIPTION
Having the not allowed cursor just caused confusion, so lets switch to just the default one