### PR TITLE
FiX/Dropdown Auto Position

### DIFF
--- a/lib/Dropdown/DropdownContent.js
+++ b/lib/Dropdown/DropdownContent.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { isEqual } from 'lodash';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { GATHER_UI_DROPDOWN } from './consts';
@@ -6,6 +7,19 @@ import { GATHER_UI_DROPDOWN } from './consts';
 const CONTENT_BOUNDARY_PADDING = 40;
 
 class DropdownContent extends Component {
+  state = {
+    style: {}
+  };
+
+  componentDidUpdate() {
+    const newStyle = this.getStyle();
+
+    if (!isEqual(newStyle, this.state.style)) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ style: newStyle });
+    }
+  }
+
   getTopPosition = (pos, bounds, contentBounds) => {
     let newPos = pos;
 
@@ -113,7 +127,7 @@ class DropdownContent extends Component {
     return (
       <div
         className={classNames}
-        style={this.getStyle()}
+        style={this.state.style}
         ref={content => {
           this.content = content;
         }}

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "faker": "^4.1.0",
     "font-awesome": "^4.7.0",
     "linkifyjs": "^2.1.6",
+    "lodash": "^4.17.15",
     "lodash.intersection": "^4.4.0",
     "lodash.range": "^3.2.0",
     "moment": "^2.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7790,7 +7790,7 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
 
-lodash@^4.0.1, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14:
+lodash@^4.0.1, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
### 💬 Description
#### Bug
We had a bug reported where the the `<DueDatePicker />` dropdown would position itself off the bottom of the screen. This dropdown had the prop `autoPosition=true`, so it was supposed to position itself on the screen.

[Video, it really did happen!](https://cl.ly/f3e3c0d8165e)
#### Cause
The `<DropdownContent />` component calculates whether its contents overflows the main window, by saying:
>  "My content starts at ***position X***, and has a ***height of Y*** pixels, therefore I know that if ***X + Y > inner window height***, then my content is off the bottom of the screen, and I need to reposition it!".

To get this Y height value, the component calls `getBoundingClientRect()` on its wrapping div element, inside the function `getStyle()`.

In the previous implementation, `getStyle()` was called inside the render method. This meant that in some cases (namely the one for which this bug was reported), `getStyle()` was called *before* all the `<DropdownContent>`'s children had rendered.

This meant that it would give an incorrect Y height value, in the case above the height was given as `2px` rather than `300px`. The `getStyle()` function therefore said, "the Y height is only two pixels, I can easily fit that on the screen!".

The component would did not fix itself when the `<DropdownContent>`'s children eventually rendered, because it was a change in its children, and wouldn't trigger a re-render.
#### Fix
The fix was to move the call to `getStyle()` out of the render method, and into `componentDidUpdate`. Calling the function ***after*** the render instead of ***during*** the render gives enough time for `<DropdownContent>`'s children to be rendered, ensuring the correct Y height value, before calculating where the dropdown should be positioned.

### 🔗 Links 
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
http://g.recordit.co/JxKdW1aoxc.gif
### 🚪 Start Points
https://github.com/gathercontent/gather-ui/pull/640/files#diff-e639efd056e0519f9e78c73125c3463a
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
