### PR TITLE
This is the actual fix now

### DIFF
--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -44,6 +44,12 @@ $field-data-p-line-height: 1.688rem !default;
 
   .row {
     display: flex;
+    flex-wrap: wrap;
+  }
+
+  .row:after,
+  .row:before {
+    display: flex;
   }
 
   &.is-disabled {


### PR DESCRIPTION
Turns out we do need to keep `flex-wrap: wrap` for our columns. I had made an assumption that our bootstrap v4 had flexbox, but we were using v3 which doesn't!

To counter that, we need to ensure that all part of the row are using flexbox, even the `before` and `after`!.