### PR TITLE
Removing unneeded flex from row

### DIFF
--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -44,7 +44,6 @@ $field-data-p-line-height: 1.688rem !default;
 
   .row {
     display: flex;
-    flex-flow: row;
   }
 
   &.is-disabled {


### PR DESCRIPTION
`flex-flow: row` caused assets to not wrap onto the new line. It turns out we should have been using media queries in app. so I'm removing that line altogether.