### PR TITLE
Update/Shareables Upgrade Modal Changes

### DIFF
--- a/lib/Icon/index.js
+++ b/lib/Icon/index.js
@@ -230,7 +230,8 @@ const Icon = props => {
     {
       'icon--hide-text': props.hideText,
       'icon--has-notification': props.notification,
-      'icon--default-fill-color': props.defaultFillColor
+      'icon--default-fill-color': props.defaultFillColor,
+      'icon--default-active-color': props.defaultActiveColor
     }
   );
 
@@ -261,7 +262,8 @@ Icon.defaultProps = {
   types: [],
   textTypes: [],
   title: null,
-  defaultFillColor: true
+  defaultFillColor: true,
+  defaultActiveColor: true
 };
 
 Icon.propTypes = {
@@ -273,7 +275,8 @@ Icon.propTypes = {
   types: PropTypes.arrayOf(PropTypes.string),
   textTypes: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string,
-  defaultFillColor: PropTypes.bool
+  defaultFillColor: PropTypes.bool,
+  defaultActiveColor: PropTypes.bool
 };
 
 export default Icon;

--- a/lib/Icon/styles.scss
+++ b/lib/Icon/styles.scss
@@ -21,7 +21,7 @@ $icon-active-color: $color-brand-blue !default;
   fill: $icon-default-color;
 }
 
-.is-active .icon path {
+.is-active .icon.icon--default-active-color path {
   fill: $icon-active-color;
 }
 

--- a/styles/helpers/_layout.scss
+++ b/styles/helpers/_layout.scss
@@ -7,27 +7,27 @@ $subProps: ('', 'left', 'right', 'top', 'bottom');
 
 @include generate-helper($props, $subProps) using ($selector, $property, $style) {
   #{$selector}-double {
-    #{$property}: $layout-spacing-base * 2;
+    #{$property}: $layout-spacing-base * 2 !important;
   }
 
   #{$selector} {
-    #{$property}: $layout-spacing-base;
+    #{$property}: $layout-spacing-base !important;
   }
 
   #{$selector}-half {
-    #{$property}: $layout-spacing-base/2;
+    #{$property}: $layout-spacing-base/2 !important;
   }
 
   #{$selector}-quarter {
-    #{$property}: $layout-spacing-base/4;
+    #{$property}: $layout-spacing-base/4 !important;
   }
 
   #{$selector}-clear {
-    #{$property}: 0;
+    #{$property}: 0 !important;
   }
 
   #{$selector}-auto {
-    #{$property}: auto;
+    #{$property}: auto !important;
   }
 }
 
@@ -203,11 +203,15 @@ $subProps: (row, column);
    ========================================================================== */
 
 $props: ('border-default');
-$subProps: (top, bottom, left, right, full);
+$subProps: (top, bottom, left, right, full, clear);
 @include generate-helper($props, $subProps) using ($selector, $property, $style) {
   @if $style == 'full' {
     #{$selector} {
       border: $color-border-base 1px solid;
+    }
+  } @else if $style == 'clear' {
+    #{$selector} {
+      border: none;
     }
   } @else {
     #{$selector} {


### PR DESCRIPTION
### 💬 Description
Here are a few changes that were spawned from the adding the Shareable Upgrade Modal:
> https://github.com/gathercontent/app/pull/2650

- Adds `defaultActiveColor` prop to Icon. By default all SVGs with the class `.icon` are set to blue if they have a parent with the class `.is-active`. Setting this new prop to false overrides this behaviour.
- Updates the `h-border-default` helper to accept a `-clear` postfix, meaning it will clear borders.
- Adds `!important` to the "Margin & Padding" SCSS helper values. This was to override some values set in React Bootstrap.
  - I wasn't so sure about this, and am happy to be challenged. I know using `!important` is a bit of a smell, as it makes it impossible to over-write. But I think it is ok for helpers to be impossible to overwrite, as they are always applied at a component level, not globally.
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/2650

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
