### PR TITLE
Makes Field text area scroll on the x axis if overflowing

### DIFF
--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -38,6 +38,10 @@ $field-data-p-line-height: 1.688rem !default;
 .field {
   margin: 0 0 $field-spacing-base*2;
 
+  .ql-editor {
+    overflow-x: auto;
+  }
+
   img {
     max-width: 100%;
   }


### PR DESCRIPTION
### 💬 Description
Makes Field text area scroll on the x-axis if overflowing (to fix issue with long nested lists overflowing the text area)
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
http://g.recordit.co/ffhASrodMO.gif
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
