### PR TITLE
Change scroll to auto for the windowing scroller

### DIFF
--- a/lib/Windowing/WindowingScroller.js
+++ b/lib/Windowing/WindowingScroller.js
@@ -42,7 +42,7 @@ const WindowingScroller = ({ children, ...rest }) => {
       data-testid="windowing-scroller"
       style={{
         height: containerHeight,
-        overflow: 'scroll',
+        overflow: 'auto',
         position: 'relative'
       }}
       {...rest}


### PR DESCRIPTION
When we auto autoflow scroll we had 1 too man scrollbars, this fixes that issue but retains the ability to scroll when overflowing on windowing.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
