### PR TITLE
Changing hierarchy row borders

### DIFF
--- a/lib/FolderRow/styles.scss
+++ b/lib/FolderRow/styles.scss
@@ -22,10 +22,9 @@ $folder-row-spacing: $layout-spacing-base/2 !default;
 .folder-row__inner {
   padding: $folder-row-spacing;
   background: $neutral-lightest;
-  border-radius: 4px;
-  border: 1px solid $neutral-light;
   position: relative;
   margin: 0 0 $layout-spacing-base/2;
+  @include before-border(1px, solid, $neutral-light, 4px);
 
   + .folder-row {
     margin-top: $folder-row-spacing;

--- a/lib/ItemRow/styles.scss
+++ b/lib/ItemRow/styles.scss
@@ -9,6 +9,7 @@ $item-row-stacked-margin: $typo-size-slight/3;
 .item-row {
   padding: $layout-spacing-base/2;
   cursor: pointer;
+  position: relative;
 
   .status-indicator {
     display: inline-flex;
@@ -93,6 +94,5 @@ $item-row-stacked-margin: $typo-size-slight/3;
 }
 
 .item-row--bordered {
-  border: 1px solid $color-border-base;
-  border-radius: $border-radius-base;
+  @include before-border(1px, solid, $color-border-base, $border-radius-base);
 }

--- a/styles/helpers/_selected.scss
+++ b/styles/helpers/_selected.scss
@@ -1,14 +1,15 @@
 .is-selected {
-  border: 1px solid $primary-blue;
-  box-shadow: inset 0 0 0 1px $primary-blue;
+  @include before-border(2px, solid, $primary-blue, 4px);
 }
 
 .is-hovered {
-  border: 1px solid $neutral-light;
-  box-shadow: inset 0 0 0 1px $neutral-light;
+  @include before-border(2px, solid, $primary-blue, 4px);
 
   &.is-selected {
-    border: 1px solid lighten($primary-blue, 30%);
-    box-shadow: inset 0 0 0 1px lighten($primary-blue, 30%);
+    @include before-border(2px, solid, lighten($primary-blue, 30%), 4px);
   }
+}
+
+.is-parent-selected {
+  @include before-border(2px, dashed, lighten($primary-blue, 30%), 4px);
 }

--- a/styles/tools/_mixins.scss
+++ b/styles/tools/_mixins.scss
@@ -130,3 +130,19 @@
   -webkit-font-smoothing: subpixel-antialiased;
   -moz-osx-font-smoothing: auto;
 }
+
+/**
+ * A border that appears in the `before` element
+ */
+@mixin before-border($pixelSize, $style, $colour, $radius) {
+  &:before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 100%;
+    border: $pixelSize $style $colour;
+    border-radius: $radius;
+  }
+}


### PR DESCRIPTION
### 💬 Description
Preface - Everything in the hierarchy is based on height. The changes in this PR might seem odd, but they were done in a way to not affect the heights of anything!

Now to the actual PR. Borders around rows in the hierarchy used to be as followed: 

`border: 1px solid grey`

Then when we wanted to apply a 2px border for a selected style we would do the following:

`border: 1px solid blue`
`box shadow: 0 0 1px blue`

This was done to preserve the height and prevent the contents from shifting around when border thickness changed.

This option is no longer viable because there'ss a fancy new border type for - `When my parent has been selected, give me a dashed blue border`. This wasn't possible because you couldn't have a dashed box shadow. Thus we're at this solution, which is an absolute pseudo element giving a border!

I'm sorry...

### 🔗 Links
https://trello-attachments.s3.amazonaws.com/5ca62742c7569644c3fefeba/5dd26b92cad7fe5d03c0fc77/b3039403f6cf344c56cdb64760d668aa/image.png
### 🚪 Start Points
`styles/tools/_mixins.scss`