### PR TITLE
Tweaks to DnD and TooltipWrapper

### DIFF
--- a/lib/DnD/DndProvider.js
+++ b/lib/DnD/DndProvider.js
@@ -22,7 +22,9 @@ function DndProvider({ children, backend }) {
   return (
     <DragAndDropProvider backend={backend}>
       <DndContext.Provider value={sharedState}>
-        {isDragging && <DragPreview>{failurePreview || preview}</DragPreview>}
+        {isDragging && (preview || failurePreview) && (
+          <DragPreview>{failurePreview || preview}</DragPreview>
+        )}
 
         {children}
       </DndContext.Provider>

--- a/lib/DnD/Droppable.js
+++ b/lib/DnD/Droppable.js
@@ -15,7 +15,8 @@ function Droppable({
     hover: onHoverHandler,
     collect: monitor => ({
       isOver: monitor.isOver(),
-      canDrop: monitor.canDrop()
+      canDrop: monitor.canDrop(),
+      item: monitor.getItem()
     })
   });
 

--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -30,6 +30,7 @@ const Field = props => {
               className="field__label"
               onChange={value => props.labelChange(value)}
               multiline
+              inputLabel={`edit field label: ${props.label}`}
             >
               {props.label}
             </EditableTextWrapper>

--- a/lib/PillInput/stories/story.js
+++ b/lib/PillInput/stories/story.js
@@ -14,6 +14,7 @@ const PillInputStory = storiesOf('Components', module).add('PillInput', () => (
           warning: 'This is not a valid email address!',
           regex: emailRegex
         }}
+        // eslint-disable-next-line no-console
         onPillsChange={pills => console.log(pills)}
       />
     </StoryItem>

--- a/lib/TooltipWrapper/index.js
+++ b/lib/TooltipWrapper/index.js
@@ -12,6 +12,11 @@ class TooltipWrapper extends Component {
         this.tooltipOverlay.hide();
       }
     }
+    if (this.props.show !== nextProps.show && nextProps.show) {
+      if (this.tooltipOverlay) {
+        this.tooltipOverlay.show();
+      }
+    }
   }
 
   render() {
@@ -24,6 +29,9 @@ class TooltipWrapper extends Component {
       clickable,
       alignLeft,
       wrapperClassName,
+      manual,
+      trigger,
+      show,
       ...rest
     } = this.props;
 
@@ -48,6 +56,7 @@ class TooltipWrapper extends Component {
     return (
       <OverlayTrigger
         {...rest}
+        trigger={manual ? null : trigger}
         overlay={overlay}
         ref={tooltipOverlay => {
           this.tooltipOverlay = tooltipOverlay;
@@ -72,7 +81,9 @@ TooltipWrapper.propTypes = {
     .isRequired,
   hide: PropTypes.bool,
   alignLeft: PropTypes.bool,
-  clickable: PropTypes.bool
+  clickable: PropTypes.bool,
+  manual: PropTypes.bool,
+  show: PropTypes.bool
 };
 
 TooltipWrapper.defaultProps = {
@@ -83,7 +94,9 @@ TooltipWrapper.defaultProps = {
   tooltipText: '',
   wrapperClassName: '',
   alignLeft: false,
-  clickable: false
+  clickable: false,
+  manual: false,
+  show: null
 };
 
 export default TooltipWrapper;


### PR DESCRIPTION
### 💬 Description
Some minor changes  to DnD components and TooltipWrapper

DnD:
- Fix error when you don't provide a custom drag preview
- Pass dragged item info to droppable child
TooltipWrapper
- Allow a manual trigger of the tooltip using hide/show props