### PR TITLE
Change empty tag to actual Fragment

### DIFF
--- a/lib/DnD/DragLine.js
+++ b/lib/DnD/DragLine.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { string, number } from 'prop-types';
 
 export const DragLine = ({ alignment, offsetPx }) => (
-  <>
+  <Fragment>
     <span
       className="drag-line__ball drag-line__ball-left"
       style={{
@@ -21,7 +21,7 @@ export const DragLine = ({ alignment, offsetPx }) => (
         [alignment]: `${-5 - offsetPx}px`
       }}
     />
-  </>
+  </Fragment>
 );
 
 DragLine.propTypes = {


### PR DESCRIPTION
When importing a component using the fancy new empty tags it breaks. It must be a Fragment tag.