### PR TITLE
Fix/figure image stretch

### DIFF
--- a/lib/Figure/FigurePreview.js
+++ b/lib/Figure/FigurePreview.js
@@ -49,7 +49,7 @@ const FigurePreview = ({
       <div
         className="figure__thumbnail"
         title={caption}
-        style={{ backgroundImage: `url("${previewSrc}` }}
+        style={{ backgroundImage: `url("${previewSrc}")` }}
         alt={altText}
         aria-hidden="true"
       />

--- a/lib/Figure/FigurePreview.js
+++ b/lib/Figure/FigurePreview.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Icon } from '../index';
 
@@ -39,12 +39,21 @@ const FigurePreview = ({
     );
   }
   return (
-    <img
-      title={caption}
-      src={previewSrc}
-      alt={altText}
-      className="figure__thumbnail"
-    />
+    <Fragment>
+      <img
+        title={caption}
+        src={previewSrc}
+        alt={altText}
+        className="visually-hidden"
+      />
+      <div
+        className="figure__thumbnail"
+        title={caption}
+        style={{ backgroundImage: `url("${previewSrc}` }}
+        alt={altText}
+        aria-hidden="true"
+      />
+    </Fragment>
   );
 };
 

--- a/styles/generic/_global.scss
+++ b/styles/generic/_global.scss
@@ -16,3 +16,11 @@ body {
         @include applyFontSmoothing();
     }
 }
+
+.visually-hidden {
+    position: absolute !important;
+    height: 1px; width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+}

--- a/tests/Figure/FigurePreview.spec.js
+++ b/tests/Figure/FigurePreview.spec.js
@@ -42,6 +42,8 @@ describe('FigurePreview', () => {
       previewSrc: 'http',
       showPreview: true
     });
-    expect(wrapper.find('.figure__thumbnail').props().src).toEqual(`http`);
+    expect(wrapper.find('.figure__thumbnail').props().style).toEqual({
+      backgroundImage: `url("http")`
+    });
   });
 });


### PR DESCRIPTION
### 👀 Overview
This is to fix a bug where file previews would show a stretched image instead of it zoomed in to cover.

This came as a result of a refactoring to a `figure`, and I changed the `div` with `background-image` to an `img` tag... causing the stretching!

### 💬 Description
To keep everything semantic and accessible, we kept the `img` tag and set it to visually hidden. Which is a class I've added, anything that is `visually-hidden` will be picked up by screen readers but not show on the page. I have then made the `div` visible but `aria-hidden`, so that does not come up on the screen reader as it's not very semantic.

### 🔗 Links
https://trello.com/c/sghpxJ8e/165-asset-thumbnails-are-distorted-on-items-score-8

### ✅ Checklist
- [x] Browser tested