### PR TITLE
Search clear button clickable when not visible

### DIFF
--- a/lib/SearchInput/styles.scss
+++ b/lib/SearchInput/styles.scss
@@ -43,10 +43,12 @@ $search-input-padding: $layout-spacing-base/2 !default;
     line-height: 1;
     transition: all $animation-time-micro ease-in-out;
     cursor: pointer;
+    pointer-events: none;
 
   &.is-visible {
     opacity: 1;
     transform: translateY(-50%) translateX(-33px);
+    pointer-events: initial;
 
         &:hover {
             background: $search-input-clear-hover-bg;


### PR DESCRIPTION
### 👀 Overview
This is a fix to `SearchInput`, when the clear button moves outside of the textbox it is still clickable, and interferes with other buttons next to the input.
### 💬 Description
_More detail on what the PR does with as much context as possible. All the changes in your PR should be described here._
### 🔗 Links
https://trello.com/c/gPfuTtuk/192-add-overdue-filtering-to-the-content-hub
### 📹 GIF (optional)
This is what happens pre-fix: https://cl.ly/4ca598b1bb76
