### PR TITLE
Upgrade view tests changes

### DIFF
--- a/lib/TooltipWrapper/index.js
+++ b/lib/TooltipWrapper/index.js
@@ -77,8 +77,7 @@ TooltipWrapper.propTypes = {
   trigger: PropTypes.arrayOf(PropTypes.string),
   id: PropTypes.string.isRequired,
   tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
-    .isRequired,
+  children: PropTypes.node.isRequired,
   hide: PropTypes.bool,
   alignLeft: PropTypes.bool,
   clickable: PropTypes.bool,

--- a/styles/helpers/_layout.scss
+++ b/styles/helpers/_layout.scss
@@ -162,6 +162,19 @@ $subProps: (stretch, center, flex-start, flex-end, baseline, initial, inherit);
 }
 
 /* ==========================================================================
+   Flex direction
+   ========================================================================== */
+
+$props: ('flex-direction');
+$subProps: (row, column);
+
+@include generate-helper($props, $subProps) using ($selector, $property, $style) {
+  #{$selector} {
+    flex-direction: $style;
+  }
+}
+
+/* ==========================================================================
    Legibility
    ========================================================================== */
 


### PR DESCRIPTION
### 💬 Description
A couple of changes accumulated whilst adding tests for the Upgrade view.

- Adds flex direction CSS helper
- Changes `children` proptype on `TooltipWrapper` to `node`, as it was throwing errors with certain other render types
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
