### PR TITLE
Add error states to FormInputs

### DIFF
--- a/lib/Form/FormInput.js
+++ b/lib/Form/FormInput.js
@@ -77,10 +77,13 @@ class FormInput extends Component {
           className={classNames}
           placeholder={placeholder}
           autoFocus={this.props.focusOnMount} // eslint-disable-line jsx-a11y/no-autofocus
+          aria-invalid={hasError}
           {...rest}
         />
         {hasError && errorMessage && (
-          <span className="form-input__error-message">{errorMessage}</span>
+          <span role="alert" className="form-input__error-message">
+            {errorMessage}
+          </span>
         )}
       </Fragment>
     );

--- a/lib/Form/FormInput.js
+++ b/lib/Form/FormInput.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
@@ -12,7 +12,9 @@ class FormInput extends Component {
     onInputChange: PropTypes.func,
     noBorder: PropTypes.bool,
     fullWidth: PropTypes.bool,
-    paddingSmall: PropTypes.bool
+    paddingSmall: PropTypes.bool,
+    hasError: PropTypes.bool,
+    errorMessage: PropTypes.bool
   };
 
   static defaultProps = {
@@ -24,7 +26,9 @@ class FormInput extends Component {
     onInputChange: () => {},
     noBorder: false,
     paddingSmall: false,
-    fullWidth: false
+    fullWidth: false,
+    hasError: false,
+    errorMessage: ''
   };
 
   constructor(props) {
@@ -50,6 +54,8 @@ class FormInput extends Component {
       value,
       fullWidth,
       paddingSmall,
+      hasError,
+      errorMessage,
       ...rest
     } = this.props;
     const inputValue = this.state.value;
@@ -57,19 +63,26 @@ class FormInput extends Component {
     const classNames = cx(`form__input ${className}`, {
       'form__input--noborder': noBorder,
       'form__input--full-width': fullWidth,
-      'form__input--padding-small': paddingSmall
+      'form__input--padding-small': paddingSmall,
+      'form__input--has-error': hasError,
+      'form__input--display-error': hasError && errorMessage
     });
 
     return (
-      <input
-        type={type}
-        value={inputValue}
-        onChange={this.handleOnChange}
-        className={classNames}
-        placeholder={placeholder}
-        autoFocus={this.props.focusOnMount} // eslint-disable-line jsx-a11y/no-autofocus
-        {...rest}
-      />
+      <Fragment>
+        <input
+          type={type}
+          value={inputValue}
+          onChange={this.handleOnChange}
+          className={classNames}
+          placeholder={placeholder}
+          autoFocus={this.props.focusOnMount} // eslint-disable-line jsx-a11y/no-autofocus
+          {...rest}
+        />
+        {hasError && errorMessage && (
+          <span className="form-input__error-message">{errorMessage}</span>
+        )}
+      </Fragment>
     );
   }
 }

--- a/lib/Form/README.md
+++ b/lib/Form/README.md
@@ -40,6 +40,8 @@ An input component used to compose a form.
 | className           | String        | ''        | No       | Adds additional classes to the input. |
 | fullWidth               | Boolean        | false        | No       | Gives the input 100% width |
 | paddingSmall               | Boolean        | false        | No       | Gives the input small padding |
+| hasError            | Boolean        | false        | No       | Toggles error styling for the input |
+| errorMessage        | String         | ''        | No       | display an error message under the input |
 
 # FormGroup
 A wrapper to group form elements.

--- a/lib/Form/styles.scss
+++ b/lib/Form/styles.scss
@@ -123,7 +123,7 @@ $form-checkbox-label-size: $typo-size-lead !default;
   padding: 0;
   background: transparent;
   border: none;
-  font-size: inherit;  
+  font-size: inherit;
 }
 
 .form__input--full-width {
@@ -141,4 +141,17 @@ $form-checkbox-label-size: $typo-size-lead !default;
 .form--disabled {
   opacity: 0.5;
   pointer-events: none;
+}
+
+.form__input.form__input--has-error {
+  border-color: $primary-red;
+}
+
+input.form__input--display-error {
+  margin-bottom: 0;
+}
+
+.form-input__error-message {
+  color: $primary-red;
+  font-size: $typo-size-small;
 }

--- a/tests/Form/FormInput.spec.js
+++ b/tests/Form/FormInput.spec.js
@@ -26,7 +26,8 @@ describe('FormInput', () => {
       value: 'test value',
       placeholder: 'test placeholder',
       onChange: wrapper.instance().handleOnChange,
-      autoFocus: false
+      autoFocus: false,
+      'aria-invalid': false
     });
   });
 

--- a/tests/Form/FormInput.spec.js
+++ b/tests/Form/FormInput.spec.js
@@ -41,6 +41,25 @@ describe('FormInput', () => {
   });
 
   test('sets the correct className', () => {
-    expect(wrapper.hasClass('test-class')).toEqual(true);
+    expect(wrapper.find('input').hasClass('test-class')).toEqual(true);
+  });
+
+  test('adds the has-error class and displays the error message', () => {
+    expect(wrapper.find('input').hasClass('form__input--has-error')).toEqual(
+      false
+    );
+    wrapper.setProps({ hasError: true });
+    expect(wrapper.find('input').hasClass('form__input--has-error')).toEqual(
+      true
+    );
+    expect(wrapper.find('.form-input__error-message')).toHaveLength(0);
+    expect(
+      wrapper.find('input').hasClass('form__input--display-error')
+    ).toEqual(false);
+    wrapper.setProps({ errorMessage: 'oooooops' });
+    expect(
+      wrapper.find('input').hasClass('form__input--display-error')
+    ).toEqual(true);
+    expect(wrapper.find('.form-input__error-message')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
### 👀 Overview
This makes the inputs look all error-y and optionally display an error message depending on props.
### 📹 GIF (optional)
![Screen Shot 2019-07-02 at 12 14 18](https://user-images.githubusercontent.com/12775966/60508671-018bb680-9cc3-11e9-9f80-719c8769020b.png)
### 🚪 Start Points
`lib/Form/FormInput.js`
### 👫 Related PRs (optional)
coming soon...

### ✅ Checklist
- [x] Tests written
- [ ] Browser tested
- [x] Added to documentation
- [ ] Added to storybook