### PR TITLE
Add sticky header functionality to FinderPanelLayout

### DIFF
--- a/lib/FinderPanelLayout/FinderPanelLayoutHeader.js
+++ b/lib/FinderPanelLayout/FinderPanelLayoutHeader.js
@@ -1,11 +1,28 @@
-import React from 'react';
+import React, { useContext, useRef, useEffect } from 'react';
 import { node, string } from 'prop-types';
+import cx from 'classnames';
+import { FinderPanelLayoutContext } from './FinderPanelLayoutProvider';
 
-const FinderPanelLayoutHeader = ({ children, className }) => (
-  <div className={`finder-panel-layout__left-head ${className}`}>
-    {children}
-  </div>
-);
+const FinderPanelLayoutHeader = ({ children, className }) => {
+  const { fixed, setHeaderHeight } = useContext(FinderPanelLayoutContext);
+  const headerRef = useRef();
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight);
+    }
+  }, [headerRef]);
+
+  const classes = cx(`finder-panel-layout__left-head ${className}`, {
+    'finder-panel-layout__left-head--fixed': fixed
+  });
+
+  return (
+    <div className={classes} ref={headerRef}>
+      {children}
+    </div>
+  );
+};
 
 FinderPanelLayoutHeader.propTypes = {
   children: node.isRequired,

--- a/lib/FinderPanelLayout/FinderPanelLayoutLeftContent.js
+++ b/lib/FinderPanelLayout/FinderPanelLayoutLeftContent.js
@@ -1,0 +1,31 @@
+import React, { useContext } from 'react';
+import { node, string } from 'prop-types';
+import { FinderPanelLayoutContext } from './FinderPanelLayoutProvider';
+
+const FinderPanelLayoutLeftContent = ({ children, className }) => {
+  const { fixed, headerHeight } = useContext(FinderPanelLayoutContext);
+  const style = fixed
+    ? {
+        marginTop: headerHeight
+      }
+    : {};
+  return (
+    <div
+      className={`finder-panel-layout__left-content ${className}`}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+};
+
+FinderPanelLayoutLeftContent.propTypes = {
+  children: node.isRequired,
+  className: string
+};
+
+FinderPanelLayoutLeftContent.defaultProps = {
+  className: ''
+};
+
+export default FinderPanelLayoutLeftContent;

--- a/lib/FinderPanelLayout/FinderPanelLayoutProvider.js
+++ b/lib/FinderPanelLayout/FinderPanelLayoutProvider.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { node, bool } from 'prop-types';
+
+export const FinderPanelLayoutContext = React.createContext({});
+
+const FinderPanelLayoutProvider = ({ children, fixed }) => {
+  const [headerHeight, setHeaderHeight] = useState(null);
+  const sharedState = {
+    headerHeight,
+    setHeaderHeight,
+    fixed
+  };
+
+  return (
+    <FinderPanelLayoutContext.Provider value={sharedState}>
+      {children}
+    </FinderPanelLayoutContext.Provider>
+  );
+};
+
+FinderPanelLayoutProvider.propTypes = {
+  children: node.isRequired,
+  fixed: bool
+};
+
+FinderPanelLayoutProvider.defaultProps = {
+  fixed: false
+};
+
+export default FinderPanelLayoutProvider;

--- a/lib/FinderPanelLayout/index.js
+++ b/lib/FinderPanelLayout/index.js
@@ -1,32 +1,38 @@
-import React, { Component } from 'react';
-import { node, string } from 'prop-types';
+import React from 'react';
+import { node, string, bool } from 'prop-types';
+import FinderPanelLayoutProvider from './FinderPanelLayoutProvider';
 import FinderPanelLayoutLeft from './FinderPanelLayoutLeft';
 import FinderPanelLayoutRight from './FinderPanelLayoutRight';
 import FinderPanelLayoutHeader from './FinderPanelLayoutHeader';
+import FinderPanelLayoutLeftContent from './FinderPanelLayoutLeftContent';
 
-class FinderPanelLayout extends Component {
-  static Left = FinderPanelLayoutLeft;
+export const FinderPanelLayoutContext = React.createContext({});
 
-  static Right = FinderPanelLayoutRight;
+const FinderPanelLayout = ({ children, className, fixed }) => {
+  return (
+    <FinderPanelLayoutProvider fixed={fixed}>
+      <div className={`finder-panel-layout ${className}`}>{children}</div>
+    </FinderPanelLayoutProvider>
+  );
+};
 
-  static Header = FinderPanelLayoutHeader;
+FinderPanelLayout.Left = FinderPanelLayoutLeft;
 
-  render() {
-    return (
-      <div className={`finder-panel-layout ${this.props.className}`}>
-        {this.props.children}
-      </div>
-    );
-  }
-}
+FinderPanelLayout.Right = FinderPanelLayoutRight;
+
+FinderPanelLayout.Header = FinderPanelLayoutHeader;
+
+FinderPanelLayout.LeftContent = FinderPanelLayoutLeftContent;
 
 FinderPanelLayout.propTypes = {
   children: node.isRequired,
-  className: string
+  className: string,
+  fixed: bool
 };
 
 FinderPanelLayout.defaultProps = {
-  className: ''
+  className: '',
+  fixed: false
 };
 
 export default FinderPanelLayout;

--- a/lib/FinderPanelLayout/styles.scss
+++ b/lib/FinderPanelLayout/styles.scss
@@ -1,6 +1,7 @@
 $finder-panel-left-bg: rgba($neutral-light, 0.5) !default;
 $finder-panel-left-width: 350px !default;
 $finder-panel-left-height: 100% !default;
+$finder-panel-right-bg: $neutral-base-lightest !default;
 
 .finder-panel-layout {
   display: flex;
@@ -14,9 +15,23 @@ $finder-panel-left-height: 100% !default;
     height: $finder-panel-left-height;
   }
   &__right {
-    padding: $layout-spacing-base;
     width: 100%;
     min-width: 0;
     margin-left: $finder-panel-left-width;
+    background: $finder-panel-right-bg;
   }
+}
+
+.finder-panel-layout__left-head {
+  padding: $layout-spacing-base $layout-spacing-base 0;
+}
+.finder-panel-layout__left-content {
+  padding: $layout-spacing-base;
+}
+
+.finder-panel-layout__left-head--fixed {
+  background: $finder-panel-right-bg;
+  position: fixed;
+  width: calc(100% - #{$finder-panel-left-width});
+  z-index: 50;
 }

--- a/stories/webapp/peoplegroups/PeopleGroups.js
+++ b/stories/webapp/peoplegroups/PeopleGroups.js
@@ -21,7 +21,7 @@ const PeopleGroups = ({
   return (
     <>
       <PeopleGroupTopbar />
-      <FinderPanelLayout>
+      <FinderPanelLayout fixed>
         <FinderPanelLayout.Left
           style={{
             top: '74px'

--- a/stories/webapp/peoplegroups/UsersCol/UsersTable.js
+++ b/stories/webapp/peoplegroups/UsersCol/UsersTable.js
@@ -6,7 +6,8 @@ import {
   AvatarInformation,
   Dropdown,
   Icon,
-  Button
+  Button,
+  FinderPanelLayout
 } from 'lib';
 import { ALL_USERS, GUEST_USERS, USER_PROJECTS } from '../consts';
 import UserRoleDropdown from './UserRoleDropdown';
@@ -20,86 +21,94 @@ const UsersTable = ({
   setActiveState,
   setActiveUser
 }) => (
-  <CollectionsTable>
-    <CollectionsTable.Row>
-      <CollectionsTable.Heading>Name</CollectionsTable.Heading>
-      {activeState !== GUEST_USERS && (
-        <CollectionsTable.Heading className="hide-small">
-          Role
-        </CollectionsTable.Heading>
-      )}
-      {activeState === ALL_USERS && (
-        <CollectionsTable.Heading className="hide-small">
-          Authentication
-        </CollectionsTable.Heading>
-      )}
-      <CollectionsTable.Heading className="hide-small">
-        {' '}
-      </CollectionsTable.Heading>
-    </CollectionsTable.Row>
-    {users.map(user => (
-      <CollectionsTable.Row key={user.id}>
-        <CollectionsTable.Cell className={cellClasses}>
-          <Avatar name={user.name} url={user.url} largeSize>
-            <AvatarInformation
-              name={
-                <Button
-                  types={['link-no-underline', 'collapse']}
-                  clickHandler={() => {
-                    setActiveUser(user.id);
-                    setActiveState(USER_PROJECTS);
-                  }}
-                >
-                  {user.name}
-                </Button>
-              }
-              email={user.email}
-            />
-          </Avatar>
-        </CollectionsTable.Cell>
+  <FinderPanelLayout.LeftContent>
+    <CollectionsTable>
+      <CollectionsTable.Row>
+        <CollectionsTable.Heading>Name</CollectionsTable.Heading>
         {activeState !== GUEST_USERS && (
-          <CollectionsTable.Cell allowOverflow className={cellClasses}>
-            <UserRoleDropdown roles={roles} user={user} />
-          </CollectionsTable.Cell>
+          <CollectionsTable.Heading className="hide-small">
+            Role
+          </CollectionsTable.Heading>
         )}
         {activeState === ALL_USERS && (
-          <CollectionsTable.Cell className={`${cellClasses} typo-size-slight`}>
-            {user.authentication}
-          </CollectionsTable.Cell>
+          <CollectionsTable.Heading className="hide-small">
+            Authentication
+          </CollectionsTable.Heading>
         )}
-        <CollectionsTable.Cell allowOverflow alignRight className={cellClasses}>
-          <Dropdown id={`user-manage-dropdown-${user.id}`}>
-            <Dropdown.Trigger
-              types={['icon-only']}
-              triggerClassName="h-padding-left-half h-padding-right-half h-padding-top-quarter"
-            >
-              <Icon name="menuDotted" />
-            </Dropdown.Trigger>
-            <Dropdown.Content collapse right>
-              <Dropdown.ActionGroup>
-                <Dropdown.Action
-                  action={() => {
-                    setActiveUser(user.id);
-                    setActiveState(USER_PROJECTS);
-                  }}
-                >
-                  Manage
-                </Dropdown.Action>
-                <Dropdown.Action action={() => {}}>
-                  Send password reset email
-                </Dropdown.Action>
-              </Dropdown.ActionGroup>
-              <Dropdown.ActionGroup>
-                <Dropdown.Action action={() => {}} danger>
-                  Delete team member
-                </Dropdown.Action>
-              </Dropdown.ActionGroup>
-            </Dropdown.Content>
-          </Dropdown>
-        </CollectionsTable.Cell>
+        <CollectionsTable.Heading className="hide-small">
+          {' '}
+        </CollectionsTable.Heading>
       </CollectionsTable.Row>
-    ))}
-  </CollectionsTable>
+      {users.map(user => (
+        <CollectionsTable.Row key={user.id}>
+          <CollectionsTable.Cell className={cellClasses}>
+            <Avatar name={user.name} url={user.url} largeSize>
+              <AvatarInformation
+                name={
+                  <Button
+                    types={['link-no-underline', 'collapse']}
+                    clickHandler={() => {
+                      setActiveUser(user.id);
+                      setActiveState(USER_PROJECTS);
+                    }}
+                  >
+                    {user.name}
+                  </Button>
+                }
+                email={user.email}
+              />
+            </Avatar>
+          </CollectionsTable.Cell>
+          {activeState !== GUEST_USERS && (
+            <CollectionsTable.Cell allowOverflow className={cellClasses}>
+              <UserRoleDropdown roles={roles} user={user} />
+            </CollectionsTable.Cell>
+          )}
+          {activeState === ALL_USERS && (
+            <CollectionsTable.Cell
+              className={`${cellClasses} typo-size-slight`}
+            >
+              {user.authentication}
+            </CollectionsTable.Cell>
+          )}
+          <CollectionsTable.Cell
+            allowOverflow
+            alignRight
+            className={cellClasses}
+          >
+            <Dropdown id={`user-manage-dropdown-${user.id}`}>
+              <Dropdown.Trigger
+                types={['icon-only']}
+                triggerClassName="h-padding-left-half h-padding-right-half h-padding-top-quarter"
+              >
+                <Icon name="menuDotted" />
+              </Dropdown.Trigger>
+              <Dropdown.Content collapse right>
+                <Dropdown.ActionGroup>
+                  <Dropdown.Action
+                    action={() => {
+                      setActiveUser(user.id);
+                      setActiveState(USER_PROJECTS);
+                    }}
+                  >
+                    Manage
+                  </Dropdown.Action>
+                  <Dropdown.Action action={() => {}}>
+                    Send password reset email
+                  </Dropdown.Action>
+                </Dropdown.ActionGroup>
+                <Dropdown.ActionGroup>
+                  <Dropdown.Action action={() => {}} danger>
+                    Delete team member
+                  </Dropdown.Action>
+                </Dropdown.ActionGroup>
+              </Dropdown.Content>
+            </Dropdown>
+          </CollectionsTable.Cell>
+        </CollectionsTable.Row>
+      ))}
+    </CollectionsTable>
+  </FinderPanelLayout.LeftContent>
 );
 
 UsersTable.propTypes = {


### PR DESCRIPTION
### 💬 Description
FinderPanelLayout now has the ability to have a sticky header, and correctly offsets the right panel content. Its set up in the webapp/peoplegroups story if you want a closer nose.
### 📹 GIF (optional)
http://g.recordit.co/xwvP5RntUg.gif
### 🚪 Start Points
`lib/FinderPanelLayout/index.js`

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
