### PR TITLE
Add an initialValue prop to SearchInput

### DIFF
--- a/lib/SearchInput/index.js
+++ b/lib/SearchInput/index.js
@@ -5,22 +5,24 @@ import { FontAwesomeIcon } from '../index';
 class SearchInputField extends Component {
   static defaultProps = {
     placeholder: 'Search...',
-    hideIcon: false
+    hideIcon: false,
+    initialValue: ''
   };
 
   static propTypes = {
     placeholder: PropTypes.string,
     onChangeHandler: PropTypes.func.isRequired,
-    hideIcon: PropTypes.bool
+    hideIcon: PropTypes.bool,
+    initialValue: PropTypes.string
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.onChange = this.onChange.bind(this);
     this.clearSearch = this.clearSearch.bind(this);
 
-    this.state = { query: '' };
+    this.state = { query: this.props.initialValue };
   }
 
   onChange(e) {

--- a/stories/components/SearchInput.js
+++ b/stories/components/SearchInput.js
@@ -1,18 +1,24 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import SearchInput from '../../lib/SearchInput/';
+import SearchInput from '../../lib/SearchInput';
 import StoryItem from '../styleguide/StoryItem';
 
-storiesOf('Components', module)
-  .add('SearchInput', () => {
-    return (
-      <div>
-        <StoryItem
-          title="Search field"
-          description="An input that contains behaviour for live search capabilities.">
-          <SearchInput onChangeHandler={ action('change') } />
-        </StoryItem>
-      </div>
-    );
-  });
+storiesOf('Components', module).add('SearchInput', () => {
+  return (
+    <div>
+      <StoryItem
+        title="Search field"
+        description="An input that contains behaviour for live search capabilities."
+      >
+        <SearchInput onChangeHandler={action('change')} />
+      </StoryItem>
+      <StoryItem
+        title="Search field with an initial value"
+        description="Use the `initialValue` prop to set an initial value "
+      >
+        <SearchInput onChangeHandler={action('change')} initialValue="foo" />
+      </StoryItem>
+    </div>
+  );
+});

--- a/tests/SearchInput.js
+++ b/tests/SearchInput.js
@@ -6,7 +6,6 @@ describe('SearchInput', () => {
 
   test('should render an input component', () => {
     props = {
-      value: 'Botão',
       type: 'primary',
       onChangeHandler() {}
     };
@@ -16,6 +15,19 @@ describe('SearchInput', () => {
 
     expect(input).toHaveLength(1);
     expect(input.props().className).toEqual('search-input__input');
+  });
+
+  test('can have an initial value', () => {
+    props = {
+      initialValue: 'foo bar',
+      type: 'primary',
+      onChangeHandler() {}
+    };
+
+    const Element = shallow(<SearchInput {...props} />);
+    const input = Element.find('input');
+
+    expect(input.props().value).toEqual('foo bar');
   });
 
   test('should run a callback when the query changes', () => {

--- a/tests/SearchInput.js
+++ b/tests/SearchInput.js
@@ -10,8 +10,8 @@ describe('SearchInput', () => {
       onChangeHandler() {}
     };
 
-    const Element = shallow(<SearchInput {...props} />);
-    const input = Element.find('input');
+    const wrapper = shallow(<SearchInput {...props} />);
+    const input = wrapper.find('input');
 
     expect(input).toHaveLength(1);
     expect(input.props().className).toEqual('search-input__input');
@@ -24,8 +24,8 @@ describe('SearchInput', () => {
       onChangeHandler() {}
     };
 
-    const Element = shallow(<SearchInput {...props} />);
-    const input = Element.find('input');
+    const wrapper = shallow(<SearchInput {...props} />);
+    const input = wrapper.find('input');
 
     expect(input.props().value).toEqual('foo bar');
   });
@@ -33,29 +33,29 @@ describe('SearchInput', () => {
   test('should run a callback when the query changes', () => {
     const onChangeHandler = jest.fn();
 
-    const Element = mount(<SearchInput onChangeHandler={onChangeHandler} />);
+    const wrapper = mount(<SearchInput onChangeHandler={onChangeHandler} />);
 
-    Element.find('input').simulate('change');
+    wrapper.find('input').simulate('change');
     expect(onChangeHandler).toHaveBeenCalledTimes(1);
   });
 
   test('should map the state query to the input value', () => {
-    const Element = mount(<SearchInput onChangeHandler={() => {}} />);
+    const wrapper = mount(<SearchInput onChangeHandler={() => {}} />);
 
-    Element.setState({ query: 'fake query' });
-    expect(Element.state().query).toEqual('fake query');
+    wrapper.setState({ query: 'fake query' });
+    expect(wrapper.state().query).toEqual('fake query');
   });
 
   test('should clear the search when button is pressed', () => {
     const callback = jest.fn();
 
-    const Element = mount(<SearchInput onChangeHandler={callback} />);
-    const clearButton = Element.find('.search-input__clear');
-    const input = Element.find('.search-input__input');
+    const wrapper = mount(<SearchInput onChangeHandler={callback} />);
+    const clearButton = wrapper.find('.search-input__clear');
+    const input = wrapper.find('.search-input__input');
 
-    Element.setState({ query: 'fake query' });
+    wrapper.setState({ query: 'fake query' });
     clearButton.simulate('click');
-    expect(Element.state().query).toEqual('');
+    expect(wrapper.state().query).toEqual('');
     expect(input.props().value).toEqual('');
   });
 });


### PR DESCRIPTION
### 👀 Overview
Allows us to set an initial value to a `SearchInput`, with an `initialValue` prop.

### 💬 Description
This is useful for when we want to profile the search input based on the url filters.

### 🚪 Start Points
I spent quite a while trying to workout why the component wasn't working in the storybook, then I realised we have a `SearchInput` component and a `Search\SearchInput` component - do we need 2?! Also, the `SearchInput` const is called `SearchInputField` inside the index.js file, so it's even more confusing for IDEs!!! 

### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [x] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook