### PR TITLE
Fixing selecting items and folders in hierarchy story

### DIFF
--- a/lib/FolderRow/FolderRow.js
+++ b/lib/FolderRow/FolderRow.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { bool, node, string } from 'prop-types';
 import cx from 'classnames';
 
-function FolderRow({ children, open, className, backdrop, ...rest }) {
+function FolderRow({ children, open, className, ...rest }) {
   const [show, setShow] = useState(open);
 
   useEffect(() => {
@@ -15,7 +15,6 @@ function FolderRow({ children, open, className, backdrop, ...rest }) {
 
   return (
     <div className={classNames} {...rest}>
-      {backdrop && <div className="folder-row__backdrop">{backdrop}</div>}
       {children(show, setShow)}
     </div>
   );
@@ -24,14 +23,12 @@ function FolderRow({ children, open, className, backdrop, ...rest }) {
 FolderRow.propTypes = {
   children: node.isRequired,
   className: string,
-  open: bool,
-  backdrop: node
+  open: bool
 };
 
 FolderRow.defaultProps = {
   className: '',
-  open: false,
-  backdrop: null
+  open: false
 };
 
 export { FolderRow };

--- a/stories/webapp/hierarchy/HierarchyFolderRow.js
+++ b/stories/webapp/hierarchy/HierarchyFolderRow.js
@@ -38,22 +38,21 @@ function HierarchyFolderRow({ id, name, childIds, nameForm, children, open }) {
   }, [name]);
 
   return (
-    <FolderRow
-      className={classNames}
-      open={open}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      backdrop={
-        <button
-          type="button"
-          className="h-button-clear"
-          onClick={handleClick}
-        />
-      }
-    >
+    <FolderRow open={open}>
       {(show, setShow) => (
         <>
-          <FolderRow.Inner style={{ minWidth: '320px' }}>
+          <FolderRow.Inner className={classNames} style={{ minWidth: '320px' }}>
+            <div
+              className="folder-row__backdrop"
+              onMouseEnter={handleMouseEnter}
+              onMouseLeave={handleMouseLeave}
+            >
+              <button
+                type="button"
+                className="h-button-clear"
+                onClick={handleClick}
+              />
+            </div>
             <FolderRow.Name setShow={setShow} show={show} showToggle>
               {nameForm || (
                 <HierarchyNameInput

--- a/stories/webapp/hierarchy/data.js
+++ b/stories/webapp/hierarchy/data.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v1';
+import uuid from 'uuid/v4';
 import faker from 'faker';
 import { boolean, number, text } from '@storybook/addon-knobs';
 


### PR DESCRIPTION
### 👀 Overview
When we did some refactoring of a `FolderRow` for the hierarchy, we broke the logic around selecting. This fixes it! 

### 💬 Description
V1 of `uuid` wasn't giving us different uuid's, that's because it goes off timestamp. The internet™ says that v4 is the place to be. I switched it and it did the job!

The backdrop was used to cover the folder row in a big button to select with, but it's not needed now we'vseparateded the component into multiple composite ones. 

### ✅ Checklist
- [x] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook