### PR TITLE
Resize SVG & Flex Center Status Indicator Label Row

### DIFF
--- a/assets/icons/bold-tick-small.svg
+++ b/assets/icons/bold-tick-small.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="10" height="13" viewBox="0 0 16 10">
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 1 16 10">
   <polyline fill="#3D8AEB" fill-rule="evenodd" points="5.6 15 2.4 11.8 0 14.2 5.6 19.8 16 9.4 13.6 7 5.6 15" transform="translate(0 -7)"/>
 </svg>

--- a/lib/StatusIndicator/styles.scss
+++ b/lib/StatusIndicator/styles.scss
@@ -19,7 +19,7 @@ $status-indicator-margin-left: 1.3rem !default;
 
 .status-indicator__label-row {
   display: flex;
-  align-items: baseline;
+  align-items: center;
 }
 
 .status-indicator__children {


### PR DESCRIPTION
Minor changes to go alongside this PR: https://github.com/gathercontent/app/pull/2334

### 💬 Description
- Resize bold-tick svg so it has no padding (and is easier to center!).
- Aligns items center in `status-indicator__label-row`

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
