### PR TITLE
Improved performance of windowing calculation

### DIFF
--- a/lib/Windowing/InViewList.js
+++ b/lib/Windowing/InViewList.js
@@ -29,18 +29,31 @@ const calculateOffsetAndLength = (renderIndexes, acceptedRange) => {
   };
 };
 
+const areRenderIndexesWithinAcceptedRange = (renderIndexes, acceptedRange) =>
+  renderIndexes.offset > acceptedRange.offset + acceptedRange.length ||
+  acceptedRange.offset > renderIndexes.offset + renderIndexes.length;
+
+const getRangeFromAcceptedRange = (renderIndexes, acceptedRange) => {
+  if (
+    acceptedRange &&
+    !areRenderIndexesWithinAcceptedRange(renderIndexes, acceptedRange)
+  ) {
+    return calculateOffsetAndLength(renderIndexes, acceptedRange);
+  }
+
+  return { offset: 0, length: 0 };
+};
+
 function InViewList({ items, children, acceptedRange, index, ...rest }) {
   const { renderIndexes, itemHeight } = useContext(WindowingContext);
 
-  let { offset, length } = renderIndexes;
-
-  if (acceptedRange) {
-    const result = calculateOffsetAndLength(renderIndexes, acceptedRange);
-    ({ offset, length } = result);
-  }
+  const { offset, length } = getRangeFromAcceptedRange(
+    renderIndexes,
+    acceptedRange
+  );
 
   const sharedState = {
-    itemsInView: items.slice(offset, offset + length)
+    itemsInView: length > 0 ? items.slice(offset, offset + length) : []
   };
 
   return (


### PR DESCRIPTION
### 👀 Overview
The nested windowing gets a bit sluggish when there are lots of layers.
### 💬 Description
We have added some extra conditional logic around certain calculations, this is so it is not doing them when it doesn't have to!

### ✅ Checklist
- [x] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [x] Added to storybook