### PR TITLE
Added override

### DIFF
--- a/styles/bootstrap/_variable-overrides.scss
+++ b/styles/bootstrap/_variable-overrides.scss
@@ -17,3 +17,6 @@ $screen-lg: 1200px;
 
 // popover
 $popover-border-color: $dropdown-border;
+
+// Breadcrumb
+$breadcrumb-active-color: $neutral-dark;


### PR DESCRIPTION
Bootstrap is messing with some breadcrumb styling due to a var being named the same. This resolves it.