### PR TITLE
Fix default active icon colour across multiple component

### DIFF
--- a/lib/Button/ButtonWithIcon.js
+++ b/lib/Button/ButtonWithIcon.js
@@ -27,7 +27,7 @@ const ButtonWithIcon = props => {
             types={['primary']}
             disabled={props.disableBoth || props.disableIcon}
           >
-            <Icon name={props.iconName} />
+            <Icon name={props.iconName} defaultActiveColor={false} />
           </Dropdown.Trigger>
           {props.dropdownContent}
         </Dropdown>

--- a/lib/StatusIndicator/index.js
+++ b/lib/StatusIndicator/index.js
@@ -50,9 +50,17 @@ const StatusIndicator = ({
         {preText && (
           <span className="status-indicator__pre-text">{preText}</span>
         )}
+
         <span className={circleClassNames} style={style}>
-          {approved && <Icon name="boldTickSmall" types={['white']} />}
+          {approved && (
+            <Icon
+              name="boldTickSmall"
+              types={['white']}
+              defaultActiveColor={false}
+            />
+          )}
         </span>
+
         {label && (
           <div className="status-indicator__label-wrapper">
             <h3 className="status-indicator__label" title={label}>
@@ -62,9 +70,14 @@ const StatusIndicator = ({
                 {label}
               </span>
             </h3>
+
             {readOnly && (
               <TooltipWrapper id={label} tooltipText="Read only">
-                <Icon name="lock" className="status-indicator__readonly" />
+                <Icon
+                  name="lock"
+                  className="status-indicator__readonly"
+                  defaultActiveColor={false}
+                />
               </TooltipWrapper>
             )}
           </div>


### PR DESCRIPTION
### 💬 Description

Icons have been changed recently to always fill their paths to blue when within a container with the 
`is-active` class. This has caused [various issues](https://share.getcloudapp.com/Apurxvn4) where [icons are going](https://share.getcloudapp.com/04uKLyYd) blue [when they shouldn't ](https://share.getcloudapp.com/Z4u51Dx0)(mainly in dropdowns and fields).

After some fixes in the consuming app, we've realised that there are additional fixes required in `gather-ui`. This is what this PR fixes.

----

I believe this recently added default behaviour should be refactored and replaced with a utility-based solution so we can add a class like `h-path-fill-primary`. We can add a helper for each colour too and remove the need to know if something has the `is-active` class etc.

----

I understand this is work that we can take on in the near future but for now, we need to fix the existing problem in a timely manner.

### 👫 Related PRs (optional)

#671 - this is where the source of the problem has come from.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
