### PR TITLE
Folder sidebar styles changes

### DIFF
--- a/lib/FinderNavigation/styles.scss
+++ b/lib/FinderNavigation/styles.scss
@@ -209,6 +209,22 @@ $finder-indent-level-support: 10 !default;
   height: 0px;
 }
 
+.finder__item-new__folder {
+  .finder__item-link-icon {
+    opacity: 0;
+  }
+
+  .finder__item-content {
+    padding: 0;
+    color: $primary-blue;
+
+    &:hover {
+      cursor: pointer;
+      text-decoration: underline;
+    }
+  }
+}
+
 /* ==========================================================================
    Indentation
    ========================================================================== */


### PR DESCRIPTION
### 👀 Overview
A button has been added to the folder navigation in the sidebar to add a new folder. It has a tiny difference in styling.

### 💬 Description
The icon has been styled to be invisible, this is because it is easier than trying to change the indentation logic to handle no icons. 

That's it really.