### PR TITLE
Update/Tooltips Word Break & Default Delay Show Value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+*.swp
 .DS_Store
 .idea
 npm-debug.log

--- a/lib/TooltipWrapper/index.js
+++ b/lib/TooltipWrapper/index.js
@@ -66,7 +66,8 @@ TooltipWrapper.propTypes = {
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     .isRequired,
   hide: PropTypes.bool,
-  clickable: PropTypes.bool
+  clickable: PropTypes.bool,
+  delayShow: PropTypes.number
 };
 
 TooltipWrapper.defaultProps = {
@@ -76,6 +77,7 @@ TooltipWrapper.defaultProps = {
   hide: false,
   tooltipText: '',
   wrapperClassName: '',
+  delayShow: 400,
   clickable: false
 };
 

--- a/lib/TooltipWrapper/index.js
+++ b/lib/TooltipWrapper/index.js
@@ -66,8 +66,7 @@ TooltipWrapper.propTypes = {
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     .isRequired,
   hide: PropTypes.bool,
-  clickable: PropTypes.bool,
-  delayShow: PropTypes.number
+  clickable: PropTypes.bool
 };
 
 TooltipWrapper.defaultProps = {
@@ -77,7 +76,6 @@ TooltipWrapper.defaultProps = {
   hide: false,
   tooltipText: '',
   wrapperClassName: '',
-  delayShow: 400,
   clickable: false
 };
 

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -62,3 +62,4 @@
 @import 'overrides/popover';
 @import 'overrides/dropdown';
 @import 'overrides/daypicker';
+@import 'overrides/bootstrap';

--- a/styles/overrides/_bootstrap.scss
+++ b/styles/overrides/_bootstrap.scss
@@ -1,0 +1,6 @@
+/**
+ * Tooltip
+ */
+.tooltip-inner {
+  word-break: break-word;
+}


### PR DESCRIPTION
### 👀 Overview
Overrides bootstrap styling for tooltips so that words like supercallerfragerlisticexpealidocious break onto a new line if they are longer than the tooltip width.

Adds a default `delayShow` value of 400 to our `<TooltipWrapper />` component.
### 🚪 Start Points
- `styles/overrides/_bootstrap.scss`
- `lib/TooltipWrapper/index.js`
### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/1903

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook