### PR TITLE
Fixing the width of the name input when interacting with selecting

### DIFF
--- a/lib/FolderRow/FolderRowName.js
+++ b/lib/FolderRow/FolderRowName.js
@@ -9,10 +9,11 @@ const FolderRowName = ({
   show,
   setShow,
   handleOnClick,
-  toggleTitle
+  toggleTitle,
+  ...rest
 }) => {
   return (
-    <div className="folder-row__name">
+    <div className="folder-row__name" {...rest}>
       {showToggle && (
         <div className="folder-row__toggle h-margin-clear h-margin-right-half">
           <Button

--- a/lib/FolderRow/styles.scss
+++ b/lib/FolderRow/styles.scss
@@ -48,12 +48,11 @@ $folder-row-spacing: $layout-spacing-base/2 !default;
 
 .folder-row__name {
   z-index: 1;
-  width: 100%;
   white-space: nowrap;
   font-weight: $typo-weight-semi-bold;
   overflow: hidden;
 
-  .editable-text__wrapper {
+  .editable-text__wrapper--editing {
     width: calc(100% - #{$editable-text-wrapper-icon-width});
   }
 

--- a/lib/ItemRow/styles.scss
+++ b/lib/ItemRow/styles.scss
@@ -8,6 +8,7 @@ $item-row-stacked-margin: $typo-size-slight/3;
    ========================================================================== */
 .item-row {
   padding: $layout-spacing-base/2;
+  cursor: pointer;
 
   .status-indicator {
     display: inline-flex;

--- a/stories/webapp/hierarchy/HierarchyFolderRow.js
+++ b/stories/webapp/hierarchy/HierarchyFolderRow.js
@@ -41,6 +41,8 @@ function HierarchyFolderRow({
     'is-hovered': isHovered
   });
 
+  const [isEditing, setIsEditing] = useState(false);
+
   return useMemo(
     () => (
       <FolderRow open={open}>
@@ -74,12 +76,19 @@ function HierarchyFolderRow({
                         )
                     : () => addIds(childIds, allWindowingIds.indexOf(id) + 1)
                 }
+                style={{
+                  width: isEditing ? '100%' : 'initial'
+                }}
               >
                 <HierarchyNameInput
                   name={folderName}
                   onChange={value => setFolderName(value)}
-                  onStartEditing={() => {}}
-                  onStopEditing={() => {}}
+                  onStartEditing={() => {
+                    setIsEditing(true);
+                  }}
+                  onStopEditing={() => {
+                    setIsEditing(false);
+                  }}
                 />
               </FolderRow.Name>
 
@@ -101,7 +110,7 @@ function HierarchyFolderRow({
         )}
       </FolderRow>
     ),
-    [isSelected, isHovered, isDisabled]
+    [isSelected, isHovered, isDisabled, isEditing]
   );
 }
 


### PR DESCRIPTION
### 💬 Description
Selecting a row doesn't work well with the editable text wrapper. This does some fun width changes to make sure only the text + pencil is clickable and the rest of the row selects it. 
### 🚪 Start Points
`stories/webapp/hierarchy/HierarchyFolderRow.js`

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
