### PR TITLE
Update/Bulk Share Test Changes

### DIFF
--- a/lib/ProgressButton/index.js
+++ b/lib/ProgressButton/index.js
@@ -14,7 +14,8 @@ class ProgressButton extends Component {
     disabled: false,
     autoSpinner: false,
     spinnerText: null,
-    className: ''
+    className: '',
+    onCallbackResolved: null
   };
 
   static propTypes = {
@@ -28,7 +29,8 @@ class ProgressButton extends Component {
     disabled: PropTypes.bool,
     autoSpinner: PropTypes.bool,
     spinnerText: PropTypes.string,
-    className: PropTypes.string
+    className: PropTypes.string,
+    onCallbackResolved: PropTypes.func
   };
 
   constructor(props) {
@@ -68,9 +70,13 @@ class ProgressButton extends Component {
     }
 
     this.showSpinner();
-    await this.props.clickHandler(e);
+    const result = await this.props.clickHandler(e);
     if (this.props.autoSpinner) {
       this.setState({ showSpinner: false });
+    }
+
+    if (this.props.onCallbackResolved) {
+      this.props.onCallbackResolved(result);
     }
   };
 

--- a/lib/SelectionProvider/index.js
+++ b/lib/SelectionProvider/index.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
+import { node, arrayOf, oneOfType, string, number } from 'prop-types';
 import ShortcutTrigger from '../ShortcutTrigger';
 
 const SelectionContext = React.createContext({});
 
-const SelectionProvider = ({ children }) => {
-  const [selected, setSelected] = useState([]);
+const SelectionProvider = ({ children, initialSelected }) => {
+  const [selected, setSelected] = useState(initialSelected);
   const [intendedToSelect, setIntendedToSelect] = useState([]);
   const [currentSelectedType, setCurrentSelectedType] = useState(null);
 
@@ -67,7 +67,12 @@ const SelectionProvider = ({ children }) => {
 };
 
 SelectionProvider.propTypes = {
-  children: PropTypes.node.isRequired
+  children: node.isRequired,
+  initialSelected: arrayOf(oneOfType([string, number]))
+};
+
+SelectionProvider.defaultProps = {
+  initialSelected: []
 };
 
 export { SelectionProvider, SelectionContext };


### PR DESCRIPTION
### 💬 Description
Couple of changes to GUI that correspond to the tests added for Bulk Share Items https://github.com/gathercontent/app/pull/2747

#### 壱 `<ProgressButton />` `onCallbackResolved` prop
This new prop is called after the `clickHandler` promise passed to progress button has resolved, and is passed the result of the promise.

Previously I had a call to close the modal _inside_ the promise `clickHandler` that was passed to a progress button.

This threw a `Cannot update state on an unmounted component` error as we unmounted the modal (and the `<ProgressButton/>` inside it), then the `<ProgressButton/>` tried to update it's `showLoader` state.

The new change means we can call `hideModal` after the `<ProgressButton/>` has finished setting state.
#### 弍 `<SelectionProvider />` `initialSelected` prop
This new prop was added so that we can set the initial selected values in tests (in the Bulk Share example, we aren't rendering the UI required to set items normally.)
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/2747

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
