### PR TITLE
Reduce finder panel indentation

### DIFF
--- a/lib/FinderNavigation/styles.scss
+++ b/lib/FinderNavigation/styles.scss
@@ -26,13 +26,12 @@ $finder-indent-level-support: 10 !default;
 }
 
 .finder__item-content {
-  padding-right: $layout-spacing-base/2;
   display: flex;
   cursor: default;
   height: 35px;
   line-height: 35px;
   transition: height 200ms;
-  padding-left: $layout-spacing-base/2;
+  padding: 0 $layout-spacing-base/2;
   .icon path {
     fill: $neutral-base;
   }

--- a/lib/FinderNavigation/styles.scss
+++ b/lib/FinderNavigation/styles.scss
@@ -26,12 +26,13 @@ $finder-indent-level-support: 10 !default;
 }
 
 .finder__item-content {
+  padding-right: $layout-spacing-base/2;
   display: flex;
   cursor: default;
   height: 35px;
   line-height: 35px;
   transition: height 200ms;
-
+  padding-left: $layout-spacing-base/2;
   .icon path {
     fill: $neutral-base;
   }
@@ -101,7 +102,7 @@ $finder-indent-level-support: 10 !default;
   }
 
   &-link-icon {
-    margin-right: $layout-spacing-base/4 + $layout-spacing-base/2;
+    margin-right: $layout-spacing-base/2;
     height: $icon-height;
     width: $icon-width;
     display: flex;
@@ -231,13 +232,10 @@ $finder-indent-level-support: 10 !default;
 
 .finder__item-link {
   width: 100%;
-  padding: 0 $layout-spacing-base/2;
 
   &:hover {
     color: $neutral-dark;
-    background-color: rgba(#ffffff, .3);
-    border-radius: $layout-spacing-base/4;
-    
+
     &.finder__item-new__folder-link{
       text-decoration: underline;
     }
@@ -273,9 +271,7 @@ $finder-indent-level-support: 10 !default;
   #{$finderItemSelector}.finder__item.is-over.dragged-insert
     > .finder__item-content,
   #{$finderItemSelector}.finder__item--selected > .finder__item-content {
-    padding-left: ($layout-spacing-base * 1.5 * $i) +
-      ($layout-spacing-base/2 + $i * 1) -
-      2;
+    padding-left: ($layout-spacing-base * 1.5 * $i) - ($layout-spacing-base/2 * ($i - 1)) - 2;
   }
 
   #{$finderItemSelector} > .finder__item-content,
@@ -283,9 +279,6 @@ $finder-indent-level-support: 10 !default;
     > .finder__item-content,
   #{$finderItemSelector}.finder__item.is-over.dragged-below
     > .finder__item-content {
-    padding-left: ($layout-spacing-base * 1.5 * $i) +
-      $layout-spacing-base/2 +
-      $i *
-      1;
+    padding-left: ($layout-spacing-base * 1.5 * $i) - ($layout-spacing-base/2 * ($i - 1));
   }
 }


### PR DESCRIPTION
### 👀 Overview
Pretty small one, just reducing the padding and indentation for the finder panel items.
### 📹 GIF (optional)
<img width="785" alt="Screen_Shot_2019-07-09_at_12_01_26_and_Screen_Shot_2019-07-09_at_12_01_19" src="https://user-images.githubusercontent.com/12775966/60896702-af1c3e00-a25e-11e9-8e23-ab89f6d3e90d.png">
### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook