### PR TITLE
Update/pill input fix

### DIFF
--- a/lib/PillInput/PillInput/PillInput.js
+++ b/lib/PillInput/PillInput/PillInput.js
@@ -36,7 +36,7 @@ const PillInput = ({
   };
 
   const removeLastPill = () => {
-    const newPills = pills.length > 1 ? pills.slice(0, pills.length - 1) : [];
+    const newPills = pills.slice(0, pills.length - 1);
     setPills(newPills);
   };
 

--- a/lib/PillInput/PillInput/PillInput.js
+++ b/lib/PillInput/PillInput/PillInput.js
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import uuid from 'uuid/v1';
 import { string, arrayOf, bool, instanceOf, shape, func } from 'prop-types';
 import cx from 'classnames';
-import { DeleteablePill } from './DeleteablePill';
+import { DeleteablePill } from '../DeleteablePill';
+import { useKeyDownHandlers } from './useKeyDownHandlers';
 
 const PillInput = ({
   className,
@@ -31,6 +32,11 @@ const PillInput = ({
 
   const removePill = id => {
     const newPills = pills.filter(pill => pill.id !== id);
+    setPills(newPills);
+  };
+
+  const removeLastPill = () => {
+    const newPills = pills.length > 1 ? pills.slice(0, pills.length - 1) : [];
     setPills(newPills);
   };
 
@@ -72,22 +78,16 @@ const PillInput = ({
     onPillsChange(pills);
   }, [pills]);
 
-  useEffect(() => {
-    const handleKeyDown = ({ keyCode }) => {
-      const ENTER_KEY_CODE = 13;
+  const inputRef = useRef(null);
 
-      if (keyCode !== ENTER_KEY_CODE) {
-        return;
-      }
-
-      addPills([inputValue]);
-      setInputValue('');
-    };
-
-    const KEYDOWN_EVENT = 'keydown';
-    document.addEventListener(KEYDOWN_EVENT, handleKeyDown);
-    return () => document.removeEventListener(KEYDOWN_EVENT, handleKeyDown);
-  }, [inputValue]);
+  useKeyDownHandlers({
+    pills,
+    addPills,
+    removeLastPill,
+    inputValue,
+    setInputValue,
+    inputRef
+  });
 
   return (
     <div className={containerClassName}>
@@ -104,6 +104,7 @@ const PillInput = ({
       })}
       <input
         {...rest}
+        ref={inputRef}
         placeholder={!pills.length ? placeholder : ''}
         className="pill-input__input h-margin-bottom-quarter h-margin-right-quarter h-padding-bottom-quarter h-padding-top-quarter h-padding-left-quarter h-padding-right-quarter"
         value={inputValue}

--- a/lib/PillInput/PillInput/useKeyDownHandlers.js
+++ b/lib/PillInput/PillInput/useKeyDownHandlers.js
@@ -8,34 +8,34 @@ function useKeyDownHandlers({
   setInputValue,
   inputRef
 }) {
-  const handleEnter = event => {
-    event.preventDefault();
-    addPills([inputValue]);
-    setInputValue('');
-  };
-
-  const handleBackSpace = () => {
-    if (inputValue) {
-      return;
-    }
-
-    removeLastPill();
-  };
-
-  const handleKeyDown = event => {
-    const ENTER_KEY_CODE = 13;
-    const BACKSPACE_KEY_CODE = 8;
-
-    if (event.keyCode === ENTER_KEY_CODE) {
-      handleEnter(event);
-    }
-
-    if (event.keyCode === BACKSPACE_KEY_CODE) {
-      handleBackSpace();
-    }
-  };
-
   useEffect(() => {
+    const handleEnter = event => {
+      event.preventDefault();
+      addPills([inputValue]);
+      setInputValue('');
+    };
+
+    const handleBackSpace = () => {
+      if (inputValue) {
+        return;
+      }
+
+      removeLastPill();
+    };
+
+    const handleKeyDown = event => {
+      const ENTER_KEY_CODE = 13;
+      const BACKSPACE_KEY_CODE = 8;
+
+      if (event.keyCode === ENTER_KEY_CODE) {
+        handleEnter(event);
+      }
+
+      if (event.keyCode === BACKSPACE_KEY_CODE) {
+        handleBackSpace();
+      }
+    };
+
     if (!inputRef) {
       return () => {};
     }
@@ -43,7 +43,7 @@ function useKeyDownHandlers({
     const KEYDOWN_EVENT = 'keydown';
     document.addEventListener(KEYDOWN_EVENT, handleKeyDown);
     return () => document.removeEventListener(KEYDOWN_EVENT, handleKeyDown);
-  }, [inputValue, inputRef, pills]);
+  }, [inputRef.current, inputValue, pills]);
 }
 
 export { useKeyDownHandlers };

--- a/lib/PillInput/PillInput/useKeyDownHandlers.js
+++ b/lib/PillInput/PillInput/useKeyDownHandlers.js
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+
+function useKeyDownHandlers({
+  pills,
+  addPills,
+  removeLastPill,
+  inputValue,
+  setInputValue,
+  inputRef
+}) {
+  const handleEnter = event => {
+    event.preventDefault();
+    addPills([inputValue]);
+    setInputValue('');
+  };
+
+  const handleBackSpace = () => {
+    if (inputValue) {
+      return;
+    }
+
+    removeLastPill();
+  };
+
+  const handleKeyDown = event => {
+    const ENTER_KEY_CODE = 13;
+    const BACKSPACE_KEY_CODE = 8;
+
+    if (event.keyCode === ENTER_KEY_CODE) {
+      handleEnter(event);
+    }
+
+    if (event.keyCode === BACKSPACE_KEY_CODE) {
+      handleBackSpace();
+    }
+  };
+
+  useEffect(() => {
+    if (!inputRef) {
+      return () => {};
+    }
+
+    const KEYDOWN_EVENT = 'keydown';
+    document.addEventListener(KEYDOWN_EVENT, handleKeyDown);
+    return () => document.removeEventListener(KEYDOWN_EVENT, handleKeyDown);
+  }, [inputValue, inputRef, pills]);
+}
+
+export { useKeyDownHandlers };

--- a/lib/PillInput/stories/story.js
+++ b/lib/PillInput/stories/story.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { PillInput } from '../PillInput';
+import { PillInput } from '../PillInput/PillInput';
 import StoryItem from '../../../stories/styleguide/StoryItem';
 
 const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;

--- a/lib/PillInput/tests/PillInput.spec.js
+++ b/lib/PillInput/tests/PillInput.spec.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { render, fireEvent, cleanup } from '@testing-library/react';
-import { PillInput } from '../PillInput';
+import { PillInput } from '../PillInput/PillInput';
 
 const PLACEHOLDER_TEXT = 'Enter an email';
 

--- a/lib/PillInput/tests/PillInput.spec.js
+++ b/lib/PillInput/tests/PillInput.spec.js
@@ -34,7 +34,7 @@ describe('PillInput', () => {
     cleanup();
   });
 
-  describe('Initilising Pills', () => {
+  describe('Initialising Pills', () => {
     const initialPills = [
       { name: 'Pill1', isValid: true },
       { name: 'Pill2', isValid: true }
@@ -169,6 +169,46 @@ describe('PillInput', () => {
     expect(getByText(emails[1]));
     expect(queryByText(emails[2])).toBeNull();
     expect(getByText(emails[3]));
+  });
+
+  it('deletes the last pill when the backspace key is pressed and there is no input', async () => {
+    const {
+      getByPlaceholderText,
+      queryByText,
+      getByText,
+      container
+    } = renderComponent();
+
+    const emails = [
+      'alex@gmail.com',
+      'amee@gmail.com',
+      'david@gmail.com',
+      'kyle@gmail.com'
+    ];
+    const inputElement = getByPlaceholderText(PLACEHOLDER_TEXT);
+
+    emails.forEach(email =>
+      fireEvent.change(inputElement, { target: { value: `${email} ` } })
+    );
+
+    fireEvent.change(inputElement, { target: { value: 's' } });
+
+    const BACKSPACE_KEY_CODE = 8;
+    fireEvent.keyDown(container, { keyCode: BACKSPACE_KEY_CODE });
+
+    expect(getByText(emails[0]));
+    expect(getByText(emails[1]));
+    expect(getByText(emails[2]));
+    expect(getByText(emails[3]));
+
+    fireEvent.change(inputElement, { target: { value: '' } });
+
+    fireEvent.keyDown(container, { keyCode: BACKSPACE_KEY_CODE });
+
+    expect(getByText(emails[0]));
+    expect(getByText(emails[1]));
+    expect(getByText(emails[2]));
+    expect(queryByText(emails[3])).toBeNull();
   });
 
   describe('Pill checker', () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ export {
 } from './DnD';
 export { Windowing } from './Windowing';
 export FinderPanelLayout from './FinderPanelLayout';
-export { PillInput } from './PillInput/PillInput';
+export { PillInput } from './PillInput/PillInput/PillInput';
 export DismissiblePrompt from './DismissiblePrompt';
 export { ButtonPrimary } from './ButtonNew/ButtonPrimary/ButtonPrimary';
 export {


### PR DESCRIPTION
### 💬 Description
Carys reported an issue where hitting enter when you were in the PillInput in the bulk share form would submit the form, when it is only supposed to add a Pill.

This PR fixes that by using `event.preventDefault()` for the enter key handler.

As a bonus, I have added the functionality to PillInput to delete a Pill by pressing backspace when you are in the input.

I have moved the keydown handlers to a custom hook, `useKeyDownHandlers`.

I also attached the listeners to the `input` element rather than the `document` element.

Video demo 👉 https://share.getcloudapp.com/E0ubypWk
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)

### 🚪 Start Points
https://github.com/gathercontent/gather-ui/pull/723/files#diff-206d0e1f7234e30c362c2abfdab1d40dlisting multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
