### PR TITLE
Adding buttonLabel to EditableTextWrapper

### DIFF
--- a/lib/EditableTextWrapper/index.js
+++ b/lib/EditableTextWrapper/index.js
@@ -17,6 +17,7 @@ export default class EditableTextWrapper extends Component {
     multiline: PropTypes.bool,
     placeholder: PropTypes.string,
     pencilEditOnly: PropTypes.bool,
+    inputLabel: PropTypes.string.isRequired,
     buttonLabel: PropTypes.string
   };
 
@@ -115,6 +116,12 @@ export default class EditableTextWrapper extends Component {
     if (!this.props.multiline) {
       return (
         <div className={classes}>
+          <label
+            htmlFor="editable-text-wrapper-input"
+            className="visually-hidden"
+          >
+            {this.props.inputLabel}
+          </label>
           <input
             placeholder={this.props.placeholder}
             className="editable-text__input single-line"
@@ -124,6 +131,7 @@ export default class EditableTextWrapper extends Component {
             onFocus={e => e.target.select()}
             onBlur={this.handleOnBlur}
             autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+            id="editable-text-wrapper-input"
           />
         </div>
       );
@@ -131,6 +139,12 @@ export default class EditableTextWrapper extends Component {
 
     return (
       <div className={classes}>
+        <label
+          htmlFor="editable-text-wrapper-input"
+          className="visually-hidden"
+        >
+          {this.props.inputLabel}
+        </label>
         <ExpandingTextArea
           placeholder={this.props.placeholder}
           className="editable-text__input"
@@ -140,6 +154,7 @@ export default class EditableTextWrapper extends Component {
           handleOnFocus={e => e.target.select()}
           handleOnBlur={this.handleOnBlur}
           focusOnMount
+          id="editable-text-wrapper-input"
         />
       </div>
     );

--- a/lib/EditableTextWrapper/index.js
+++ b/lib/EditableTextWrapper/index.js
@@ -16,7 +16,8 @@ export default class EditableTextWrapper extends Component {
     className: PropTypes.string,
     multiline: PropTypes.bool,
     placeholder: PropTypes.string,
-    pencilEditOnly: PropTypes.bool
+    pencilEditOnly: PropTypes.bool,
+    buttonLabel: PropTypes.string
   };
 
   static defaultProps = {
@@ -26,7 +27,8 @@ export default class EditableTextWrapper extends Component {
     pencilEditOnly: false,
     placeholder: 'Enter a value',
     onStopEditing: () => {},
-    onStartEditing: () => {}
+    onStartEditing: () => {},
+    buttonLabel: ''
   };
 
   state = { editing: false, value: this.props.value };
@@ -93,6 +95,9 @@ export default class EditableTextWrapper extends Component {
           clickHandler={this.startEditing}
           title={title}
         >
+          {this.props.buttonLabel && (
+            <span className="visually-hidden">{this.props.buttonLabel}</span>
+          )}
           <Icon name="pencil" />
         </Button>
       </div>

--- a/stories/components/EditableTextWrapper.js
+++ b/stories/components/EditableTextWrapper.js
@@ -4,36 +4,48 @@ import { action } from '@storybook/addon-actions';
 import EditableTextWrapper from '../../lib/EditableTextWrapper';
 import StoryItem from '../styleguide/StoryItem';
 
-const longText = 'Original text thats quite long and may well go over a single line, so its much safer to set the multiline prop, that way we render an ExpandingTextArea component instead of a normal text input';
+const longText =
+  'Original text thats quite long and may well go over a single line, so its much safer to set the multiline prop, that way we render an ExpandingTextArea component instead of a normal text input';
 
-storiesOf('Components', module)
-  .add('EditableTextWrapper', () => (
-    <div>
-      <StoryItem
-        title="EditableTextWrapper"
-        description="Wraps text in an editable wrapper"
+storiesOf('Components', module).add('EditableTextWrapper', () => (
+  <div>
+    <StoryItem
+      title="EditableTextWrapper"
+      description="Wraps text in an editable wrapper"
+    >
+      <EditableTextWrapper
+        buttonLabel="Editable text"
+        value="Original text"
+        onChange={v => action('renamed to: ')(v)}
       >
-        <EditableTextWrapper value="Original text" onChange={v => action('renamed to: ')(v)}>
-          <h1>Original text</h1>
-        </EditableTextWrapper>
-      </StoryItem>
+        <h1>Original text</h1>
+      </EditableTextWrapper>
+    </StoryItem>
 
-      <StoryItem
-        title="EditableTextWrapper pencilEditOnly"
-        description="An EditableTextWrapper where the edit state can only be activated by the pencil button"
+    <StoryItem
+      title="EditableTextWrapper pencilEditOnly"
+      description="An EditableTextWrapper where the edit state can only be activated by the pencil button"
+    >
+      <EditableTextWrapper
+        value="Original text"
+        onChange={v => action('renamed to: ')(v)}
+        pencilEditOnly
       >
-        <EditableTextWrapper value="Original text" onChange={v => action('renamed to: ')(v)} pencilEditOnly>
-          <h1>Original text</h1>
-        </EditableTextWrapper>
-      </StoryItem>
+        <h1>Original text</h1>
+      </EditableTextWrapper>
+    </StoryItem>
 
-      <StoryItem
-        title="EditableTextWrapper multiline"
-        description="An EditableTextWrapper that displays an ExpandingTextArea when in the edit state"
+    <StoryItem
+      title="EditableTextWrapper multiline"
+      description="An EditableTextWrapper that displays an ExpandingTextArea when in the edit state"
+    >
+      <EditableTextWrapper
+        value={longText}
+        onChange={v => action('renamed to: ')(v)}
+        multiline
       >
-        <EditableTextWrapper value={longText} onChange={v => action('renamed to: ')(v)} multiline>
-          <h1>{longText}</h1>
-        </EditableTextWrapper>
-      </StoryItem>
-    </div>
-  ));
+        <h1>{longText}</h1>
+      </EditableTextWrapper>
+    </StoryItem>
+  </div>
+));


### PR DESCRIPTION
### 👀 Overview
This adds a prop to have some text inside the pencil button.

EDIT:

A label has also been added for the input that `EditableTextWrapper` renders. All inputs should have labels!
### 💬 Description
**Any** button that is just an icon should also have some text inside, but set to `visually-hidden`. This is so screen readers know what the button does.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [x] Added to storybook