### PR TITLE
Hierarchy DND styling fixes

### DIFF
--- a/lib/FinderNavigation/styles.scss
+++ b/lib/FinderNavigation/styles.scss
@@ -47,6 +47,10 @@ $finder-indent-level-support: 10 !default;
   .form__input:disabled {
     background: none;
   }
+
+  .form__input:focus {
+    padding: 0;
+  }
 }
 
 .finder__item-content-inner {

--- a/styles/helpers/_selected.scss
+++ b/styles/helpers/_selected.scss
@@ -11,5 +11,5 @@
 }
 
 .is-parent-selected {
-  @include before-border(2px, dashed, lighten($primary-blue, 30%), 4px);
+  @include before-border(2px, dashed, $primary-blue, 4px);
 }


### PR DESCRIPTION
### 💬 Description
This fixes a couple of minor styling issues:

- The `parent-selected` style of a hierarchy row is too light.
- Then new folder form in the sidebar had some padding when focussed.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
