### PR TITLE
Sets collection table to flex-shrink: 0

### DIFF
--- a/lib/CollectionsTable/styles.scss
+++ b/lib/CollectionsTable/styles.scss
@@ -33,6 +33,7 @@ $collections-table-cell-min-height: 40px !default;
   width: 100%;
   display: flex;
   flex-flow: row nowrap;
+  flex-shrink: 0;
   padding: $collections-table-spacing;
 }
 


### PR DESCRIPTION
### 💬 Description
A browser issue fix for dismiss-able notifications that was still in my local machine and got left behind 😢 
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
