### PR TITLE
Update/Pass onStart/StopEdit Actions to <EditableTextWrapper>

### DIFF
--- a/lib/EditableTextWrapper/index.js
+++ b/lib/EditableTextWrapper/index.js
@@ -10,6 +10,8 @@ export default class EditableTextWrapper extends Component {
     children: PropTypes.node.isRequired,
     value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    onStartEditing: PropTypes.func.isRequired,
+    onStopEditing: PropTypes.func.isRequired,
     title: PropTypes.string,
     className: PropTypes.string,
     multiline: PropTypes.bool,
@@ -34,10 +36,12 @@ export default class EditableTextWrapper extends Component {
   }
 
   startEditing = () => {
+    this.props.onStartEditing();
     this.setState({ editing: true });
   };
 
   stopEditing = () => {
+    this.props.onStopEditing();
     this.setState({ editing: false });
   };
 

--- a/tests/EditableTextWrapper/index.js
+++ b/tests/EditableTextWrapper/index.js
@@ -4,11 +4,21 @@ import { EditableTextWrapper, Button, ExpandingTextArea } from '../../lib';
 describe('EditableTextWrapper', () => {
   let wrapper;
   let onChangeSpy;
+  let onStartEditingSpy;
+  let onStopEditingSpy;
 
   beforeEach(() => {
     onChangeSpy = jest.fn();
+    onStartEditingSpy = jest.fn();
+    onStopEditingSpy = jest.fn();
+
     wrapper = shallow(
-      <EditableTextWrapper value="Hello" onChange={onChangeSpy}>
+      <EditableTextWrapper
+        value="Hello"
+        onStopEditing={onStopEditingSpy}
+        onStartEditing={onStartEditingSpy}
+        onChange={onChangeSpy}
+      >
         Hello
       </EditableTextWrapper>
     );


### PR DESCRIPTION
### 👀 Overview
Modifies `<EditableTextWrapper />` to accept the following props:
- `onStartEditing`
- `onStopEditing`

These are used in the related PR to stop items from being draggable when the name is being edited.

I've made sure the tests pass but not updated them. I think by updating them I would have just furthered testing implementation detail, when I think in reality the tests need re-writing as integration tests. 
### 🔗 Links
[Trello Card](https://trello.com/c/TzVaXHUj/344-ability-to-select-text-on-the-content-hub-item-name-title-by-dragging-my-curser-when-ive-selected-to-edit-it-this-should-be-poss)
### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/1910


### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook