### PR TITLE
Hierarchy folder name cursor

### DIFF
--- a/lib/FolderRow/styles.scss
+++ b/lib/FolderRow/styles.scss
@@ -65,6 +65,10 @@ $folder-row-gap: 6px;
     text-overflow: ellipsis;
     overflow: hidden;
   }
+
+  .editable-text__wrapper {
+    cursor: text;
+  }
 }
 
 .folder-row__aside {


### PR DESCRIPTION
### 💬 Description
The cursor for the hierarchy folder name should be one for text. That's it, that's the PR. 

