### PR TITLE
Fix participant info email padding

### DIFF
--- a/lib/ParticipantInfo/styles.scss
+++ b/lib/ParticipantInfo/styles.scss
@@ -18,5 +18,5 @@ $participant-info-name-size: $typo-size-lead !default;
 }
 
 .participant_info__email {
-  margin: $typo-size-lead/5 0 $typo-size-lead/2 0;
+  margin: $typo-size-lead/5 0;
 }


### PR DESCRIPTION
Exactly how the title says, the larger bottom margin looked a bit off