### PR TITLE
Fix proptype errors for PageInformation

### DIFF
--- a/lib/PageInformation/index.js
+++ b/lib/PageInformation/index.js
@@ -7,7 +7,8 @@ const PageInformation = ({
   subtitle,
   editable,
   rename,
-  contextName
+  contextName,
+  inputLabel
 }) => (
   <div className="page-information">
     {editable ? (
@@ -16,6 +17,7 @@ const PageInformation = ({
         onChange={rename}
         title={`Rename ${contextName}`}
         className="page-information__editable"
+        inputLabel={inputLabel || `Rename ${contextName}`}
       >
         <h1 className="page-information__title" title={title}>
           {title}
@@ -36,14 +38,16 @@ PageInformation.propTypes = {
   subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   editable: PropTypes.bool,
   rename: PropTypes.func,
-  contextName: PropTypes.string
+  contextName: PropTypes.string,
+  inputLabel: PropTypes.string
 };
 
 PageInformation.defaultProps = {
   subtitle: '',
   editable: false,
   rename: () => {},
-  contextName: ''
+  contextName: '',
+  inputLabel: ''
 };
 
 export default PageInformation;

--- a/tests/PageInformation/index.js
+++ b/tests/PageInformation/index.js
@@ -46,4 +46,25 @@ describe('PageInformation', () => {
       'Foo'
     );
   });
+
+  test('adds an inputLabel', () => {
+    wrapper = shallow(
+      <PageInformation title="Foo" subtitle="bar" editable contextName="bla" />
+    );
+    expect(wrapper.find(EditableTextWrapper).prop('inputLabel')).toEqual(
+      'Rename bla'
+    );
+
+    wrapper = shallow(
+      <PageInformation
+        title="Foo"
+        subtitle="bar"
+        editable
+        inputLabel="hello!"
+      />
+    );
+    expect(wrapper.find(EditableTextWrapper).prop('inputLabel')).toEqual(
+      'hello!'
+    );
+  });
 });


### PR DESCRIPTION
### 💬 Description
A required inputLabel prop was recently added to EditableTextWrapper, our PageInformation component uses it but doesn't give it its newly required prop.

### ✅ Checklist
- [x] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
