### PR TITLE
Hierarchy row styles

### DIFF
--- a/lib/FolderRow/styles.scss
+++ b/lib/FolderRow/styles.scss
@@ -10,6 +10,7 @@ $folder-row-spacing: $layout-spacing-base/2 !default;
 
 .folder-row {
   overflow: hidden;
+  width: 100%;
 }
 
 .folder-row__inner,
@@ -23,7 +24,7 @@ $folder-row-spacing: $layout-spacing-base/2 !default;
   padding: $folder-row-spacing;
   background: $neutral-lightest;
   position: relative;
-  margin: 0 0 $layout-spacing-base/2;
+  margin: 6px 0 6px;
   @include before-border(1px, solid, $neutral-light, 4px);
 
   + .folder-row {

--- a/lib/FolderRow/styles.scss
+++ b/lib/FolderRow/styles.scss
@@ -3,6 +3,7 @@
    ========================================================================== */
 
 $folder-row-spacing: $layout-spacing-base/2 !default;
+$folder-row-gap: 6px;
 
 /* ==========================================================================
    Styles
@@ -24,7 +25,7 @@ $folder-row-spacing: $layout-spacing-base/2 !default;
   padding: $folder-row-spacing;
   background: $neutral-lightest;
   position: relative;
-  margin: 6px 0 6px;
+  margin: $folder-row-gap 0 $folder-row-gap;
   @include before-border(1px, solid, $neutral-light, 4px);
 
   + .folder-row {

--- a/lib/ItemRow/styles.scss
+++ b/lib/ItemRow/styles.scss
@@ -2,6 +2,7 @@
    Config
    ========================================================================== */
 $item-row-stacked-margin: $typo-size-slight/3;
+$item-row-gap: 6px;
 
 /* ==========================================================================
    Styles
@@ -11,7 +12,7 @@ $item-row-stacked-margin: $typo-size-slight/3;
   cursor: pointer;
   background-color: white;
   position: relative;
-  margin: 6px 0 6px;
+  margin: $item-row-gap 0 $item-row-gap;
   width: 100%;
 
   .status-indicator {

--- a/lib/ItemRow/styles.scss
+++ b/lib/ItemRow/styles.scss
@@ -11,6 +11,8 @@ $item-row-stacked-margin: $typo-size-slight/3;
   cursor: pointer;
   background-color: white;
   position: relative;
+  margin: 6px 0 6px;
+  width: 100%;
 
   .status-indicator {
     display: inline-flex;


### PR DESCRIPTION
### 💬 Description
Each row in the hierarchy should have it's margin shared between top and bottom, instead of just all at the bottom. This makes calculating the drop area easily, as the row is now symmetrical!

6px might seem like a random number, but it is to fill out the whole row in the hierarchy.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
