### PR TITLE
Fix widths for windowing items and lists

### DIFF
--- a/lib/FolderRow/FolderRowInner.js
+++ b/lib/FolderRow/FolderRowInner.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import { node } from 'prop-types';
 
-function FolderRowInner({ children }) {
-  return <div className="folder-row__inner">{children}</div>;
+function FolderRowInner({ children, ...rest }) {
+  return (
+    <div className="folder-row__inner" {...rest}>
+      {children}
+    </div>
+  );
 }
 
 FolderRowInner.propTypes = {

--- a/lib/FolderRow/styles.scss
+++ b/lib/FolderRow/styles.scss
@@ -100,18 +100,6 @@ $folder-row-spacing: $layout-spacing-base/2 !default;
     width: 2px;
     background: $neutral-light;
   }
-
-  .windowing-list {
-    width: calc(100% - 40px);
-
-    > .windowing-item {
-      width: 100%;
-    }
-  }
-}
-
-.folder-row > .windowing-item {
-  width: calc(100% - 40px);
 }
 
 /* ==========================================================================

--- a/lib/Windowing/InViewListItem.js
+++ b/lib/Windowing/InViewListItem.js
@@ -15,7 +15,10 @@ function InViewListItem({ children, index, relativeToRenderIndexes }) {
   return (
     <div
       key={`${index}-id`}
-      style={{ ...baseItemStyle, top: `${top}px` }}
+      style={{
+        ...baseItemStyle,
+        top: `${top}px`
+      }}
       className="windowing-item"
     >
       {children}

--- a/lib/Windowing/stories/WindowingFolderRow.js
+++ b/lib/Windowing/stories/WindowingFolderRow.js
@@ -7,53 +7,60 @@ function WindowingFolderRow({
   offset,
   childrenDepth,
   itemCount,
-  currentDepth
+  depth
 }) {
   const items = [...new Array(itemCount)].map(
-    (i, childIndex) => `folder-${currentDepth}-${childIndex}`
+    (i, childIndex) => `folder-${depth}-${childIndex}`
   );
 
   return (
-    currentDepth <= childrenDepth && (
+    depth <= childrenDepth && (
       <FolderRow open>
         {(show, setShow) => (
           <>
             <InViewListItem index={index} relativeToRenderIndexes={false}>
-              <FolderRow.Inner>
+              <FolderRow.Inner style={{ minWidth: '320px' }}>
                 <FolderRow.Name show={show} setShow={setShow}>
-                  {`folder ${currentDepth}`}
+                  {`folder ${depth}`}
                 </FolderRow.Name>
               </FolderRow.Inner>
             </InViewListItem>
 
-            <InViewList
-              items={items}
-              index={index + 1}
-              acceptedRange={{ offset, length: itemCount }}
-            >
-              {sharedState => (
-                <FolderRow.Contents show={show}>
-                  {sharedState.itemsInView.map(i => (
-                    <InViewListItem
-                      key={i}
-                      index={items.indexOf(i)}
-                      relativeToRenderIndexes={false}
-                    >
-                      <ItemRow bordered data-testid={i}>
-                        <ItemRow.Name>{i}</ItemRow.Name>
-                      </ItemRow>
-                    </InViewListItem>
-                  ))}
-                  <WindowingFolderRow
-                    index={itemCount}
-                    offset={currentDepth * (itemCount + 1)}
-                    itemCount={itemCount}
-                    childrenDepth={childrenDepth}
-                    currentDepth={currentDepth + 1}
-                  />
-                </FolderRow.Contents>
-              )}
-            </InViewList>
+            <FolderRow.Contents show={show}>
+              <InViewList
+                items={items}
+                index={index + 1}
+                depth={depth}
+                acceptedRange={{ offset, length: itemCount }}
+              >
+                {sharedState => (
+                  <>
+                    {sharedState.itemsInView.map(i => (
+                      <InViewListItem
+                        key={i}
+                        index={items.indexOf(i)}
+                        relativeToRenderIndexes={false}
+                      >
+                        <ItemRow
+                          bordered
+                          data-testid={i}
+                          style={{ minWidth: '320px' }}
+                        >
+                          <ItemRow.Name>{i}</ItemRow.Name>
+                        </ItemRow>
+                      </InViewListItem>
+                    ))}
+                    <WindowingFolderRow
+                      index={itemCount}
+                      depth={depth + 1}
+                      offset={depth * (itemCount + 1)}
+                      itemCount={itemCount}
+                      childrenDepth={childrenDepth}
+                    />
+                  </>
+                )}
+              </InViewList>
+            </FolderRow.Contents>
           </>
         )}
       </FolderRow>

--- a/lib/Windowing/stories/WindowingFolderRow.js
+++ b/lib/Windowing/stories/WindowingFolderRow.js
@@ -73,11 +73,11 @@ WindowingFolderRow.propTypes = {
   offset: number.isRequired,
   childrenDepth: number.isRequired,
   itemCount: number.isRequired,
-  currentDepth: number
+  depth: number
 };
 
 WindowingFolderRow.defaultProps = {
-  currentDepth: 1
+  depth: 1
 };
 
 export { WindowingFolderRow };

--- a/lib/Windowing/stories/WindowingStory.js
+++ b/lib/Windowing/stories/WindowingStory.js
@@ -39,8 +39,8 @@ stories
     );
   })
   .add('Nested', () => {
-    const childrenDepth = number('Depth of children', 6);
-    const itemCount = number('Number of items in each layer', 100);
+    const childrenDepth = number('Depth of children', 20);
+    const itemCount = number('Number of items in each layer', 5);
     const buffer = number('Buffer', 20);
 
     const allIdslength = childrenDepth * itemCount + childrenDepth;
@@ -53,8 +53,9 @@ stories
         buffer={buffer}
       >
         <WindowingFolderRow
-          index={0}
           name="folder 1"
+          index={0}
+          depth={1}
           offset={0}
           itemCount={itemCount}
           childrenDepth={childrenDepth}

--- a/lib/Windowing/styles.scss
+++ b/lib/Windowing/styles.scss
@@ -1,8 +1,10 @@
 .windowing-list {
   position: absolute;
+  width: calc(100% - 40px);
 }
 
 .windowing-item {
   float: left;
   position: absolute;
+  width: 100%;
 }

--- a/lib/Windowing/tests/WindowingProvider.spec.js
+++ b/lib/Windowing/tests/WindowingProvider.spec.js
@@ -85,8 +85,8 @@ describe('WindowingProvider', () => {
           containerHeight={500}
         >
           <WindowingFolderRow
-            index={0}
             name="folder-1"
+            index={0}
             offset={0}
             itemCount={itemCount}
             childrenDepth={childrenDepth}

--- a/stories/webapp/hierarchy/ItemRow/HierarchyItemRow.js
+++ b/stories/webapp/hierarchy/ItemRow/HierarchyItemRow.js
@@ -72,7 +72,7 @@ export const HierarchyItemRow = ({ id, name, status, nameForm }) => {
           <ItemRow.Aside>
             <ItemRow.Data>No template</ItemRow.Data>
             <ItemRow.Data style={{ minWidth: '75px' }}>{avatars}</ItemRow.Data>
-          </ItemRow.Aside>{' '}
+          </ItemRow.Aside>
         </>
       )}
     </ItemRow>


### PR DESCRIPTION
## 💬 Description
Windowing and widths are funky due to the absolute positioning element to windowing. There were a few bugs with how it was currently done but nothing major.

This PR moves some CSS around to get a correct looking UI (check GIF).

## 📹 GIF (optional)
https://cl.ly/81b4aab51683 

### ✅ Checklist
- [ ] ~~Tests written~~
- [x] Browser tested
- [ ] ~~Added to documentation~~
- [x] Added to storybook