### PR TITLE
Styles blank slate content using flexbox

### DIFF
--- a/lib/BlankSlate/styles.scss
+++ b/lib/BlankSlate/styles.scss
@@ -19,6 +19,9 @@
     padding: $layout-spacing-base/2;
     font-size: $typo-size-base;
     color: $neutral-base;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
   &__heading {
     font-size: $typo-size-large;


### PR DESCRIPTION
### 👀 Overview
Styles the blank slate contents layout in exactly the same way, but makes the container `display: flex` instead of `display: block`
### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/1878

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook