### PR TITLE
Allow style prop to be passed to Windowing.Scroller but keep existing CSS props too

### DIFF
--- a/lib/Windowing/WindowingScroller.js
+++ b/lib/Windowing/WindowingScroller.js
@@ -1,9 +1,9 @@
 import React, { useCallback, useContext, useEffect } from 'react';
-import { node } from 'prop-types';
+import { node, shape } from 'prop-types';
 import debounce from 'debounce';
 import { WindowingContext } from './Windowing';
 
-const WindowingScroller = ({ children, ...rest }) => {
+const WindowingScroller = ({ children, style, ...rest }) => {
   const {
     setScrollTop,
     setHeight,
@@ -43,7 +43,8 @@ const WindowingScroller = ({ children, ...rest }) => {
       style={{
         height: containerHeight,
         overflow: 'auto',
-        position: 'relative'
+        position: 'relative',
+        ...style
       }}
       {...rest}
     >
@@ -53,7 +54,12 @@ const WindowingScroller = ({ children, ...rest }) => {
 };
 
 WindowingScroller.propTypes = {
-  children: node.isRequired
+  children: node.isRequired,
+  style: shape()
+};
+
+WindowingScroller.defaultProps = {
+  style: {}
 };
 
 export { WindowingScroller };

--- a/lib/Windowing/stories/WindowingStory.js
+++ b/lib/Windowing/stories/WindowingStory.js
@@ -47,7 +47,7 @@ stories
             allIds={allWindowingIds}
             containerHeight="500px"
           >
-            <Windowing.Scroller>
+            <Windowing.Scroller style={{}}>
               <Windowing.List>
                 {({ inViewWindowingIds }) =>
                   inViewWindowingIds.map(i => (


### PR DESCRIPTION
### 💬 Description
Just a suggestion - this is one way we could solve the problem when a style prop was passed to the Scroller, which would allow us complete control from the client, but a sensible, resilient, default implementation .

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
