### PR TITLE
Update/Use rem units for spacing

### DIFF
--- a/lib/Notification/bar/NotificationBarBase.js
+++ b/lib/Notification/bar/NotificationBarBase.js
@@ -28,7 +28,7 @@ const NotificationBarBase = ({
   return (
     <Alert
       onClick={clickHandler}
-      className={`notification text-base font-semi-bold p-half border-0 rounded-none inherit-color-icon inherit-color-link ${classes} ${className}`}
+      className={`notification text-base font-semi-bold p-3 border-0 rounded-none inherit-color-icon inherit-color-link ${classes} ${className}`}
       {...rest}
     >
       <div className="notification__content w-full">{children}</div>

--- a/lib/Notification/inline/NotificationInlineBase.js
+++ b/lib/Notification/inline/NotificationInlineBase.js
@@ -23,12 +23,12 @@ const NotificationInlineBase = ({
   return (
     <div
       role="alert"
-      className={`notification text-base font-semi-bold py-half px-threeQuarter border-2 border-solid inline-flex text-neutral-20 bg-white rounded items-center inherit-color-icon inherit-color-link border-${borderColor} ${classes} ${className}`}
+      className={`notification text-base font-semi-bold py-3 px-4 border-2 border-solid inline-flex text-neutral-20 bg-white rounded items-center inherit-color-icon inherit-color-link border-${borderColor} ${classes} ${className}`}
       {...rest}
     >
       <Icon
         name={iconName}
-        className={`text-${borderColor} mr-half`}
+        className={`text-${borderColor} mr-3`}
         defaultActiveColor={false}
       />
       <div className="notification__content w-full">{children}</div>

--- a/lib/Pill/PillBase.js
+++ b/lib/Pill/PillBase.js
@@ -3,7 +3,7 @@ import { types, defaults } from './pillTypes';
 
 const PillBase = ({ className, children, ...rest }) => (
   <span
-    className={`pill inline-flex items-center py-quarter px-half rounded ${className}`}
+    className={`pill inline-flex items-center py-1 px-3 rounded ${className}`}
     {...rest}
   >
     {children}

--- a/lib/PillInput/DeleteablePill.js
+++ b/lib/PillInput/DeleteablePill.js
@@ -9,7 +9,7 @@ const DeleteablePill = ({ name, onRemove, warning, id }) => {
   const pillType = warning ? 'error' : 'default';
   return (
     <TooltipWrapper id={`pill-input-pill-tooltip-${id}`} tooltipText={warning}>
-      <Pill className="mr-quarter mb-quarter" type={pillType}>
+      <Pill className="mr-1 mb-1" type={pillType}>
         <p className="h-margin-clear h-margin-right-half">{name}</p>
         <Button onClick={onRemove} types={['clear']}>
           <Icon name="cross" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,13 +9,6 @@ module.exports = {
       'semi-bold': 500,
       bold: 600
     },
-    spacing: {
-      quarter: '5px',
-      half: '10px',
-      threeQuarter: '15px',
-      base: '20px',
-      double: '40px',
-    },
     borderRadius: {
       default: '6px',
     },


### PR DESCRIPTION
### 💬 Description
As agreed the other day, we're moving to `rem` spacing!

This means we can use all of tailwinds lovely spacing classes, and not have to bother to keep inventing our own 👌 

This PR:
- Removes the old spacing values from `tailwind.config.js`, which enables tailwinds default `rem` values
- Replaces uses of the old spacing values.
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
