### PR TITLE
Add id prop to Button component

### DIFF
--- a/lib/Button/index.js
+++ b/lib/Button/index.js
@@ -20,7 +20,8 @@ class Button extends Component {
     isSubmit: false,
     title: '',
     clickHandler: () => {},
-    onClick: null
+    onClick: null,
+    id: null
   };
 
   static propTypes = {
@@ -32,7 +33,8 @@ class Button extends Component {
     disableOnClick: PropTypes.bool,
     className: PropTypes.string,
     title: PropTypes.string,
-    isSubmit: PropTypes.bool
+    isSubmit: PropTypes.bool,
+    id: PropTypes.string
   };
 
   constructor() {
@@ -64,13 +66,14 @@ class Button extends Component {
   }
 
   render() {
-    const { disabled, children, className, isSubmit, title } = this.props;
+    const { disabled, children, className, isSubmit, title, id } = this.props;
 
     const shareProps = {
       disabled: disabled || this.state.disabled,
       onClick: this.handleOnClick,
       className: `${this.getTypeClasses()} ${className}`,
-      title
+      title,
+      id
     };
 
     return isSubmit ? (

--- a/stories/components/Button.js
+++ b/stories/components/Button.js
@@ -1,154 +1,179 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import Button from "../../lib/Button";
+import Button from '../../lib/Button';
 import ButtonWithTooltip from '../../lib/Button/ButtonWithTooltip';
 import ButtonWithIcon from '../../lib/Button/ButtonWithIcon';
 import ProgressButton from '../../lib/ProgressButton';
 import Icon from '../../lib/Icon';
 import StoryItem from '../styleguide/StoryItem';
 
-const button = storiesOf('Components', module)
-  .add('Buttons', () => (
-    <div>
-      <StoryItem
-        title="Primary button"
-        description="The primary action button for creation activities"
-      >
-        <Button types={['primary']} clickHandler={action('clickedHandler')}>Primary button</Button>
-      </StoryItem>
+const button = storiesOf('Components', module).add('Buttons', () => (
+  <div>
+    <StoryItem
+      title="Primary button"
+      description="The primary action button for creation activities"
+    >
+      <Button types={['primary']} clickHandler={action('clickedHandler')}>
+        Primary button
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Button with link style"
-        description="A button which looks like a regular link"
-      >
-        <Button types={['link']} clickHandler={action('clickedHandler')}>Link type</Button>
-      </StoryItem>
+    <StoryItem
+      title="Button with link style"
+      description="A button which looks like a regular link"
+    >
+      <Button types={['link']} clickHandler={action('clickedHandler')}>
+        Link type
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Button with link danger style"
-        description="A button which looks like a regular link"
-      >
-        <Button types={['link-danger']} clickHandler={action('clickedHandler')}>Link type</Button>
-      </StoryItem>
+    <StoryItem
+      title="Button with link danger style"
+      description="A button which looks like a regular link"
+    >
+      <Button types={['link-danger']} clickHandler={action('clickedHandler')}>
+        Link type
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Outline button"
-        description="A button with an outline style"
-      >
-        <Button types={['outline']} clickHandler={action('clickedHandler')}>Outline button</Button>
-      </StoryItem>
+    <StoryItem
+      title="Outline button"
+      description="A button with an outline style"
+    >
+      <Button types={['outline']} clickHandler={action('clickedHandler')}>
+        Outline button
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Loading button"
-        description="A button that generates a spinner when pressed. It is of type `button` by default but can also be a `submit` button by setting the `isSubmit` prop to `true`."
-      >
-        <ProgressButton
-          clickHandler={action('clickedHandler')}
-          value="Click to load"
-        />
-      </StoryItem>
+    <StoryItem
+      title="Loading button"
+      description="A button that generates a spinner when pressed. It is of type `button` by default but can also be a `submit` button by setting the `isSubmit` prop to `true`."
+    >
+      <ProgressButton
+        clickHandler={action('clickedHandler')}
+        value="Click to load"
+      />
+    </StoryItem>
 
-      <StoryItem
-        title="Danger button"
-        description="A button that generates a dangerous action"
-      >
-        <Button types={['danger']} clickHandler={action('clickedHandler')}>Danger button</Button>
-      </StoryItem>
+    <StoryItem
+      title="Danger button"
+      description="A button that generates a dangerous action"
+    >
+      <Button types={['danger']} clickHandler={action('clickedHandler')}>
+        Danger button
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Misc buttons (light and dark)"
-        description="Buttons that looks like they performs a secondary action."
-      >
-        <Button types={['light-grey']} clickHandler={action('clickedHandler')}>Import</Button>
-        <Button types={['dark-grey']} clickHandler={action('clickedHandler')}>Export</Button>
-      </StoryItem>
+    <StoryItem
+      title="Misc buttons (light and dark)"
+      description="Buttons that looks like they performs a secondary action."
+    >
+      <Button types={['light-grey']} clickHandler={action('clickedHandler')}>
+        Import
+      </Button>
+      <Button types={['dark-grey']} clickHandler={action('clickedHandler')}>
+        Export
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Buttons side by side"
-        description="Spacing is added when you add multiple Buttons side by side."
-      >
-        <Button types={['danger']} clickHandler={action('clickedHandler')}>Delete Items</Button>
-        <Button types={['link']} clickHandler={action('clickedHandler')}>Cancel</Button>
-      </StoryItem>
+    <StoryItem
+      title="Buttons side by side"
+      description="Spacing is added when you add multiple Buttons side by side."
+    >
+      <Button types={['danger']} clickHandler={action('clickedHandler')}>
+        Delete Items
+      </Button>
+      <Button types={['link']} clickHandler={action('clickedHandler')}>
+        Cancel
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Button with a tooltip"
-        description="Buttons can includes tooltips to provide context to the user."
+    <StoryItem
+      title="Button with a tooltip"
+      description="Buttons can includes tooltips to provide context to the user."
+    >
+      <ButtonWithTooltip
+        types={['light-grey']}
+        clickHandler={action('clickedHandler')}
+        tooltipText="You may reverse this action at a later date"
+        tooltipSize="large"
+        tooltipPosition="right"
       >
-        <ButtonWithTooltip
-          types={['light-grey']}
-          clickHandler={action('clickedHandler')}
-          tooltipText="You may reverse this action at a later date"
-          tooltipSize="large"
-          tooltipPosition="right"
-        >
-          Archive Item
-        </ButtonWithTooltip>
-      </StoryItem>
+        Archive Item
+      </ButtonWithTooltip>
+    </StoryItem>
 
-      <StoryItem
-        title="Icon Only Content"
-        description="A Button can use more than just text as content."
-      >
-        <Button
-          types={['icon-only']}
-          clickHandler={action('I was clicked')}
-        >
-          <Icon
-            name="comment"
-            text="add comment"
-            hideText
-          />
-        </Button>
-      </StoryItem>
+    <StoryItem
+      title="Icon Only Content"
+      description="A Button can use more than just text as content."
+    >
+      <Button types={['icon-only']} clickHandler={action('I was clicked')}>
+        <Icon name="comment" text="add comment" hideText />
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Danger button, Icon only"
-        description="A button with an icon and a red background"
+    <StoryItem
+      title="Danger button, Icon only"
+      description="A button with an icon and a red background"
+    >
+      <Button
+        types={['danger', 'icon-only']}
+        clickHandler={action('clickedHandler')}
       >
-        <Button types={['danger', 'icon-only']} clickHandler={action('clickedHandler')}><Icon name="clock" /></Button>
-      </StoryItem>
+        <Icon name="clock" />
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Icon Contents & Contained"
-        description="Icon contents go well with a border when they're interactive."
+    <StoryItem
+      title="Icon Contents & Contained"
+      description="Icon contents go well with a border when they're interactive."
+    >
+      <Button
+        types={['icon-only', 'contained']}
+        clickHandler={action('I was clicked')}
       >
-        <Button
-          types={['icon-only', 'contained']}
-          clickHandler={action('I was clicked')}
-        >
-          <Icon
-            name="comment"
-            text="add comment"
-            hideText
-          />
-        </Button>
-      </StoryItem>
+        <Icon name="comment" text="add comment" hideText />
+      </Button>
+    </StoryItem>
 
-      <StoryItem
-        title="Enhanced Hover Interaction"
-        description="Buttons can have an enhanced hover interaction."
+    <StoryItem
+      title="Enhanced Hover Interaction"
+      description="Buttons can have an enhanced hover interaction."
+    >
+      <Button
+        types={['primary', 'hover-transform']}
+        clickHandler={action('I was clicked')}
       >
-        <Button
-          types={['primary', 'hover-transform']}
-          clickHandler={action('I was clicked')}
-        >
-          Hover me
-        </Button>
-      </StoryItem>
-      <StoryItem
-        title="Button with icon"
+        Hover me
+      </Button>
+    </StoryItem>
+    <StoryItem title="Button with icon">
+      <ButtonWithIcon
+        mainClickHandler={action('I was clicked')}
+        iconClickHandler={action('Icon was clicked')}
+        iconName="bell"
       >
-        <ButtonWithIcon
-          mainClickHandler={action('I was clicked')}
-          iconClickHandler={action('Icon was clicked')}
-          iconName="bell"
-        >
-          hello!
-        </ButtonWithIcon>
-      </StoryItem>
-    </div>
-  ));
+        hello!
+      </ButtonWithIcon>
+    </StoryItem>
+
+    <StoryItem
+      title="Button with an id"
+      description="Set the id prop, so can be accessed by a label"
+    >
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label htmlFor="my-button">This is a label for #my-button</label>
+      <Button
+        id="my-button"
+        types={['icon-only', 'contained']}
+        clickHandler={action('I was clicked')}
+        aria-label="My accessible button"
+      >
+        <Icon name="comment" text="add comment" hideText />
+      </Button>
+    </StoryItem>
+  </div>
+));
 
 export default button;

--- a/tests/Button/index.js
+++ b/tests/Button/index.js
@@ -71,4 +71,10 @@ describe('Button', () => {
     wrapper.simulate('click');
     expect(wrapper.state('disabled')).toEqual(false);
   });
+
+  test('it can pass an id prop down to button attribute', () => {
+    wrapper.setProps({ id: 'my-id' });
+    button = wrapper.find('button');
+    expect(button.prop('id')).toEqual('my-id');
+  });
 });


### PR DESCRIPTION
### 👀 Overview
Adds the `Button.id` prop as an attribute to `<button>`.

### 💬 Description
If we allow an id on the button we can reference it from labels and elsewhere, e.g.
```
<label for="button-id">Toggle filter</label>
<button id="button-id">icon</button>
```

### ✅ Checklist
- [x] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook