### PR TITLE
fix disabled state on fields

### DIFF
--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -13,7 +13,7 @@ const Field = props => {
     field__editor: props.canEdit,
     'has-formatting': props.hasFormatting,
     'is-active': props.isActive,
-    'is-disabled': props.disabled
+    'is-visibly-disabled': props.disabled
   });
 
   const dataRowSize = props.canEdit ? 3 : 4;

--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -13,7 +13,7 @@ const Field = props => {
     field__editor: props.canEdit,
     'has-formatting': props.hasFormatting,
     'is-active': props.isActive,
-    'is-visibly-disabled': props.disabled
+    'is-visually-disabled': props.disabled
   });
 
   const dataRowSize = props.canEdit ? 3 : 4;

--- a/styles/helpers/_disabled.scss
+++ b/styles/helpers/_disabled.scss
@@ -5,6 +5,6 @@ $disabled-opacity: 0.5;
   pointer-events: none;
 }
 
-.is-visibly-disabled {
+.is-visually-disabled {
   opacity: $disabled-opacity;
 }

--- a/styles/helpers/_disabled.scss
+++ b/styles/helpers/_disabled.scss
@@ -1,4 +1,10 @@
+$disabled-opacity: 0.5;
+
 .is-disabled {
-  opacity: 0.5;
+  opacity: $disabled-opacity;
   pointer-events: none;
+}
+
+.is-visibly-disabled {
+  opacity: $disabled-opacity;
 }

--- a/tests/Field/Field.js
+++ b/tests/Field/Field.js
@@ -73,7 +73,7 @@ describe('Field', () => {
       disabled: true
     });
     expect(wrapper.hasClass('has-formatting')).toEqual(true);
-    expect(wrapper.hasClass('is-disabled')).toEqual(true);
+    expect(wrapper.hasClass('is-visually-disabled')).toEqual(true);
   });
 
   test('that fields do not render instructions when none are set', () => {


### PR DESCRIPTION
Disabling entire fields from an event POV is a bad idea. Mainly due to read-only mode.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
