### PR TITLE
remove conversation subheading, replace with showing the user type

### DIFF
--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -27,7 +27,6 @@ class Comment extends Component {
     userCanComment: PropTypes.bool.isRequired,
     retryComment: PropTypes.func.isRequired,
     hasFailed: PropTypes.bool,
-    conversationSubheading: PropTypes.string.isRequired,
     isLatestReply: PropTypes.bool
   };
 
@@ -107,26 +106,19 @@ class Comment extends Component {
       index,
       userCanComment,
       hasFailed,
-      conversationSubheading,
       isLatestReply
     } = this.props;
     const isOp = index === 0 && !isLatestReply;
     const removalText = isOp ? 'Delete thread' : 'Delete comment';
     const userCanEdit = createdBy === user.id && userCanComment;
-    const subHeading = isOp ? conversationSubheading : '';
     const className = cx('conversation__comment', {
       'is-disabled': this.state.confirmRemoval,
       'has-failed': this.props.hasFailed,
-      'has-subheading': subHeading
+      'has-author-type': author.type
     });
-
     return (
       <div className={className}>
-        <Person
-          person={author}
-          className="conversation"
-          personSubheading={subHeading}
-        />
+        <Person person={author} className="conversation" />
 
         <div className="conversation__comment-body">
           {!this.state.showEditForm && (

--- a/lib/Conversation/index.js
+++ b/lib/Conversation/index.js
@@ -36,8 +36,7 @@ class Conversation extends Component {
     handleUndoResolve: PropTypes.func,
     onSubscribeChange: PropTypes.func,
     isSubscribed: PropTypes.bool,
-    cornerIcon: PropTypes.string,
-    conversationSubheading: PropTypes.string
+    cornerIcon: PropTypes.string
   };
 
   static defaultProps = {
@@ -62,8 +61,7 @@ class Conversation extends Component {
     handleUndoResolve: null,
     onSubscribeChange: null,
     isSubscribed: false,
-    cornerIcon: null,
-    conversationSubheading: ''
+    cornerIcon: null
   };
 
   state = {

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -237,9 +237,6 @@ $conversation-meta-text-color: $neutral-base !default;
   padding-top: 0;
 }
 
-.conversation__person-subheading {
-  color: $primary-purple;
-}
 
 /* ==========================================================================
    State Styles
@@ -304,7 +301,7 @@ $conversation-meta-text-color: $neutral-base !default;
   margin-bottom: $conversation-padding;
 }
 
-.is-disabled .conversation__person-subheading,
+.is-disabled .conversation__person-type,
 .is-disabled .conversation__person-name,
 .is-disabled .conversation__comment-body {
   background: rgba(255, 255, 255, .75);
@@ -322,11 +319,13 @@ $conversation-meta-text-color: $neutral-base !default;
     border-bottom: none;
   }
 }
-.has-subheading.conversation__comment {
+.is-active .has-author-type.conversation__comment:before,
+.show-reply-preview > .conversation__comment-list .has-author-type.conversation__comment:before {
+  margin-top: $layout-spacing-base/4 - 1;
+  height: calc(100% - #{$layout-spacing-base/4 - 1});
+}
+.has-author-type.conversation__comment {
   .conversation__comment-body {
     margin: -0.1rem 0 0;
-  }
-  &:before {
-    margin-top: $layout-spacing-base/4;
   }
 }

--- a/lib/Person/index.js
+++ b/lib/Person/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Avatar from '../Avatar';
 
-const Person = ({ person, className, personSubheading }) => (
+const Person = ({ person, className }) => (
   <div className={`person ${className}__person`}>
     <Avatar
       className="avatar--supporting"
@@ -11,14 +11,14 @@ const Person = ({ person, className, personSubheading }) => (
       initials={person.initials}
     />
     <div>
-      {personSubheading && (
-        <p className={`person__subheading ${className}__person-subheading`}>
-          {personSubheading}
-        </p>
-      )}
       <span className={`person__name ${className}__person-name`}>
         {person.name}
       </span>
+      {person.type && (
+        <p className={`person__type ${className}__person-type`}>
+          {person.type}
+        </p>
+      )}
     </div>
   </div>
 );
@@ -27,20 +27,20 @@ Person.propTypes = {
   person: PropTypes.shape({
     avatar: PropTypes.string,
     name: PropTypes.string,
-    initials: PropTypes.string
+    initials: PropTypes.string,
+    type: PropTypes.string
   }),
-  className: PropTypes.string,
-  personSubheading: PropTypes.string
+  className: PropTypes.string
 };
 
 Person.defaultProps = {
   person: {
     name: '',
     avatar: '',
-    initials: ''
+    initials: '',
+    type: ''
   },
-  className: '',
-  personSubheading: ''
+  className: ''
 };
 
 export default Person;

--- a/lib/Person/styles.scss
+++ b/lib/Person/styles.scss
@@ -24,8 +24,8 @@ $person-avatar-border-radius: 40px !default;
   width: $person-avatar-size;
   margin: 0 $layout-spacing-base/2 0 0;
 }
-.person__subheading {
-  margin: 0;
+.person__type {
+  margin: (-$layout-spacing-base/10) 0 0 0;
   font-size: $typo-size-slight;
-  font-weight: $person-name-weight;
+  color: $neutral-base;
 }

--- a/stories/components/Conversation.js
+++ b/stories/components/Conversation.js
@@ -10,7 +10,7 @@ const mockUser = {
   name: 'Bruce',
   avatar: 'https://gathercontent-production-avatars.s3-us-west-2.amazonaws.com/208205_yHGd7vA5HRxsnMQpES4UzjJ7Yxgn6Bp54165gqksRXyDJhuOnW88H6djhLJeE2BZ.jpg',
   initials: 'BB',
-  display: 'brucebanner'
+  display: 'brucebanner',
 };
 
 const mockUserNoAvatar = {
@@ -28,7 +28,7 @@ const mockUsers = [
     display: 'saulgoodman',
     name: 'Saul Goodman',
     initials: 'SG',
-    email: 'heythere@lol.com'
+    email: 'heythere@lol.com',
   },
   {
     id: '456',
@@ -61,6 +61,7 @@ const mockComments = [{
     avatar: 'https://gathercontent-production-avatars.s3-us-west-2.amazonaws.com/26263_nH1Vuciy3psgQEUCVXZPTVU2RzUyMJ2arUIH7le8U4RrJ9LjFrtvEmyzf2XFgnZ7.png',
     name: 'Ricardo',
     initials: 'RB',
+    type: 'Guest user'
   },
   createdBy: 4
 }];
@@ -198,7 +199,6 @@ storiesOf('Components', module)
                 userCanResolve
                 onSubscribeChange={mockActions.onSubscribeChange}
                 isSubscribed
-                conversationSubheading="This is a special comment"
               />
             )}
           </BoundaryClickWatcher>

--- a/tests/Conversation/Comment.js
+++ b/tests/Conversation/Comment.js
@@ -48,8 +48,7 @@ describe('Comment', () => {
     focusFallback: document.createElement('input'),
     users: mockUsers,
     userCanComment: true,
-    retryComment: retryCommentSpy,
-    conversationSubheading: ''
+    retryComment: retryCommentSpy
   };
 
   beforeEach(() => {
@@ -201,14 +200,5 @@ describe('Comment', () => {
   test('retryComment passes the comment id and body', () => {
     wrapper.instance().retryComment();
     expect(retryCommentSpy).toHaveBeenCalledWith('123', 'comment body text');
-  });
-
-  test('shows a sub heading', () => {
-    wrapper.setProps({ conversationSubheading: 'hello!', index: 0 });
-    expect(wrapper.find(Person).prop('personSubheading')).toEqual('hello!');
-    wrapper.setProps({ index: 3 });
-    expect(wrapper.find(Person).prop('personSubheading')).toEqual('');
-    wrapper.setProps({ index: 0, isLatestReply: true });
-    expect(wrapper.find(Person).prop('personSubheading')).toEqual('');
   });
 });


### PR DESCRIPTION
### 👀 Overview
This is me rejigging some work I've just done to add a conversation subheading. Instead of a subheading for the conversation, we're showing the user type beneath each author if required. 

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [x] Added to storybook