### PR TITLE
Refactor SearchInput to no longer be controlled

### DIFF
--- a/lib/SearchInput/index.js
+++ b/lib/SearchInput/index.js
@@ -1,79 +1,54 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '../index';
 
-class SearchInputField extends Component {
-  static defaultProps = {
-    placeholder: 'Search...',
-    hideIcon: false,
-    initialValue: ''
-  };
+const SearchInputField = ({
+  placeholder,
+  onChangeHandler,
+  onClearHandler,
+  hideIcon,
+  value
+}) => {
+  const hasSearch = value ? 'is-visible' : '';
 
-  static propTypes = {
-    placeholder: PropTypes.string,
-    onChangeHandler: PropTypes.func.isRequired,
-    hideIcon: PropTypes.bool,
-    initialValue: PropTypes.string
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.onChange = this.onChange.bind(this);
-    this.clearSearch = this.clearSearch.bind(this);
-
-    this.state = { query: this.props.initialValue };
-  }
-
-  onChange(e) {
-    this.props.onChangeHandler(e);
-    this.setState({ query: e.target.value });
-  }
-
-  /**
-   * Clears the search input (x) button
-   * Runs the onChange callback with an empty value.
-   */
-  clearSearch() {
-    this.setState({ query: '' });
-    this.props.onChangeHandler({
-      target: { value: '' }
-    });
-    this.searchInput.value = '';
-  }
-
-  render() {
-    const { placeholder } = this.props;
-    const hasSearch = this.state.query ? 'is-visible' : '';
-
-    return (
-      <span className="search-input">
-        <input
-          ref={input => {
-            this.searchInput = input;
-          }}
-          value={this.state.query}
-          onChange={this.onChange}
-          type="text"
-          className="search-input__input"
-          placeholder={placeholder}
+  return (
+    <span className="search-input">
+      <input
+        value={value}
+        onChange={e => onChangeHandler(e)}
+        type="text"
+        className="search-input__input"
+        placeholder={placeholder}
+      />
+      <button
+        type="button"
+        onClick={onClearHandler}
+        className={`search-input__clear ${hasSearch}`}
+      >
+        ×
+      </button>
+      {!hideIcon && (
+        <FontAwesomeIcon
+          name="fa-search"
+          className={`search-input__icon ${hasSearch}`}
         />
-        <button
-          type="button"
-          onClick={this.clearSearch}
-          className={`search-input__clear ${hasSearch}`}
-        >
-          ×
-        </button>
-        {!this.props.hideIcon && (
-          <FontAwesomeIcon
-            name="fa-search"
-            className={`search-input__icon ${hasSearch}`}
-          />
-        )}
-      </span>
-    );
-  }
-}
+      )}
+    </span>
+  );
+};
+
+SearchInputField.defaultProps = {
+  placeholder: 'Search...',
+  hideIcon: false,
+  value: ''
+};
+
+SearchInputField.propTypes = {
+  placeholder: PropTypes.string,
+  onChangeHandler: PropTypes.func.isRequired,
+  onClearHandler: PropTypes.func.isRequired,
+  hideIcon: PropTypes.bool,
+  value: PropTypes.string
+};
 
 export default SearchInputField;

--- a/tests/SearchInput.js
+++ b/tests/SearchInput.js
@@ -1,4 +1,4 @@
-import { React, shallow, mount } from './setup';
+import { React, shallow } from './setup';
 import SearchInput from '../lib/SearchInput';
 
 describe('SearchInput', () => {
@@ -19,7 +19,7 @@ describe('SearchInput', () => {
 
   test('can have an initial value', () => {
     props = {
-      initialValue: 'foo bar',
+      value: 'foo bar',
       type: 'primary',
       onChangeHandler() {}
     };
@@ -28,34 +28,5 @@ describe('SearchInput', () => {
     const input = wrapper.find('input');
 
     expect(input.props().value).toEqual('foo bar');
-  });
-
-  test('should run a callback when the query changes', () => {
-    const onChangeHandler = jest.fn();
-
-    const wrapper = mount(<SearchInput onChangeHandler={onChangeHandler} />);
-
-    wrapper.find('input').simulate('change');
-    expect(onChangeHandler).toHaveBeenCalledTimes(1);
-  });
-
-  test('should map the state query to the input value', () => {
-    const wrapper = mount(<SearchInput onChangeHandler={() => {}} />);
-
-    wrapper.setState({ query: 'fake query' });
-    expect(wrapper.state().query).toEqual('fake query');
-  });
-
-  test('should clear the search when button is pressed', () => {
-    const callback = jest.fn();
-
-    const wrapper = mount(<SearchInput onChangeHandler={callback} />);
-    const clearButton = wrapper.find('.search-input__clear');
-    const input = wrapper.find('.search-input__input');
-
-    wrapper.setState({ query: 'fake query' });
-    clearButton.simulate('click');
-    expect(wrapper.state().query).toEqual('');
-    expect(input.props().value).toEqual('');
   });
 });


### PR DESCRIPTION
### 👀 Overview
A lot of work has been done around filtering in the app, as a result there has been a need to control the Search Input, either to clear it or update it from the app.
### 💬 Description
I have removed the local state and exposed it's API. It is now going to be controlled through the props instead.

**This will be a minor version update.**

### ✅ Checklist
- [x] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook