### PR TITLE
Use clientOffset instead of currentOffset for drag previews

### DIFF
--- a/lib/DnD/DragPreview.js
+++ b/lib/DnD/DragPreview.js
@@ -4,13 +4,16 @@ import { useDragLayer } from 'react-dnd';
 import { getItemStyles } from './helpers/getItemStyles';
 
 function DragPreview({ children }) {
-  const { initialOffset, currentOffset } = useDragLayer(monitor => ({
-    item: monitor.getItem(),
-    itemType: monitor.getItemType(),
-    initialOffset: monitor.getInitialSourceClientOffset(),
-    currentOffset: monitor.getSourceClientOffset(),
-    isDragging: monitor.isDragging()
-  }));
+  const { initialOffset, currentOffset, clientOffset } = useDragLayer(
+    monitor => ({
+      item: monitor.getItem(),
+      itemType: monitor.getItemType(),
+      initialOffset: monitor.getInitialSourceClientOffset(),
+      currentOffset: monitor.getSourceClientOffset(),
+      isDragging: monitor.isDragging(),
+      clientOffset: monitor.getClientOffset()
+    })
+  );
 
   return (
     <div
@@ -24,7 +27,9 @@ function DragPreview({ children }) {
         height: '100%'
       }}
     >
-      <div style={getItemStyles(initialOffset, currentOffset)}>{children}</div>
+      <div style={getItemStyles(initialOffset, currentOffset, clientOffset)}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/lib/DnD/Draggable.js
+++ b/lib/DnD/Draggable.js
@@ -34,7 +34,7 @@ function Draggable({ children, preview, item }) {
 
 Draggable.propTypes = {
   children: func.isRequired,
-  item: shape.isRequired,
+  item: shape().isRequired,
   preview: node
 };
 

--- a/lib/DnD/helpers/getItemStyles.js
+++ b/lib/DnD/helpers/getItemStyles.js
@@ -1,17 +1,18 @@
-function getItemStyles(initialOffset, currentOffset) {
-  if (!initialOffset || !currentOffset) {
+function getItemStyles(initialOffset, currentOffset, clientOffset) {
+  if (!initialOffset || !currentOffset || !clientOffset) {
     return {
       display: 'none'
     };
   }
 
-  const { x, y } = currentOffset;
+  const { x, y } = clientOffset;
 
   const transform = `translate(${x}px, ${y}px)`;
 
   return {
     transform,
-    WebkitTransform: transform
+    WebkitTransform: transform,
+    display: 'inline-block'
   };
 }
 


### PR DESCRIPTION
### 💬 Description
I was having issues getting the drag preview to line up with where I was actually dragging, using clientOffset instead seems to fix it perfectly!
### 📹 GIF (optional)
http://g.recordit.co/QfuphfQneb.gif

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
