### PR TITLE
Border pseudo-element pointer events

### DIFF
--- a/styles/tools/_mixins.scss
+++ b/styles/tools/_mixins.scss
@@ -144,5 +144,6 @@
     height: 100%;
     border: $pixelSize $style $colour;
     border-radius: $radius;
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
### 💬 Description
I need to add `pointer-events: none` to the border pseudo element, so it doesn't cover up anything underneath!

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
