### PR TITLE
Changing prop type for containerHeight to be either a number or string

### DIFF
--- a/lib/Windowing/Windowing.js
+++ b/lib/Windowing/Windowing.js
@@ -1,5 +1,5 @@
 import React, { useState, createContext, useEffect } from 'react';
-import { node, number, arrayOf, any, string } from 'prop-types';
+import { node, number, arrayOf, any, string, oneOfType } from 'prop-types';
 
 export const WindowingContext = createContext({});
 
@@ -82,7 +82,7 @@ Windowing.propTypes = {
   children: node.isRequired,
   itemHeight: number.isRequired,
   debounceTimer: number,
-  containerHeight: string,
+  containerHeight: oneOfType([string, number]),
   buffer: number,
   allIds: arrayOf(any).isRequired
 };


### PR DESCRIPTION
### 👀 Overview
The prop type for `containerHeight` is incorrect. It can accept either a string or number, not just a string!