### PR TITLE
Adding focus states for the BoundaryClickWatcher

### DIFF
--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -27,7 +27,7 @@ class BoundaryClickWatcher extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { boundaryIsActive: false };
+    this.state = { boundaryIsActive: false, boundaryIsFocussed: false };
     this.handleClick = this.handleClick.bind(this);
     this.addDocumentEventListener = this.addDocumentEventListener.bind(this);
     this.removeDocumentEventListener = this.removeDocumentEventListener.bind(
@@ -35,6 +35,8 @@ class BoundaryClickWatcher extends Component {
     );
     this.handleInnerClick = this.handleInnerClick.bind(this);
     this.handleOuterClick = this.handleOuterClick.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
   }
 
   componentDidMount() {
@@ -105,6 +107,18 @@ class BoundaryClickWatcher extends Component {
     }
   }
 
+  handleBlur(e) {
+    this.setState({
+      boundaryIsFocussed: e.target === this.container && false
+    });
+  }
+
+  handleFocus(e) {
+    this.setState({
+      boundaryIsFocussed: e.target === this.container
+    });
+  }
+
   render() {
     const {
       children,
@@ -113,12 +127,12 @@ class BoundaryClickWatcher extends Component {
       onMouseLeave,
       BoundaryElement
     } = this.props;
-    const { boundaryIsActive } = this.state;
+    const { boundaryIsActive, boundaryIsFocussed } = this.state;
 
     return (
       <BoundaryElement
+        tabIndex={0}
         role="button"
-        tabIndex={-1}
         ref={el => {
           this.container = el;
         }}
@@ -127,8 +141,12 @@ class BoundaryClickWatcher extends Component {
         className={`boundary-click-watcher ${className}`}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
       >
-        {typeof children === 'function' ? children(boundaryIsActive) : children}
+        {typeof children === 'function'
+          ? children(boundaryIsActive, boundaryIsFocussed)
+          : children}
       </BoundaryElement>
     );
   }

--- a/lib/Comment/CommentBody.js
+++ b/lib/Comment/CommentBody.js
@@ -64,7 +64,7 @@ export function CommentBody({
         )}
         {children}
       </div>
-      <input className="sr-only" type="text" aria-hidden="true" />
+      <input className="sr-only" type="text" tabIndex={-1} aria-hidden="true" />
     </div>
   );
 }

--- a/lib/Comment/styles.scss
+++ b/lib/Comment/styles.scss
@@ -7,7 +7,11 @@
 }
 
 .new-comment__input {
-  @apply border-0 p-2;
+  &:focus,
+  &:active {
+    @apply border-blue-primary border border-solid rounded;
+  }
+  @apply border border-solid border-transparent p-2;
 }
 
 .edit-comment__input {

--- a/lib/Conversation/Conversation.js
+++ b/lib/Conversation/Conversation.js
@@ -5,10 +5,12 @@ import { ConversationHeader } from './ConversationHeader';
 import { ConversationFooter } from './ConversationFooter';
 import { ConversationBody } from './ConversationBody';
 
-function Conversation({ className, children, isActive, ...rest }) {
+function Conversation({ className, children, isActive, isFocussed, ...rest }) {
   const innerClassName = cx(`${className} relative rounded m-4 w-full`, {
     'border border-solid border-neutral-90 shadow-small': isActive,
-    'conversation__inactive border-1 border-solid border-transparent hover:bg-neutral-95 border- cursor-pointer': !isActive
+    'cursor-pointer hover:bg-neutral-95 conversation__inactive border-1 border-solid': !isActive,
+    'border-transparent': !isActive && !isFocussed,
+    'border-blue-80': !isActive && isFocussed
   });
 
   return (
@@ -21,12 +23,14 @@ function Conversation({ className, children, isActive, ...rest }) {
 Conversation.propTypes = {
   className: string,
   children: node.isRequired,
-  isActive: bool
+  isActive: bool,
+  isFocussed: bool
 };
 
 Conversation.defaultProps = {
   className: '',
-  isActive: false
+  isActive: false,
+  isFocussed: false
 };
 
 Conversation.Header = ConversationHeader;

--- a/lib/Conversation/stories/CollapsedConversationWrappedBoundary.js
+++ b/lib/Conversation/stories/CollapsedConversationWrappedBoundary.js
@@ -21,8 +21,11 @@ export function CollapsedConversationWrappedBoundary() {
 
   return (
     <BoundaryClickWatcher>
-      {boundaryIsActive => (
-        <Conversation isActive={boundaryIsActive}>
+      {(boundaryIsActive, boundaryIsFocussed) => (
+        <Conversation
+          isActive={boundaryIsActive}
+          isFocussed={boundaryIsFocussed}
+        >
           {boundaryIsActive && (
             <Conversation.Header>
               <Comment.SubscribeToggle


### PR DESCRIPTION
### 💬 Description
We would like to be able to tab onto our BoundaryClickWatchers, and apply a focus state to it's children if they care.

This adds the correct events to the watcher and passes down the focussed state through render props.

### 🚪 Start Points
`lib/BoundaryClickWatcher/index.js`

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
