### PR TITLE
Add Drag and Drop UI components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,13 @@
 module.exports = {
   verbose: true,
   testMatch: ['**/tests/**/*.js?(x)'],
-  testPathIgnorePatterns: ['tests/setup.js']
+  testPathIgnorePatterns: ['tests/setup.js'],
+  moduleNameMapper: {
+    "^dnd-core$": "dnd-core/dist/cjs",
+    "^react-dnd$": "react-dnd/dist/cjs",
+    "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
+    "^react-dnd-touch-backend$": "react-dnd-touch-backend/dist/cjs",
+    "^react-dnd-test-backend$": "react-dnd-test-backend/dist/cjs",
+    "^react-dnd-test-utils$": "react-dnd-test-utils/dist/cjs"
+  }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   verbose: true,
   testMatch: ['**/tests/**/*.js?(x)'],
-  testPathIgnorePatterns: ['tests/setup.js'],
+  testPathIgnorePatterns: ['tests/setup.js', 'dist'],
   moduleNameMapper: {
     "^dnd-core$": "dnd-core/dist/cjs",
     "^react-dnd$": "react-dnd/dist/cjs",

--- a/lib/DnD/DnDStory.js
+++ b/lib/DnD/DnDStory.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { DndProvider } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { storiesOf } from '@storybook/react';
+import { ItemRow, Draggable, DragPreview } from '..';
+import StatusIndicator from '../StatusIndicator';
+
+const stories = storiesOf('Components', module);
+
+stories.add('Drag and Drop', () => (
+  <DndProvider backend={HTML5Backend}>
+    <Draggable type="item" disablePreview>
+      {({ isDragging, itemType }, dragRef) => (
+        <>
+          {isDragging && (
+            <DragPreview>
+              <div style={{ maxWidth: '300px' }}>
+                <ItemRow indicator={<StatusIndicator color="red" />} bordered>
+                  1 {itemType}
+                </ItemRow>
+              </div>
+            </DragPreview>
+          )}
+
+          <div ref={dragRef}>
+            <ItemRow
+              bordered
+              indicator={<StatusIndicator color="red" />}
+              style={{
+                opacity: isDragging ? '.5' : '1'
+              }}
+            >
+              Test
+            </ItemRow>
+          </div>
+        </>
+      )}
+    </Draggable>
+  </DndProvider>
+));

--- a/lib/DnD/DndProvider.js
+++ b/lib/DnD/DndProvider.js
@@ -1,0 +1,37 @@
+import React, { createContext, useState } from 'react';
+import { DndProvider as DragAndDropProvider } from 'react-dnd';
+import { node, shape } from 'prop-types';
+import { DragPreview } from './DragPreview';
+
+export const DndContext = createContext({});
+
+function DndProvider({ children, backend }) {
+  const [isDragging, setIsDragging] = useState('');
+  const [preview, setPreview] = useState(null);
+  const [failurePreview, setFailurePreview] = useState(null);
+
+  const sharedState = {
+    isDragging,
+    setIsDragging,
+    preview,
+    setPreview,
+    setFailurePreview
+  };
+
+  return (
+    <DragAndDropProvider backend={backend}>
+      <DndContext.Provider value={sharedState}>
+        {isDragging && <DragPreview>{failurePreview || preview}</DragPreview>}
+
+        {children}
+      </DndContext.Provider>
+    </DragAndDropProvider>
+  );
+}
+
+DndProvider.propTypes = {
+  children: node.isRequired,
+  backend: shape.isRequired
+};
+
+export { DndProvider };

--- a/lib/DnD/DndProvider.js
+++ b/lib/DnD/DndProvider.js
@@ -1,12 +1,12 @@
 import React, { createContext, useState } from 'react';
 import { DndProvider as DragAndDropProvider } from 'react-dnd';
-import { node, shape } from 'prop-types';
+import { func, node } from 'prop-types';
 import { DragPreview } from './DragPreview';
 
 export const DndContext = createContext({});
 
 function DndProvider({ children, backend }) {
-  const [isDragging, setIsDragging] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
   const [preview, setPreview] = useState(null);
   const [failurePreview, setFailurePreview] = useState(null);
 
@@ -31,7 +31,7 @@ function DndProvider({ children, backend }) {
 
 DndProvider.propTypes = {
   children: node.isRequired,
-  backend: shape.isRequired
+  backend: func.isRequired
 };
 
 export { DndProvider };

--- a/lib/DnD/DragPreview.js
+++ b/lib/DnD/DragPreview.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { oneOfType, node, string } from 'prop-types';
+import { node } from 'prop-types';
 import { useDragLayer } from 'react-dnd';
 import { getItemStyles } from './helpers/getItemStyles';
 
@@ -30,7 +30,7 @@ function DragPreview({ children }) {
 }
 
 DragPreview.propTypes = {
-  children: oneOfType([node, string]).isRequired
+  children: node.isRequired
 };
 
 export { DragPreview };

--- a/lib/DnD/DragPreview.js
+++ b/lib/DnD/DragPreview.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { oneOfType, node, string } from 'prop-types';
+import { useDragLayer } from 'react-dnd';
+import { getItemStyles } from './helpers/getItemStyles';
+
+function DragPreview({ children }) {
+  const { initialOffset, currentOffset } = useDragLayer(monitor => ({
+    item: monitor.getItem(),
+    itemType: monitor.getItemType(),
+    initialOffset: monitor.getInitialSourceClientOffset(),
+    currentOffset: monitor.getSourceClientOffset(),
+    isDragging: monitor.isDragging()
+  }));
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        pointerEvents: 'none',
+        zIndex: 100,
+        left: 0,
+        top: 0,
+        width: '100%',
+        height: '100%'
+      }}
+    >
+      <div style={getItemStyles(initialOffset, currentOffset)}>{children}</div>
+    </div>
+  );
+}
+
+DragPreview.propTypes = {
+  children: oneOfType([node, string]).isRequired
+};
+
+export { DragPreview };

--- a/lib/DnD/Draggable.js
+++ b/lib/DnD/Draggable.js
@@ -1,11 +1,18 @@
-import React from 'react';
-import { func, bool, string } from 'prop-types';
+import React, { useContext } from 'react';
+import { func, string, node } from 'prop-types';
 import { DragPreviewImage, useDrag } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
+import { DndContext } from './DndProvider';
 
-function Draggable({ children, type, disablePreview }) {
+function Draggable({ children, type, preview }) {
+  const { setIsDragging, setPreview } = useContext(DndContext);
   const [collect, defineDragRef, definePreviewRef] = useDrag({
     item: { type },
+    begin: () => {
+      setPreview(preview);
+      setIsDragging(true);
+    },
+    end: () => setIsDragging(false),
     collect: monitor => ({
       itemType: monitor.getItemType(),
       isDragging: !!monitor.isDragging()
@@ -14,7 +21,7 @@ function Draggable({ children, type, disablePreview }) {
 
   return (
     <>
-      {disablePreview && (
+      {preview && (
         <DragPreviewImage
           src={getEmptyImage().getAttribute('src')}
           connect={definePreviewRef}
@@ -28,11 +35,11 @@ function Draggable({ children, type, disablePreview }) {
 Draggable.propTypes = {
   children: func.isRequired,
   type: string.isRequired,
-  disablePreview: bool
+  preview: node
 };
 
 Draggable.defaultProps = {
-  disablePreview: false
+  preview: null
 };
 
 export { Draggable };

--- a/lib/DnD/Draggable.js
+++ b/lib/DnD/Draggable.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { func, bool, string } from 'prop-types';
+import { DragPreviewImage, useDrag } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+
+function Draggable({ children, type, disablePreview }) {
+  const [collect, defineDragRef, definePreviewRef] = useDrag({
+    item: { type },
+    collect: monitor => ({
+      itemType: monitor.getItemType(),
+      isDragging: !!monitor.isDragging()
+    })
+  });
+
+  return (
+    <>
+      {disablePreview && (
+        <DragPreviewImage
+          src={getEmptyImage().getAttribute('src')}
+          connect={definePreviewRef}
+        />
+      )}
+      {children(collect, defineDragRef, definePreviewRef)}
+    </>
+  );
+}
+
+Draggable.propTypes = {
+  children: func.isRequired,
+  type: string.isRequired,
+  disablePreview: bool
+};
+
+Draggable.defaultProps = {
+  disablePreview: false
+};
+
+export { Draggable };

--- a/lib/DnD/Droppable.js
+++ b/lib/DnD/Droppable.js
@@ -23,7 +23,6 @@ Droppable.propTypes = {
 };
 
 Droppable.defaultProps = {
-  onHover: () => {},
   canDropChecker: () => true
 };
 

--- a/lib/DnD/Droppable.js
+++ b/lib/DnD/Droppable.js
@@ -1,5 +1,5 @@
 import { useDrop } from 'react-dnd';
-import { func, string } from 'prop-types';
+import { func, node } from 'prop-types';
 
 function Droppable({ children, acceptDragTypes, onDrop, canDropChecker }) {
   const [collected, defineDropRef] = useDrop({
@@ -18,7 +18,7 @@ function Droppable({ children, acceptDragTypes, onDrop, canDropChecker }) {
 Droppable.propTypes = {
   children: func.isRequired,
   onDrop: func.isRequired,
-  acceptDragTypes: string.isRequired,
+  acceptDragTypes: node.isRequired,
   canDropChecker: func
 };
 

--- a/lib/DnD/Droppable.js
+++ b/lib/DnD/Droppable.js
@@ -1,0 +1,30 @@
+import { useDrop } from 'react-dnd';
+import { func, string } from 'prop-types';
+
+function Droppable({ children, acceptDragTypes, onDrop, canDropChecker }) {
+  const [collected, defineDropRef] = useDrop({
+    accept: acceptDragTypes,
+    drop: onDrop,
+    canDrop: canDropChecker,
+    collect: monitor => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop()
+    })
+  });
+
+  return children(collected, defineDropRef);
+}
+
+Droppable.propTypes = {
+  children: func.isRequired,
+  onDrop: func.isRequired,
+  acceptDragTypes: string.isRequired,
+  canDropChecker: func
+};
+
+Droppable.defaultProps = {
+  onHover: () => {},
+  canDropChecker: () => true
+};
+
+export { Droppable };

--- a/lib/DnD/helpers/getItemStyles.js
+++ b/lib/DnD/helpers/getItemStyles.js
@@ -1,0 +1,18 @@
+function getItemStyles(initialOffset, currentOffset) {
+  if (!initialOffset || !currentOffset) {
+    return {
+      display: 'none'
+    };
+  }
+
+  const { x, y } = currentOffset;
+
+  const transform = `translate(${x}px, ${y}px)`;
+
+  return {
+    transform,
+    WebkitTransform: transform
+  };
+}
+
+export { getItemStyles };

--- a/lib/DnD/index.js
+++ b/lib/DnD/index.js
@@ -1,0 +1,6 @@
+import { DndProvider } from './DndProvider';
+import { DragPreview } from './DragPreview';
+import { Draggable } from './Draggable';
+import { Droppable } from './Droppable';
+
+export { DndProvider, DragPreview, Draggable, Droppable };

--- a/lib/DnD/stories/DnDStory.js
+++ b/lib/DnD/stories/DnDStory.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { DndProvider } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { storiesOf } from '@storybook/react';
-import { ItemRow, Draggable, DragPreview } from '..';
-import StatusIndicator from '../StatusIndicator';
+import { ItemRow, Draggable, DragPreview } from '../../index';
+import StatusIndicator from '../../StatusIndicator';
 
 const stories = storiesOf('Components', module);
 
@@ -15,8 +15,14 @@ stories.add('Drag and Drop', () => (
           {isDragging && (
             <DragPreview>
               <div style={{ maxWidth: '300px' }}>
-                <ItemRow indicator={<StatusIndicator color="red" />} bordered>
-                  1 {itemType}
+                <ItemRow bordered>
+                  <ItemRow.Name>
+                    <StatusIndicator
+                      color="red"
+                      className="h-margin-right-half"
+                    />
+                    1 {itemType}
+                  </ItemRow.Name>
                 </ItemRow>
               </div>
             </DragPreview>
@@ -30,7 +36,9 @@ stories.add('Drag and Drop', () => (
                 opacity: isDragging ? '.5' : '1'
               }}
             >
-              Test
+              <ItemRow.Name>
+                <StatusIndicator color="red" className="h-margin-right-half" />1
+              </ItemRow.Name>
             </ItemRow>
           </div>
         </>

--- a/lib/DnD/stories/DnDStory.js
+++ b/lib/DnD/stories/DnDStory.js
@@ -1,48 +1,19 @@
 import React from 'react';
-import { DndProvider } from 'react-dnd';
+import faker from 'faker';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { storiesOf } from '@storybook/react';
-import { ItemRow, Draggable, DragPreview } from '../../index';
-import StatusIndicator from '../../StatusIndicator';
+import { DndDropNotification } from './DndDropNotification';
+import { ItemDndMock } from './ItemDndMock';
+import { DndProvider } from '../DndProvider';
+import { FolderDndMock } from './FolderDndMock';
 
 const stories = storiesOf('Components', module);
 
 stories.add('Drag and Drop', () => (
   <DndProvider backend={HTML5Backend}>
-    <Draggable type="item" disablePreview>
-      {({ isDragging, itemType }, dragRef) => (
-        <>
-          {isDragging && (
-            <DragPreview>
-              <div style={{ maxWidth: '300px' }}>
-                <ItemRow bordered>
-                  <ItemRow.Name>
-                    <StatusIndicator
-                      color="red"
-                      className="h-margin-right-half"
-                    />
-                    1 {itemType}
-                  </ItemRow.Name>
-                </ItemRow>
-              </div>
-            </DragPreview>
-          )}
-
-          <div ref={dragRef}>
-            <ItemRow
-              bordered
-              indicator={<StatusIndicator color="red" />}
-              style={{
-                opacity: isDragging ? '.5' : '1'
-              }}
-            >
-              <ItemRow.Name>
-                <StatusIndicator color="red" className="h-margin-right-half" />1
-              </ItemRow.Name>
-            </ItemRow>
-          </div>
-        </>
-      )}
-    </Draggable>
+    <FolderDndMock name={faker.commerce.productName()} showToggle open>
+      <ItemDndMock>{faker.commerce.productName()}</ItemDndMock>
+    </FolderDndMock>
+    <DndDropNotification />
   </DndProvider>
 ));

--- a/lib/DnD/stories/DndDropNotification.js
+++ b/lib/DnD/stories/DndDropNotification.js
@@ -1,0 +1,81 @@
+import React, { useContext } from 'react';
+import { bool, node } from 'prop-types';
+import { action } from '@storybook/addon-actions';
+import { Droppable } from '../Droppable';
+import Notification from '../../Notification';
+import { DndContext } from '../DndProvider';
+import { ItemRow } from '../../ItemRow';
+
+const Message = ({ children, canDrop, isOver, isDragging }) => {
+  let level = 'info';
+
+  if (isDragging && canDrop) {
+    level = 'warning';
+  }
+
+  if (isDragging && isOver) {
+    level = 'success';
+  }
+
+  if (isDragging && isOver && !canDrop) {
+    level = 'danger';
+  }
+
+  return (
+    <Notification level={level} style={{ height: '200px' }}>
+      {children}
+    </Notification>
+  );
+};
+
+Message.propTypes = {
+  children: node.isRequired,
+  canDrop: bool.isRequired,
+  isOver: bool.isRequired,
+  isDragging: bool.isRequired
+};
+
+function DndDropNotification() {
+  const { isDragging, setFailurePreview } = useContext(DndContext);
+
+  const failurePreview = (
+    <div style={{ maxWidth: '300px' }}>
+      <ItemRow bordered>
+        <ItemRow.Name>You cannot drag folders into here!</ItemRow.Name>
+      </ItemRow>
+    </div>
+  );
+
+  return (
+    <Droppable
+      acceptDragTypes={['item', 'folder']}
+      onDrop={action('something was dropped')}
+      canDropChecker={({ type }, monitor) => {
+        const typeIsItem = type === 'item';
+
+        if (!typeIsItem) {
+          setFailurePreview(failurePreview);
+        }
+
+        if (!monitor.isOver()) {
+          setFailurePreview(null);
+        }
+
+        return typeIsItem;
+      }}
+    >
+      {({ canDrop, isOver }, defineDropRef) => (
+        <div ref={defineDropRef} className="h-margin-top">
+          <Message isDragging={isDragging} isOver={isOver} canDrop={canDrop}>
+            {!isDragging && 'Start by dragging items in here.'}
+            {isDragging && !isOver && 'Drag it here.'}
+            {isDragging && isOver && canDrop && 'Drop it!'}
+            {isDragging && isOver && !canDrop && 'You cannot drag here!'}
+          </Message>
+        </div>
+      )}
+    </Droppable>
+  );
+}
+
+export { DndDropNotification };

--- a/lib/DnD/stories/DndDropNotification.js
+++ b/lib/DnD/stories/DndDropNotification.js
@@ -67,8 +67,9 @@ function DndDropNotification() {
       {({ canDrop, isOver }, defineDropRef) => (
         <div ref={defineDropRef} className="h-margin-top">
           <Message isDragging={isDragging} isOver={isOver} canDrop={canDrop}>
-            {!isDragging && 'Start by dragging items in here.'}
-            {isDragging && !isOver && 'Drag it here.'}
+            {(!isDragging || (!canDrop && !isOver)) &&
+              'Start by dragging items in here.'}
+            {isDragging && !isOver && canDrop && 'Drag it here.'}
             {isDragging && isOver && canDrop && 'Drop it!'}
             {isDragging && isOver && !canDrop && 'You cannot drag here!'}
           </Message>

--- a/lib/DnD/stories/FolderDndMock.js
+++ b/lib/DnD/stories/FolderDndMock.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { FolderRow } from '../../FolderRow';
+import { Draggable } from '../Draggable';
+
+function FolderDndMock({ children, ...rest }) {
+  const preview = (
+    <div style={{ maxWidth: '300px' }}>
+      <FolderRow {...rest} />
+    </div>
+  );
+
+  return (
+    <Draggable type="folder" preview={preview}>
+      {({ isDragging }, dragRef) => (
+        <div ref={dragRef}>
+          <FolderRow
+            {...rest}
+            style={{
+              opacity: isDragging ? '.5' : '1'
+            }}
+          >
+            {children}
+          </FolderRow>
+        </div>
+      )}
+    </Draggable>
+  );
+}
+
+FolderDndMock.propTypes = FolderRow.propTypes;
+
+export { FolderDndMock };

--- a/lib/DnD/stories/ItemDndMock.js
+++ b/lib/DnD/stories/ItemDndMock.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ItemRow } from '../../ItemRow';
+import { Draggable } from '../Draggable';
+
+function ItemDndMock({ children }) {
+  const preview = (
+    <div style={{ maxWidth: '300px' }}>
+      <ItemRow bordered>{children}</ItemRow>
+    </div>
+  );
+
+  return (
+    <Draggable type="item" preview={preview}>
+      {({ isDragging }, dragRef) => (
+        <div ref={dragRef}>
+          <ItemRow
+            bordered
+            style={{
+              opacity: isDragging ? '.5' : '1'
+            }}
+            className="h-margin-top-half"
+          >
+            {children}
+          </ItemRow>
+        </div>
+      )}
+    </Draggable>
+  );
+}
+
+ItemDndMock.propTypes = ItemRow.propTypes;
+
+export { ItemDndMock };

--- a/lib/ItemRow/styles.scss
+++ b/lib/ItemRow/styles.scss
@@ -7,6 +7,7 @@ $item-row-stacked-margin: $typo-size-slight/3;
    Styles
    ========================================================================== */
 .item-row {
+  background: white;
   padding: $layout-spacing-base/2;
 
   .status-indicator {

--- a/lib/ItemRow/styles.scss
+++ b/lib/ItemRow/styles.scss
@@ -7,7 +7,6 @@ $item-row-stacked-margin: $typo-size-slight/3;
    Styles
    ========================================================================== */
 .item-row {
-  background: white;
   padding: $layout-spacing-base/2;
 
   .status-indicator {

--- a/lib/Notification/index.js
+++ b/lib/Notification/index.js
@@ -8,7 +8,14 @@ import cx from 'classnames';
  *
  * <Notification level="warning">This is a warning</Notification>
  */
-const Notification = ({ children, level, clickHandler, className, center }) => {
+const Notification = ({
+  children,
+  level,
+  clickHandler,
+  className,
+  center,
+  ...rest
+}) => {
   const alertClasses = cx({
     'has-click-handler': clickHandler,
     'notification--centred': center
@@ -19,6 +26,7 @@ const Notification = ({ children, level, clickHandler, className, center }) => {
       onClick={clickHandler}
       bsStyle={level}
       className={`notification notification--${level} ${alertClasses} ${className}`}
+      {...rest}
     >
       {children}
     </Alert>

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,3 +99,4 @@ export Pill from './Pill';
 export GuideCard from './GuideCard';
 export { DragPreview } from './DnD/DragPreview';
 export { Draggable } from './DnD/Draggable';
+export { Droppable } from './DnD/Droppable';

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,4 @@ export ImageLoader from './images/ImageLoader';
 export InputWithButton from './InputWithButton';
 export Pill from './Pill';
 export GuideCard from './GuideCard';
-export { DragPreview } from './DnD/DragPreview';
-export { Draggable } from './DnD/Draggable';
-export { Droppable } from './DnD/Droppable';
+export { DndProvider, DragPreview, Draggable, Droppable } from './DnD';

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,3 +97,5 @@ export ImageLoader from './images/ImageLoader';
 export InputWithButton from './InputWithButton';
 export Pill from './Pill';
 export GuideCard from './GuideCard';
+export { DragPreview } from './DnD/DragPreview';
+export { Draggable } from './DnD/Draggable';

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "react": "^16.8.6",
     "react-bootstrap": "0.32.1",
     "react-day-picker": "^7.1.1",
+    "react-dnd": "^9.3.2",
+    "react-dnd-html5-backend": "^9.3.2",
     "react-dom": "^16.8.6",
     "react-mentions": "2.2.0",
     "react-svg-inline": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "prettier": "1.16.4",
     "raw-loader": "^3.1.0",
     "react-addons-test-utils": "^15.4.2",
+    "react-dnd-test-backend": "^9.3.2",
     "sass": "^1.22.7",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
+    "@storybook/addon-actions": "^5.1.9",
     "@storybook/addon-knobs": "^5.1.9",
     "@storybook/react": "5.1.9",
     "bootstrap": "3.4.1",
@@ -128,7 +129,6 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@storybook/addon-a11y": "^5.1.9",
-    "@storybook/addon-actions": "^5.1.9",
     "@storybook/addon-notes": "^5.1.9",
     "@storybook/addons": "^5.1.9",
     "babel-core": "^7.0.0-bridge.0",

--- a/stories/index.js
+++ b/stories/index.js
@@ -59,6 +59,6 @@ import ImageLoader from './components/images/ImageLoader';
 import InputWithButton from './components/InputWithButton';
 import Pill from './components/Pill';
 import GuideCard from '../lib/GuideCard/stories/GuideCardStory';
-import DnD from '../lib/DnD/DnDStory';
+import DnD from '../lib/DnD/stories/DnDStory';
 
 import Hierarchy from './webapp/hierarchy/HierarchyStory';

--- a/stories/index.js
+++ b/stories/index.js
@@ -59,4 +59,6 @@ import ImageLoader from './components/images/ImageLoader';
 import InputWithButton from './components/InputWithButton';
 import Pill from './components/Pill';
 import GuideCard from '../lib/GuideCard/stories/GuideCardStory';
+import DnD from '../lib/DnD/DnDStory';
+
 import Hierarchy from './webapp/hierarchy/HierarchyStory';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,14 +1835,50 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@types/asap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/asap/-/asap-2.0.0.tgz#d529e9608c83499a62ae08c871c5e62271aa2963"
+  integrity sha512-upIS0Gt9Mc8eEpCbYMZ1K8rhNosfKUtimNcINce+zLwJF5UpM3Vv7yz3S5l/1IX+DxTa8lTkUjqynvjRXyJzsg==
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
+"@types/invariant@^2.2.30":
+  version "2.2.30"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.30.tgz#20efa342807606ada5483731a8137cb1561e5fe9"
+  integrity sha512-98fB+yo7imSD2F7PF7GIpELNgtLNgo5wjivu0W5V4jx+KVVJxo6p/qN4zdzSTBWy4/sN3pPyXwnhRSD28QX+ag==
+
 "@types/node@*":
   version "11.13.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.7.tgz#85dbb71c510442d00c0631f99dae957ce44fd104"
+
+"@types/prop-types@*":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/react@*":
+  version "16.8.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
+  integrity sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/shallowequal@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/shallowequal/-/shallowequal-1.1.1.tgz#aad262bb3f2b1257d94c71d545268d592575c9b1"
+  integrity sha512-Lhni3aX80zbpdxRuWhnuYPm8j8UQaa571lHP/xI4W+7BAFhSIhRReXnqjEgT/XzPoXZTJkCqstFMJ8CZTK6IlQ==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -2345,7 +2381,7 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@~2.0.3:
+asap@^2.0.6, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -4138,7 +4174,7 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.5.2, csstype@^2.5.7:
+csstype@^2.2.0, csstype@^2.5.2, csstype@^2.5.7:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
@@ -4351,6 +4387,17 @@ dir-glob@2.0.0:
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
+dnd-core@^9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-9.3.2.tgz#d30f4a53fc296d6fedee05ed690db97974c7decc"
+  integrity sha512-cc6aAFmLDYdXguC+YbKB+SCsXlNd+LS/+T22M4OpmehWI3wBqXBik3o+myjr19ie3K11S3ATTiwir7b0s3TAhw==
+  dependencies:
+    "@types/asap" "^2.0.0"
+    "@types/invariant" "^2.2.30"
+    asap "^2.0.6"
+    invariant "^2.2.4"
+    redux "^4.0.1"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -9391,6 +9438,24 @@ react-dev-utils@^9.0.0:
     sockjs-client "1.3.0"
     strip-ansi "5.2.0"
     text-table "0.2.0"
+
+react-dnd-html5-backend@^9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-9.3.2.tgz#4833043aec91e69dd968ac136deebf7535f5eb9d"
+  integrity sha512-EsQLA3fikHxkkvs6COnEdo3McJg2Q82z6EQxo7s3yqez4LAutrcp7pf5/eyW1nFDcdN3JNx2p+TrkjVjEd5exw==
+  dependencies:
+    dnd-core "^9.3.2"
+
+react-dnd@^9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-9.3.2.tgz#e06c0f566201fbd4617db6d023fcb45629874bbc"
+  integrity sha512-3xwrd+z25CplNmO1j6BmvFlL72fK0IjW0WqCV7NCYLvKCjomZLhf3ZPAfCyCOSP9riTglnh53OV47M3ydo25ZA==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/shallowequal" "^1.1.1"
+    dnd-core "^9.3.2"
+    hoist-non-react-statics "^3.3.0"
+    shallowequal "^1.1.0"
 
 react-docgen@^4.1.0:
   version "4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4963,11 +4963,6 @@ eslint@^5.15.1:
     table "^5.2.3"
     text-table "^0.2.0"
 
-esm@^3.2.25:
-  version "3.2.25"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
-
 espree@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4963,6 +4963,11 @@ eslint@^5.15.1:
     table "^5.2.3"
     text-table "^0.2.0"
 
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
@@ -9443,6 +9448,13 @@ react-dnd-html5-backend@^9.3.2:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-9.3.2.tgz#4833043aec91e69dd968ac136deebf7535f5eb9d"
   integrity sha512-EsQLA3fikHxkkvs6COnEdo3McJg2Q82z6EQxo7s3yqez4LAutrcp7pf5/eyW1nFDcdN3JNx2p+TrkjVjEd5exw==
+  dependencies:
+    dnd-core "^9.3.2"
+
+react-dnd-test-backend@^9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/react-dnd-test-backend/-/react-dnd-test-backend-9.3.2.tgz#dbda4173af22089bf086e22c3445aed9729bd816"
+  integrity sha512-Ud1SmXUw3445HiqhmOCxnOx21ohnJ2gTKtkfRp8K/4Sfh79DC505zvNCnDUo/OGGdIWDN6R2wM3h6kIgAAsASQ==
   dependencies:
     dnd-core "^9.3.2"
 


### PR DESCRIPTION
## 👀 Overview
This PR adds UI components which enabled us to establish re-usable drag and drop patterns.

## 💬 Description
In the past, we've added Drag and Drop to our consuming app directly because we believed it was better suited to not include that domain into this library. However, with the new hierarchy view, we cannot build it without drag and drop.

As well as this we had a number of substantial challenges when building our Drag and Drop experience in the app, to my knowledge the biggest challenge was;

- generating a custom drag preview (which altered based on selection context & warnings)

We thought as well as creating the predictable `Draggable` & `Droppable` components I would also resolve the challenge above by adding a `DragPreview` component and showing how we can disable the default preview per drag instance.

We also thought that we'd show just how we can handle custom `canDrop` logic which is shown in the GIF on this PR.

**Surely this isn't just using components?**

You're correct, this PR also contains a provider which enables us to have a top-level parent to manage our drag and drop experience.

**Is this tested?**

No. I tried to get tests working but even using their tutorial doesn't work. I will investigate this further but please don't hold this back because of that. We will get this covered, just not right now.

## 📹 GIF (optional)
https://cl.ly/11ab65720e16

## 🚪 Start Points
I've commented on the changes.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook