### PR TITLE
Styling lines for dragging in the hierarchy

### DIFF
--- a/lib/DnD/DragLine.js
+++ b/lib/DnD/DragLine.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { string, number } from 'prop-types';
+
+export const DragLine = ({ alignment, offsetPx }) => (
+  <>
+    <span
+      className="drag-line__ball drag-line__ball-left"
+      style={{
+        [alignment]: `${-5 - offsetPx}px`
+      }}
+    />
+    <span
+      className="drag-line"
+      style={{
+        [alignment]: `${-3 - offsetPx}px`
+      }}
+    />
+    <span
+      className="drag-line__ball drag-line__ball-right"
+      style={{
+        [alignment]: `${-5 - offsetPx}px`
+      }}
+    />
+  </>
+);
+
+DragLine.propTypes = {
+  alignment: string.isRequired,
+  offsetPx: number
+};
+
+DragLine.defaultProps = {
+  offsetPx: 0
+};

--- a/lib/DnD/styles.scss
+++ b/lib/DnD/styles.scss
@@ -1,0 +1,24 @@
+.drag-line {
+  background: $primary-blue;
+  left: 0;
+  height: 2px;
+  width: 100%;
+  position: absolute;
+}
+
+.drag-line__ball {
+  background: $primary-blue;
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  background: $primary-blue;
+  border-radius: $layout-spacing-base;
+
+  &.drag-line__ball-right {
+    right: 0;
+  }
+
+  &.drag-line__ball-left {
+    left: 0;
+  }
+}

--- a/lib/FolderRow/stories/FolderRowStory.js
+++ b/lib/FolderRow/stories/FolderRowStory.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, text } from '@storybook/addon-knobs';
+import cx from 'classnames';
 import StoryItem from '../../../stories/styleguide/StoryItem';
 import { FolderRow, TooltipWrapper, Icon, Button } from '../../index';
 
@@ -35,13 +36,22 @@ const actions = (
 
 storiesOf('Components', module).add('Folder Row', () => {
   const open = boolean('Open', true);
+  const draggedOver = boolean('Dragged over', false);
+
+  const classNameInner = cx('folder-row__inner', {
+    'folder-row__inner-dragged-insert': draggedOver
+  });
+
+  const classNameLine = cx('hierarchy-line', {
+    'dragged-insert': draggedOver
+  });
 
   return (
     <StoryItem title="Folder Row">
       <FolderRow open={open}>
-        {show => (
+        {() => (
           <>
-            <FolderRow.Inner>
+            <FolderRow.Inner className={classNameInner}>
               <FolderRow.Name showToggle={boolean('Show toggle', true)}>
                 <p className="h-margin-clear">{text('Name', 'Folder name')}</p>
               </FolderRow.Name>
@@ -56,10 +66,16 @@ storiesOf('Components', module).add('Folder Row', () => {
             </FolderRow.Inner>
 
             <FolderRow.Contents
-              highlight={boolean('Highlight contents', true)}
-              show={show}
+              style={{ position: 'relative', height: '150px' }}
             >
-              <p>Folder contents</p>
+              <span
+                className={classNameLine}
+                style={{
+                  top: '0',
+                  left: '20px',
+                  height: '100px'
+                }}
+              />
             </FolderRow.Contents>
           </>
         )}

--- a/lib/FolderRow/styles.scss
+++ b/lib/FolderRow/styles.scss
@@ -31,6 +31,10 @@ $folder-row-spacing: $layout-spacing-base/2 !default;
   }
 }
 
+.folder-row__inner-dragged-insert {
+  @include before-border(2px, solid, $primary-blue, 4px);
+}
+
 .folder-row__backdrop {
   position: absolute;
   display: block;
@@ -97,7 +101,7 @@ $folder-row-spacing: $layout-spacing-base/2 !default;
 
   button:hover,
   button:focus {
-    background: rgba($primary-blue, .05);
+    background: rgba($primary-blue, 0.05);
   }
 }
 

--- a/lib/Hierarchy/styles.scss
+++ b/lib/Hierarchy/styles.scss
@@ -4,4 +4,8 @@
   bottom: 0;
   width: 2px;
   background: $neutral-light;
+
+  &.dragged-insert {
+    background: $primary-blue;
+  }
 }

--- a/lib/ItemRow/stories/ItemRowStory.js
+++ b/lib/ItemRow/stories/ItemRowStory.js
@@ -5,6 +5,7 @@ import { ItemRow, StatusIndicator, TooltipWrapper } from '../../index';
 import notes from '../README.md';
 import Icon from '../../Icon';
 import { AvatarGroupMock } from '../../Avatar/stories/AvatarGroupMock';
+import { DragLine } from '../../DnD/DragLine';
 
 const createStatusIndicator = props => (
   <TooltipWrapper
@@ -23,9 +24,28 @@ storiesOf('Components', module).add(
     const bordered = boolean('Bordered', true);
     const commentCount = text('Comment count', 0);
     const templateName = text('Template name', '');
+    const draggedAbove = boolean('Dragged above', false);
+    const draggedBelow = boolean('Dragged below', false);
+
+    let alignment = '';
+
+    if (draggedAbove) {
+      alignment = 'top';
+    } else if (draggedBelow) {
+      alignment = 'bottom';
+    }
 
     return (
-      <ItemRow bordered={bordered} stacked={stacked}>
+      <ItemRow
+        bordered={bordered}
+        stacked={stacked}
+        style={{
+          position: 'relative'
+        }}
+      >
+        {(draggedAbove || draggedBelow) && (
+          <DragLine alignment={alignment} offsetPx={2} />
+        )}
         <ItemRow.Name>
           {!stacked &&
             createStatusIndicator(

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -71,4 +71,4 @@
 @import '../../lib/Windowing/styles.scss';
 @import '../../lib/Hierarchy/styles.scss';
 @import '../../lib/FinderPanelLayout/styles.scss';
-
+@import '../../lib/DnD/styles.scss';


### PR DESCRIPTION
### 💬 Description
This implements some new knobs to show what it would look like when you want to drop things on the rows in the hierarchy.

It also creates a new component called `DragLine` which is what you can render to get that nice line beneath or above something to imply you're dropping next to it!


### 🚪 Start Points
`ItemRow` and `FolderRow` in the storybook, there are new knobs to play with!

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
