### PR TITLE
Add a tabindex to TooltipWrapper

### DIFF
--- a/lib/TooltipWrapper/index.js
+++ b/lib/TooltipWrapper/index.js
@@ -51,7 +51,9 @@ class TooltipWrapper extends Component {
           this.tooltipOverlay = tooltipOverlay;
         }}
       >
-        <span className={wrapperChildClassNames}>{children}</span>
+        <span className={wrapperChildClassNames} tabIndex="0" role="button">
+          {children}
+        </span>
       </OverlayTrigger>
     );
   }

--- a/lib/TooltipWrapper/styles.scss
+++ b/lib/TooltipWrapper/styles.scss
@@ -7,3 +7,7 @@
 .tooltip-wrapper__child--clickable {
     cursor: pointer;
 }
+
+.tooltip-wrapper__child {
+  outline: none;
+}


### PR DESCRIPTION
### 💬 Description
Sometimes our TooltipWrapper needs to be used for blur/focus events, adding a tabindex will allow us to do so! See related PR for a usecase.

### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/2144

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
