### PR TITLE
Update/boundary click watcher multiple ignore class

### DIFF
--- a/lib/BoundaryClickWatcher/README.md
+++ b/lib/BoundaryClickWatcher/README.md
@@ -14,6 +14,7 @@ BoundaryClickWatcher uses the render callback pattern and returns a boolean.
 | alwaysListen          | bool          | `false`       | No       | If true the click event listener is added on mount instead of being added when handleInnerClick is called. |
 | onMouseEnter          | Function      | `() {};`      | No       | Executes when the user's mouse enters the boundary. |
 | onMouseLeave          | Function      | `() {};`      | No       | Executes when the user's leaves the boundary.       |
+| ignoreClass          | String      | `submit-button cancel-button`      | No       | Class of element to ignore if clicked. Used to stop outsideClickHandler being triggered when clicking an element that is immediately removed from the DOM after being clicked. Multiple classes can be added in the same string.       |
 
 ```
 <BoundaryClickWatcher insideClickHandler={someFunc} outsideClickHandler={someOtherFunc} alwaysListen={false}>

--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -76,21 +76,24 @@ class BoundaryClickWatcher extends Component {
   }
 
   handleClick(event) {
+    const { ignoreClass } = this.props;
+    const { target } = event;
+
     const targetIsContainer = event.target !== this.container;
     let containerDoesNotContainTarget = false;
     let containerDoesNotContainFocus = false;
-    let targetHasIgnoreClass = false;
     if (this.container) {
       containerDoesNotContainTarget = !this.container.contains(event.target);
       containerDoesNotContainFocus = !this.container.contains(
         document.activeElement
       );
     }
-    if (this.props.ignoreClass) {
-      targetHasIgnoreClass = event.target.classList.contains(
-        this.props.ignoreClass
-      );
-    }
+
+    const ignoreClasses = ignoreClass ? ignoreClass.match(/\S+/g) : [];
+    const targetHasIgnoreClass = ignoreClasses.some(className =>
+      target.classList.contains(className)
+    );
+
     const userHasClickedOutside =
       targetIsContainer &&
       containerDoesNotContainTarget &&

--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -79,11 +79,11 @@ class BoundaryClickWatcher extends Component {
     const { ignoreClass } = this.props;
     const { target } = event;
 
-    const targetIsContainer = event.target !== this.container;
+    const targetIsContainer = target !== this.container;
     let containerDoesNotContainTarget = false;
     let containerDoesNotContainFocus = false;
     if (this.container) {
-      containerDoesNotContainTarget = !this.container.contains(event.target);
+      containerDoesNotContainTarget = !this.container.contains(target);
       containerDoesNotContainFocus = !this.container.contains(
         document.activeElement
       );

--- a/lib/DueDatePicker/DueDateHeader.js
+++ b/lib/DueDatePicker/DueDateHeader.js
@@ -54,7 +54,11 @@ const DueDateHeader = props => {
         </Dropdown.Trigger>
         <Dropdown.Content right collapse>
           <Dropdown.ActionGroup>
-            <Dropdown.Action action={props.removeDueDate} danger>
+            <Dropdown.Action
+              className="duedate__remove-action"
+              action={props.removeDueDate}
+              danger
+            >
               Remove due date
             </Dropdown.Action>
           </Dropdown.ActionGroup>


### PR DESCRIPTION
### 💬 Description
- Updates `<BoundaryClickWatcher />` to accept multiple classes in the `ignoreClass` prop.
- Updates the README
- Adds class to "Remove due date" action, to be targeted by `ignoreClass` in the related PR.
### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/2258
### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
