### PR TITLE
Refactor windowing to use props rather than localised state

### DIFF
--- a/lib/Windowing/Windowing.js
+++ b/lib/Windowing/Windowing.js
@@ -14,13 +14,11 @@ const Windowing = ({
   const [scrollTop, setScrollTop] = useState(null);
   const [height, setHeight] = useState(null);
   const [renderIndexes, setRenderIndexes] = useState({});
-  const [allWindowingIds, setAllWindowingIds] = useState(allIds);
   const [inViewWindowingIds, setInViewWindowingIds] = useState([]);
 
   const subtractFromStartIndex = index => Math.max(index - buffer, 0);
 
-  const addToEndIndex = index =>
-    Math.min(allWindowingIds.length, index + buffer);
+  const addToEndIndex = index => Math.min(allIds.length, index + buffer);
 
   const getRenderIndexes = () => {
     const startBoundary = scrollTop;
@@ -38,20 +36,7 @@ const Windowing = ({
     });
   };
 
-  useEffect(getRenderIndexes, [height, scrollTop, allWindowingIds]);
-
-  const addIds = (ids, index) =>
-    setAllWindowingIds([
-      ...allWindowingIds.slice(0, index),
-      ...ids,
-      ...allWindowingIds.slice(index)
-    ]);
-
-  const removeIds = (offset, length) =>
-    setAllWindowingIds([
-      ...allWindowingIds.slice(0, offset),
-      ...allWindowingIds.slice(offset + length, allWindowingIds.length)
-    ]);
+  useEffect(getRenderIndexes, [height, scrollTop, allIds]);
 
   const sharedState = {
     scrollTop,
@@ -64,11 +49,9 @@ const Windowing = ({
     setHeight,
     debounceTimer,
     containerHeight,
-    addIds,
-    removeIds,
-    allWindowingIds,
     inViewWindowingIds,
-    setInViewWindowingIds
+    setInViewWindowingIds,
+    allWindowingIds: allIds
   };
 
   return (

--- a/lib/Windowing/stories/WindowingIdsMock.js
+++ b/lib/Windowing/stories/WindowingIdsMock.js
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+function WindowingIdsMock({ children, allWindowingIds }) {
+  const [allIds, setAllIds] = useState(allWindowingIds);
+
+  const addIds = (ids, index) =>
+    setAllIds([...allIds.slice(0, index), ...ids, ...allIds.slice(index)]);
+
+  const removeIds = (offset, length) =>
+    setAllIds([
+      ...allIds.slice(0, offset),
+      ...allIds.slice(offset + length, allIds.length)
+    ]);
+
+  return children({
+    allWindowingIds: allIds,
+    addIds,
+    removeIds
+  });
+}
+
+export { WindowingIdsMock };

--- a/lib/Windowing/stories/WindowingStory.js
+++ b/lib/Windowing/stories/WindowingStory.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, number } from '@storybook/addon-knobs';
 import { Windowing, ItemRow, FolderRow } from '../../index';
-import { WindowingContext } from '../Windowing';
 import { createData } from './windowingData';
+import { WindowingIdsMock } from './WindowingIdsMock';
 
 const stories = storiesOf('Components/Windowing', module);
 stories.addDecorator(withKnobs);
@@ -39,26 +39,26 @@ stories
     const { allIds, parentIds, byId } = createData(parents, children);
 
     return (
-      <Windowing
-        itemHeight={50}
-        buffer={20}
-        allIds={allIds}
-        containerHeight="500px"
-      >
-        <Windowing.Scroller>
-          <Windowing.List>
-            {({ inViewWindowingIds }) =>
-              inViewWindowingIds.map(i => (
-                <Windowing.Item
-                  key={i}
-                  index={allIds.indexOf(i)}
-                  style={{
-                    paddingLeft: `${byId[i].depth * 40}px`
-                  }}
-                >
-                  <WindowingContext.Consumer>
-                    {({ removeIds, addIds, allWindowingIds }) =>
-                      parentIds.indexOf(i) === -1 ? (
+      <WindowingIdsMock allWindowingIds={allIds}>
+        {({ allWindowingIds, addIds, removeIds }) => (
+          <Windowing
+            itemHeight={50}
+            buffer={20}
+            allIds={allWindowingIds}
+            containerHeight="500px"
+          >
+            <Windowing.Scroller>
+              <Windowing.List>
+                {({ inViewWindowingIds }) =>
+                  inViewWindowingIds.map(i => (
+                    <Windowing.Item
+                      key={i}
+                      index={allIds.indexOf(i)}
+                      style={{
+                        paddingLeft: `${byId[i].depth * 40}px`
+                      }}
+                    >
+                      {parentIds.indexOf(i) === -1 ? (
                         <ItemRow bordered>
                           <ItemRow.Name>{byId[i].name}</ItemRow.Name>
                         </ItemRow>
@@ -92,14 +92,14 @@ stories
                             </FolderRow.Inner>
                           )}
                         </FolderRow>
-                      )
-                    }
-                  </WindowingContext.Consumer>
-                </Windowing.Item>
-              ))
-            }
-          </Windowing.List>
-        </Windowing.Scroller>
-      </Windowing>
+                      )}
+                    </Windowing.Item>
+                  ))
+                }
+              </Windowing.List>
+            </Windowing.Scroller>
+          </Windowing>
+        )}
+      </WindowingIdsMock>
     );
   });

--- a/stories/webapp/hierarchy/HierarchyCollection.js
+++ b/stories/webapp/hierarchy/HierarchyCollection.js
@@ -6,7 +6,9 @@ import { HierarchyItemRow } from './ItemRow/HierarchyItemRow';
 export const HierarchyCollection = ({
   inViewWindowingIds,
   data,
-  statusColor
+  statusColor,
+  addIds,
+  removeIds
 }) => {
   const { allWindowingIds } = useContext(Windowing.Context);
   const [newItemParentId, setNewItemParentId] = useState('');
@@ -28,6 +30,8 @@ export const HierarchyCollection = ({
               setNewItemParentId(id);
             }}
             childIds={data.itemsByParent[id]}
+            addIds={addIds}
+            removeIds={removeIds}
           />
         </Windowing.Item>
       );

--- a/stories/webapp/hierarchy/HierarchyFolderRow.js
+++ b/stories/webapp/hierarchy/HierarchyFolderRow.js
@@ -6,10 +6,18 @@ import cx from 'classnames';
 import { HierarchyFolderRowActions } from './FolderRow/HierarchyFolderRowActions';
 import { HierarchyNameInput } from './shared/HierarchyNameInput';
 
-function HierarchyFolderRow({ id, name, open, onNewItem, childIds }) {
+function HierarchyFolderRow({
+  id,
+  name,
+  open,
+  onNewItem,
+  childIds,
+  addIds,
+  removeIds
+}) {
   const [folderName, setFolderName] = useState(name);
 
-  const { addIds, allWindowingIds, removeIds } = useContext(Windowing.Context);
+  const { allWindowingIds } = useContext(Windowing.Context);
 
   const {
     isSelected,
@@ -95,7 +103,9 @@ HierarchyFolderRow.propTypes = {
   name: string.isRequired,
   open: bool,
   onNewItem: func,
-  childIds: arrayOf(node)
+  childIds: arrayOf(node),
+  addIds: func.isRequired,
+  removeIds: func.isRequired
 };
 
 HierarchyFolderRow.defaultProps = {

--- a/stories/webapp/hierarchy/HierarchyStory.js
+++ b/stories/webapp/hierarchy/HierarchyStory.js
@@ -4,6 +4,7 @@ import { number, text } from '@storybook/addon-knobs';
 import { SelectionProvider, Windowing } from 'lib';
 import { createData } from './data';
 import { HierarchyCollection } from './HierarchyCollection';
+import { WindowingIdsMock } from '../../../lib/Windowing/stories/WindowingIdsMock';
 
 const stories = storiesOf('Web app', module);
 
@@ -13,21 +14,32 @@ const maxItemCount = number('Max number of items', 10);
 
 stories.add('Hierarchy', () => {
   const data = createData({ levelCount, maxItemCount, statusColor });
+
   return (
     <SelectionProvider>
-      <Windowing itemHeight={52} allIds={data.allIds} containerHeight="500px">
-        <Windowing.Scroller>
-          <Windowing.List>
-            {({ inViewWindowingIds }) => (
-              <HierarchyCollection
-                data={data}
-                inViewWindowingIds={inViewWindowingIds}
-                statusColor={statusColor}
-              />
-            )}
-          </Windowing.List>
-        </Windowing.Scroller>
-      </Windowing>
+      <WindowingIdsMock allWindowingIds={data.allIds}>
+        {({ allWindowingIds, addIds, removeIds }) => (
+          <Windowing
+            itemHeight={52}
+            allIds={allWindowingIds}
+            containerHeight="100%"
+          >
+            <Windowing.Scroller>
+              <Windowing.List>
+                {({ inViewWindowingIds }) => (
+                  <HierarchyCollection
+                    data={data}
+                    inViewWindowingIds={inViewWindowingIds}
+                    statusColor={statusColor}
+                    addIds={addIds}
+                    removeIds={removeIds}
+                  />
+                )}
+              </Windowing.List>
+            </Windowing.Scroller>
+          </Windowing>
+        )}
+      </WindowingIdsMock>
     </SelectionProvider>
   );
 });


### PR DESCRIPTION
## 💬 Description
When using the component we realised that we unnecessarily built in an id array into the localised state for the context...it would consume the all ids prop and then filter it...however when we needed to update the core all ids prop it didn't hydrate down. 

Now, we could have applied a `useEffect` hook and update the local state but we felt like the provider didn't need to concern itself with this part of the logic. Hence the refactor.

### ✅ Checklist
- [x] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
