### PR TITLE
Update/Add justify-content helper class

### DIFF
--- a/lib/CheckToggle/index.js
+++ b/lib/CheckToggle/index.js
@@ -88,6 +88,7 @@ class CheckToggle extends Component {
         {labelLeft && <p className={wrapperLabelClasses}>{labelLeft}</p>}
         <span className="toggle-wrapper__inner">
           <input
+            data-testid={id}
             onChange={this.onClickHandler}
             checked={checked}
             type="checkbox"

--- a/lib/CheckToggle/index.js
+++ b/lib/CheckToggle/index.js
@@ -70,7 +70,7 @@ class CheckToggle extends Component {
     const wrapperClasses = cx(`toggle-wrapper ${className}`, {
       'size-small': displaySmall,
       'is-checked': displayChecked && checked,
-      'space-between': spaceBetween,
+      'h-justify-content-space-between': spaceBetween,
       'margin-large': marginSizeLarge,
       disabled
     });

--- a/styles/helpers/_layout.scss
+++ b/styles/helpers/_layout.scss
@@ -162,6 +162,19 @@ $subProps: (stretch, center, flex-start, flex-end, baseline, initial, inherit);
 }
 
 /* ==========================================================================
+   justify-content
+   ========================================================================== */
+
+$props: ('justify-content');
+$subProps: (baseline, center, end, flex-end, flex-start, initial, inherit, space-around, space-between, space-evenly, stretch);
+
+@include generate-helper($props, $subProps) using ($selector, $property, $style) {
+  #{$selector} {
+    justify-content: $style;
+  }
+}
+
+/* ==========================================================================
    Flex direction
    ========================================================================== */
 
@@ -172,14 +185,6 @@ $subProps: (row, column);
   #{$selector} {
     flex-direction: $style;
   }
-}
-
-/* ==========================================================================
-   Legibility
-   ========================================================================== */
-
-.space-between {
-  justify-content: space-between;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
### 💬 Description
Add `justify-content` helper class.

Same idea as `align-items` helper class.

Also removes the old `space-between` helper class. Usage instances have been removed here and in app (as you will see in the required PR 👇)

Required for https://github.com/gathercontent/app/pull/2655
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
