### PR TITLE
Fix memory leaks with Draggables

### DIFF
--- a/lib/DnD/Draggable.js
+++ b/lib/DnD/Draggable.js
@@ -14,8 +14,10 @@ function Draggable({ children, preview, item, onBeginDrag, onEndDrag }) {
       onBeginDrag(item, monitor);
     },
     end: (targetItem, monitor) => {
-      onEndDrag(targetItem, monitor);
-      setIsDragging(false);
+      if (!monitor.didDrop()) {
+        onEndDrag(targetItem, monitor);
+        setIsDragging(false);
+      }
     },
     collect: monitor => ({
       itemType: monitor.getItemType(),

--- a/lib/DnD/Droppable.js
+++ b/lib/DnD/Droppable.js
@@ -1,5 +1,7 @@
 import { useDrop } from 'react-dnd';
 import { func, node } from 'prop-types';
+import { useContext } from 'react';
+import { DndContext } from 'lib';
 
 function Droppable({
   children,
@@ -8,9 +10,13 @@ function Droppable({
   canDropChecker,
   onHoverHandler
 }) {
+  const { setIsDragging } = useContext(DndContext);
   const [collected, defineDropRef] = useDrop({
     accept: acceptDragTypes,
-    drop: onDrop,
+    drop: (...args) => {
+      setIsDragging(false);
+      return onDrop(...args);
+    },
     canDrop: canDropChecker,
     hover: onHoverHandler,
     collect: monitor => ({

--- a/lib/Dropdown/DropdownTrigger.js
+++ b/lib/Dropdown/DropdownTrigger.js
@@ -7,13 +7,17 @@ import { GATHER_UI_DROPDOWN } from './consts';
 
 class DropdownTrigger extends Component {
   handleClick = () => {
-    const { toggleShowContent, autoPosition } = this.context[
+    const { toggleShowContent, autoPosition, showContent } = this.context[
       GATHER_UI_DROPDOWN
     ];
+
+    this.props.onClick(!showContent);
+
     if (this.trigger && autoPosition) {
       const bounds = this.trigger.getBoundingClientRect();
       return toggleShowContent(bounds);
     }
+
     return toggleShowContent();
   };
 


### PR DESCRIPTION
### 💬 Description
When writing tests we've noticed that our `Draggable` component can cause memory leaks. The underlining source of the issue is still an unknown but there are complications with `onDrop` and `onEndDrag` which cause us to have memory leaks in our tests.

There's a silver lining. The change to `Draggable` makes sense because when we drop A into B we should handle changes in `onDrop` via `Droppable`. This leaves `onEndDrag` to handle all those times we don't drag something into a dropable.

E.g. we should clear the drag preview when we drag `A` into some whitespace. We should also clear the preview when dropping `A` successfully.

---

I've also added a nice little additional for `Dropdown`s where we can expose the showing boolean so we can log it for usage tracking 👍 

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
