### PR TITLE
Make participant email styling match avatars

### DIFF
--- a/lib/ParticipantInfo/styles.scss
+++ b/lib/ParticipantInfo/styles.scss
@@ -20,3 +20,8 @@ $participant-info-name-size: $typo-size-lead !default;
 .participant_info__email {
   margin: $typo-size-lead/5 0;
 }
+
+.participant_info__name + .participant_info__email {
+  color: $neutral-base;
+  font-size: $typo-size-slight;
+}


### PR DESCRIPTION
### 👀 Overview
As the title says, Avatar had this styling block but ParticipantInfo did not
### 📹 GIF (optional)
http://g.recordit.co/1eVoSQRmOC.gif

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook