### PR TITLE
Adding the DragLine component to be exported

### DIFF
--- a/lib/DnD/index.js
+++ b/lib/DnD/index.js
@@ -2,5 +2,6 @@ import { DndProvider, DndContext } from './DndProvider';
 import { DragPreview } from './DragPreview';
 import { Draggable } from './Draggable';
 import { Droppable } from './Droppable';
+import { DragLine } from './DragLine';
 
-export { DndProvider, DragPreview, Draggable, Droppable, DndContext };
+export { DndProvider, DragPreview, Draggable, Droppable, DndContext, DragLine };

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,8 @@ export {
   DragPreview,
   Draggable,
   Droppable,
-  DndContext
+  DndContext,
+  DragLine
 } from './DnD';
 export { Windowing } from './Windowing';
 export FinderPanelLayout from './FinderPanelLayout';


### PR DESCRIPTION
Look, it's my first day back since Christmas. The issue I have been having was that DragLine wasn't being exported from gather-ui. And Webstorm was trying to import it directly from node modules (for some reason).