### PR TITLE
Fix/user search dropdown is active selector

### DIFF
--- a/lib/TagUserForm/styles.scss
+++ b/lib/TagUserForm/styles.scss
@@ -61,17 +61,9 @@
     background: $neutral-lightest;
     color: $neutral-base;
     .icon {
-      path {
-	  fill: $neutral-base;
-      }
       vertical-align: text-bottom;
       svg {
         height: 13px;
-      }
-    }
-    &.is-active {
-      .icon path {
-	  fill: $primary-blue;
       }
     }
   }

--- a/lib/UserSearchDropdown/styles.scss
+++ b/lib/UserSearchDropdown/styles.scss
@@ -8,7 +8,7 @@
   .icon path {
     fill: $neutral-base;
   }
-  &.is-active {
+  .is-active {
     .icon path {
       fill: $primary-blue;
     }


### PR DESCRIPTION
### 💬 Description
Updates the `UserSearchDropdown` component `css` so that it is active blue when the `.user-search__dropdown` class has a `.is_active` child.

Previously the selector was `.user-search__dropdown.is-active`, meaning the @ symbol would be blue if the `.user-search__dropdown` had a `.is_active` class higher and lower in the DOM tree, rathe than just lower.

Also removes `.is_active` styles I previously added for the `TagUserForm`, as we don't use this component anywhere and the styles have not been tested.
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
