### PR TITLE
Changing flex property to work in all browsers

### DIFF
--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -44,7 +44,7 @@ $field-data-p-line-height: 1.688rem !default;
 
   .row {
     display: flex;
-    flex-wrap: wrap;
+    flex-flow: row;
   }
 
   &.is-disabled {


### PR DESCRIPTION
### 👀 Overview
`flex-wrap: wrap` does not work in safari! According to stack overflow this line does. I have tested it in chrome, safari + firefox and it looks good!

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook