### PR TITLE
Update/user search dropdown style

### DIFF
--- a/lib/TagUserForm/styles.scss
+++ b/lib/TagUserForm/styles.scss
@@ -61,9 +61,17 @@
     background: $neutral-lightest;
     color: $neutral-base;
     .icon {
+      path {
+	fill: $neutral-base;
+      }
       vertical-align: text-bottom;
       svg {
         height: 13px;
+      }
+    }
+    &.is-active {
+      .icon path {
+	fill: $primary-blue;
       }
     }
   }

--- a/lib/TagUserForm/styles.scss
+++ b/lib/TagUserForm/styles.scss
@@ -62,7 +62,7 @@
     color: $neutral-base;
     .icon {
       path {
-	fill: $neutral-base;
+	  fill: $neutral-base;
       }
       vertical-align: text-bottom;
       svg {
@@ -71,7 +71,7 @@
     }
     &.is-active {
       .icon path {
-	fill: $primary-blue;
+	  fill: $primary-blue;
       }
     }
   }

--- a/lib/UserSearchDropdown/styles.scss
+++ b/lib/UserSearchDropdown/styles.scss
@@ -4,4 +4,13 @@
     min-width: 300px;
     padding: $layout-spacing-base/2 0 0 0;
   }
+
+  .icon path {
+    fill: $neutral-base;
+  }
+  &.is-active {
+    .icon path {
+      fill: $primary-blue;
+    }
+  }
 }


### PR DESCRIPTION
### 💬 Description
- Adds styles to make the @ icon dropdown trigger grey when inactive and blue when active for:
- `<UserSearchDropdown />`
- `<TagUserForm />`

previously these styles were applied in the app codebase for the mentions form on the workflow dropdown. Those styles have been removed in this PR https://github.com/gathercontent/app/pull/2421

### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
http://g.recordit.co/VOyJK7XP1H.gif_
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/2421
### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
