### PR TITLE
Update clock icon

### DIFF
--- a/assets/icons/clock.svg
+++ b/assets/icons/clock.svg
@@ -1,18 +1,8 @@
-<svg width="16" height="16" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Artboard-2" transform="translate(-1033.000000, -699.000000)" fill="#3D8AEB">
-            <g id="Group-5-Copy" transform="translate(990.000000, 142.000000)">
-                <g id="Status" transform="translate(20.000000, 517.000000)">
-                    <g transform="translate(0.000000, 15.000000)" id="Due-date">
-                        <g transform="translate(23.000000, 25.000000)">
-                            <g id="Group-4">
-                                <path d="M12.7,0.3 C12.3,-0.1 11.7,-0.1 11.3,0.3 C10.9,0.7 10.9,1.3 11.3,1.7 L12.1,2.5 L11.2,3.4 C10,2.5 8.6,2 7,2 C3.1,2 0,5.1 0,9 C0,12.9 3.1,16 7,16 C10.9,16 14,12.9 14,9 C14,7.4 13.5,6 12.6,4.8 L13.5,3.9 L14.3,4.7 C14.5,4.9 14.7,5 15,5 C15.3,5 15.5,4.9 15.7,4.7 C16.1,4.3 16.1,3.7 15.7,3.3 L12.7,0.3 L12.7,0.3 Z M7,14 C4.2,14 2,11.8 2,9 C2,6.2 4.2,4 7,4 C9.8,4 12,6.2 12,9 C12,11.8 9.8,14 7,14 L7,14 Z" id="Fill-23"></path>
-                                <polyline id="Fill-24" points="8 6 6 6 6 10 10 10 10 8 8 8 8 6"></polyline>
-                            </g>
-                        </g>
-                    </g>
-                </g>
-            </g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="icon/16/clock/default">
+            <path d="M15,7 C19.4,7 23,10.6 23,15 C23,19.4 19.4,23 15,23 C10.6,23 7,19.4 7,15 C7,10.6 10.6,7 15,7 Z M15,21 C18.3,21 21,18.3 21,15 C21,11.7 18.3,9 15,9 C11.7,9 9,11.7 9,15 C9,18.3 11.7,21 15,21 Z M16,11 L16,14 L19,14 L19,16 L14,16 L14,11 L16,11 Z" id="Combined-Shape"></path>
         </g>
     </g>
 </svg>

--- a/lib/Button/styles.scss
+++ b/lib/Button/styles.scss
@@ -126,6 +126,9 @@ $btn-border-radius: 3px !default;
 .button--danger {
   background: $primary-red;
   color: $color-btn-warning--text;
+  .icon path {
+    fill: $color-btn-warning--text;
+  }
 
   &:hover {
     color: $color-btn-warning--text;
@@ -211,7 +214,9 @@ $btn-border-radius: 3px !default;
 
 .button--icon-only,
 .button--icon-only-padding {
-  background: none;
+  &:not(.button--danger) {
+    background: none;
+  }
   border: none;
   box-shadow: none;
   padding: 0;

--- a/stories/components/Button.js
+++ b/stories/components/Button.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import Button from '../../lib/Button/';
+import Button from "../../lib/Button";
 import ButtonWithTooltip from '../../lib/Button/ButtonWithTooltip';
 import ButtonWithIcon from '../../lib/Button/ButtonWithIcon';
 import ProgressButton from '../../lib/ProgressButton';
@@ -101,6 +101,13 @@ const button = storiesOf('Components', module)
             hideText
           />
         </Button>
+      </StoryItem>
+
+      <StoryItem
+        title="Danger button, Icon only"
+        description="A button with an icon and a red background"
+      >
+        <Button types={['danger', 'icon-only']} clickHandler={action('clickedHandler')}><Icon name="clock" /></Button>
       </StoryItem>
 
       <StoryItem


### PR DESCRIPTION
### 👀 Overview
Update clock icon (I don't think we're using this anywhere, @Cyapow added this in February 2018 when he was working on the Workflow Status Dropdown, I think it was since dropped from the designs??)

### 💬 Description
It will be used on the new content hub to filter overdue items. I've also had to tweak the sass slightly so that an `icon-only` type doesn't override the red background applied from `danger`.

### 🔗 Links

https://projects.invisionapp.com/share/FZSSB9RK4T7#/screens/371764753

### 📹 GIF (optional)
![Jul-02-2019 13-36-00](https://user-images.githubusercontent.com/3472717/60513175-6dbfe780-9cce-11e9-9d94-af31e4f59d3d.gif)

### 🚪 Start Points
Viewing the storybook

### 👫 Related PRs (optional)

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook