### PR TITLE
Fixing disabled styles for deleting a comment

### DIFF
--- a/lib/Conversation/Comment.js
+++ b/lib/Conversation/Comment.js
@@ -112,7 +112,7 @@ class Comment extends Component {
     const removalText = isOp ? 'Delete thread' : 'Delete comment';
     const userCanEdit = createdBy === user.id && userCanComment;
     const className = cx('conversation__comment', {
-      'is-disabled': this.state.confirmRemoval,
+      'is-visually-disabled': this.state.confirmRemoval,
       'has-failed': this.props.hasFailed,
       'has-author-type': author && author.type
     });

--- a/lib/Conversation/styles.scss
+++ b/lib/Conversation/styles.scss
@@ -301,9 +301,9 @@ $conversation-meta-text-color: $neutral-base !default;
   margin-bottom: $conversation-padding;
 }
 
-.is-disabled .conversation__person-type,
-.is-disabled .conversation__person-name,
-.is-disabled .conversation__comment-body {
+.is-visually-disabled .conversation__person-type,
+.is-visually-disabled .conversation__person-name,
+.is-visually-disabled .conversation__comment-body {
   background: rgba(255, 255, 255, .75);
 
   @supports (filter: blur()) {


### PR DESCRIPTION
### 💬 Description
`is-disabled` now turns off pointer events, the delete comment button needs to now be `is-visually-disabled`
