### PR TITLE
Tab Options Icon Colour Fix

### DIFF
--- a/lib/Tabs/TabsOptions.js
+++ b/lib/Tabs/TabsOptions.js
@@ -6,7 +6,7 @@ import DropdownMenu from '../DropdownMenu';
 const TabOptions = ({ options }) => (
   <DropdownMenu type="icon-only" items={options} listClassName="tabs__dropdown">
     <span className="tabs__options">
-      <Icon className="tabs__icon" name="cog" />
+      <Icon className="tabs__icon" name="cog" defaultActiveColor={false} />
     </span>
   </DropdownMenu>
 );


### PR DESCRIPTION
### 💬 Description
Adds the `defaultActiveColor=false` prop to the `<TabOptions />` component to fix the issue where the icon was blue instead of white.
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
