### PR TITLE
Adds a border and changes background color of guidline fields

### DIFF
--- a/lib/Guideline/index.js
+++ b/lib/Guideline/index.js
@@ -51,9 +51,14 @@ class Guideline extends Component {
     const toggleText = this.state.showContent
       ? 'Hide guidelines'
       : 'Show guidelines';
-    const classNames = cx('guideline', {
-      'is-active': this.state.showContent
-    });
+
+    const classNames = cx(
+      'guideline bg-blue-98 border border-blue-90 border-solid',
+      {
+        'is-active': this.state.showContent
+      }
+    );
+
     return (
       <div className={classNames}>
         <div className="guideline__head">

--- a/lib/Guideline/styles.scss
+++ b/lib/Guideline/styles.scss
@@ -9,7 +9,6 @@ $guideline-title-size: $typo-size-large !default;
    Styles
    ========================================================================== */
 .guideline {
-  background: $guideline-bg-colour;
   padding: $guideline-spacing;
   margin: 0 0 $guideline-spacing*2;
   border-radius: 4px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,7 @@ module.exports = {
       colors: {
         current: 'currentColor',
         blue: {
+          '98': '#F5F9FF',
           '95': '#E6F1FF',
           '90': '#CCE2FF',
           '80': blue80,


### PR DESCRIPTION
### 💬 Description
Cheeky peaks tweak - as the title says!

<img width="1166" alt="Screenshot 2020-05-06 at 13 28 16" src="https://user-images.githubusercontent.com/25352812/81176755-80b1e100-8f9d-11ea-8df1-40e98eab7f5a.png">

### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
