### PR TITLE
Add RepeatableSettings component to field

### DIFF
--- a/lib/Field/FieldActions.js
+++ b/lib/Field/FieldActions.js
@@ -1,25 +1,32 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { arrayOf, func, shape, string } from 'prop-types';
 import Button from '../Button';
 
-const FieldActions = props => {
-  const actions = props.actions.map(action => (
+export const FieldActions = ({ actions, className }) => {
+  const actionButtons = actions.map(({ text, clickHandler }) => (
     <Button
-      key={`${props.fieldId}-action-${action.text}`}
+      key={`action-${text}`}
       className="field__action"
-      clickHandler={action.clickHandler}
+      clickHandler={clickHandler}
       types={['link-default', 'collapse']}
     >
-      {action.text}
+      {text}
     </Button>
   ));
 
-  return <div className="field__actions">{actions}</div>;
+  return <div className={`field__actions ${className}`}>{actionButtons}</div>;
 };
 
 FieldActions.propTypes = {
-  actions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  fieldId: PropTypes.string.isRequired
+  actions: arrayOf(
+    shape({
+      text: string,
+      clickHandler: func
+    })
+  ).isRequired,
+  className: string
 };
 
-export default FieldActions;
+FieldActions.defaultProps = {
+  className: ''
+};

--- a/lib/Field/FieldInStructureEditModeProvider.js
+++ b/lib/Field/FieldInStructureEditModeProvider.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { node, bool } from 'prop-types';
+
+export const FieldInStructureEditModeContext = React.createContext({});
+
+export const FieldInStructureEditModeProvider = ({
+  children,
+  inStructureEditMode
+}) => {
+  const sharedState = {
+    inStructureEditMode
+  };
+
+  return (
+    <FieldInStructureEditModeContext.Provider value={sharedState}>
+      {children}
+    </FieldInStructureEditModeContext.Provider>
+  );
+};
+
+FieldInStructureEditModeProvider.propTypes = {
+  children: node.isRequired,
+  inStructureEditMode: bool
+};
+
+FieldInStructureEditModeProvider.defaultProps = {
+  inStructureEditMode: false
+};

--- a/lib/Field/FieldInstructions.js
+++ b/lib/Field/FieldInstructions.js
@@ -1,0 +1,54 @@
+import React, { useContext } from 'react';
+import { func, number, string } from 'prop-types';
+import Linkify from 'linkifyjs/react';
+import ExpandingTextArea from '../ExpandingTextArea';
+import { FieldInStructureEditModeContext } from './FieldInStructureEditModeProvider';
+
+export const FieldInstructions = ({
+  instructions,
+  onChange,
+  minRows,
+  placeholder,
+  className
+}) => {
+  const { inStructureEditMode } = useContext(FieldInStructureEditModeContext);
+
+  if (inStructureEditMode) {
+    return (
+      <ExpandingTextArea
+        type="text"
+        className={`field__instructions ${className}`}
+        handleOnChange={onChange}
+        value={instructions}
+        placeholder={placeholder}
+        minRows={minRows}
+      />
+    );
+  }
+
+  if (instructions) {
+    return (
+      <div className={`field__instructions ${className}`}>
+        <Linkify>{instructions}</Linkify>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+FieldInstructions.propTypes = {
+  instructions: string,
+  onChange: func,
+  minRows: number,
+  placeholder: string,
+  className: string
+};
+
+FieldInstructions.defaultProps = {
+  minRows: 1,
+  onChange: () => {},
+  instructions: '',
+  placeholder: 'Add field instructions here...',
+  className: ''
+};

--- a/lib/Field/FieldLabel.js
+++ b/lib/Field/FieldLabel.js
@@ -1,0 +1,36 @@
+import React, { useContext } from 'react';
+import { func, string } from 'prop-types';
+import EditableTextWrapper from '../EditableTextWrapper';
+import { FieldInStructureEditModeContext } from './FieldInStructureEditModeProvider';
+
+export const FieldLabel = ({ label, onChange, className }) => {
+  const { inStructureEditMode } = useContext(FieldInStructureEditModeContext);
+
+  if (inStructureEditMode) {
+    return (
+      <EditableTextWrapper
+        value={label}
+        className={`field__label ${className}`}
+        onChange={onChange}
+        multiline
+        inputLabel={`edit field label: ${label}`}
+      >
+        {label}
+      </EditableTextWrapper>
+    );
+  }
+
+  return <div className={`field__label ${className}`}>{label}</div>;
+};
+
+FieldLabel.propTypes = {
+  label: string,
+  onChange: func,
+  className: string
+};
+
+FieldLabel.defaultProps = {
+  label: '',
+  onChange: () => {},
+  className: ''
+};

--- a/lib/Field/FieldLeft.js
+++ b/lib/Field/FieldLeft.js
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import Col from 'react-bootstrap/lib/Col';
+import { node, string } from 'prop-types';
+import { FieldInStructureEditModeContext } from './FieldInStructureEditModeProvider';
+
+export const FieldLeft = ({ children, className }) => {
+  const { inStructureEditMode } = useContext(FieldInStructureEditModeContext);
+
+  return (
+    <Col
+      xs={12}
+      sm={inStructureEditMode ? 3 : 4}
+      className={`field__data ${className}`}
+    >
+      {children}
+    </Col>
+  );
+};
+
+FieldLeft.propTypes = {
+  children: node.isRequired,
+  className: string
+};
+
+FieldLeft.defaultProps = {
+  className: ''
+};

--- a/lib/Field/FieldMiddle.js
+++ b/lib/Field/FieldMiddle.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { node, string } from 'prop-types';
+import Col from 'react-bootstrap/lib/Col';
+
+export const FieldMiddle = ({ children, className }) => (
+  <Col xs={12} sm={8} className={`field__content--wrapper ${className}`}>
+    <div className="field__content border border-solid border-neutral-90">
+      <div className="field__child">{children}</div>
+    </div>
+  </Col>
+);
+
+FieldMiddle.propTypes = {
+  children: node.isRequired,
+  className: string
+};
+
+FieldMiddle.defaultProps = {
+  className: ''
+};

--- a/lib/Field/FieldValidations.js
+++ b/lib/Field/FieldValidations.js
@@ -1,26 +1,31 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { arrayOf, bool, shape, string } from 'prop-types';
 
-const FieldValidations = props => {
-  const validations = props.validations.map(validation => {
-    const cssClass = validation.hasFailed ? 'color-overdue' : '';
+export const FieldValidations = ({ validations, className }) => {
+  const validationsList = validations.map(({ text, hasFailed }) => (
+    <span
+      key={`validation-${text}`}
+      className={`field__validation ${hasFailed ? 'color-overdue' : ''}`}
+    >
+      {text}
+    </span>
+  ));
 
-    return (
-      <span
-        key={`${props.fieldId}-validation-${validation.text}`}
-        className={`field__validation ${cssClass}`}
-      >
-        {validation.text}
-      </span>
-    );
-  });
-
-  return <div className="field__validations">{validations}</div>;
+  return (
+    <div className={`field__validations ${className}`}>{validationsList}</div>
+  );
 };
 
 FieldValidations.propTypes = {
-  validations: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  fieldId: PropTypes.string.isRequired
+  validations: arrayOf(
+    shape({
+      text: string,
+      hasFailed: bool
+    })
+  ).isRequired,
+  className: string
 };
 
-export default FieldValidations;
+FieldValidations.defaultProps = {
+  className: ''
+};

--- a/lib/Field/RepeatableSettings.js
+++ b/lib/Field/RepeatableSettings.js
@@ -3,35 +3,20 @@ import { bool, number } from 'prop-types';
 import { ButtonIcon } from '../ButtonNew/ButtonIcon/ButtonIcon';
 import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
 
-const RepeatableSettings = ({
-  isTextDirLTR,
-  fieldIsActive,
-  repeatPosition,
-  isLastRepeat
-}) => {
+export const RepeatableSettings = ({ repeatPosition, isLastRepeat }) => {
   const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
 
   return (
     <div
-      className={`
+      className="field__repeatable-settings
       text-neutral-primary
       text-lg
       leading-snug
       flex
       items-center
-      -my-3
-      ${isTextDirLTR ? 'ml-auto' : 'mr-auto'}
-    `}
+      -my-3"
     >
-      <div
-        className={`
-        ${fieldIsActive ? '' : 'opacity-0'}
-        group-hover:opacity-100
-        transition-opacity
-        duration-200
-        ease-animation-curve
-        flex`}
-      >
+      <div className="flex field__repeatable-settings-controls">
         {repeatPosition > 0 && (
           <ButtonIconDanger name="trash" className="repeat-icon m-0" />
         )}
@@ -42,22 +27,14 @@ const RepeatableSettings = ({
           <ButtonIcon name="arrowDown" className="repeat-icon m-0" />
         )}
       </div>
-      <span className={`leading-8 my-2 ${isTextDirLTR ? 'ml-2' : 'mr-2'}`}>
+      <span className="leading-8 my-2 field__repeatable-settings-label">
         {label}
       </span>
     </div>
   );
 };
 
-RepeatableSettings.defaultProps = {
-  isTextDirLTR: true
-};
-
 RepeatableSettings.propTypes = {
-  isTextDirLTR: bool,
-  fieldIsActive: bool.isRequired,
   repeatPosition: number.isRequired,
   isLastRepeat: bool.isRequired
 };
-
-export { RepeatableSettings };

--- a/lib/Field/RepeatableSettings.js
+++ b/lib/Field/RepeatableSettings.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { bool, number } from 'prop-types';
+import { ButtonIcon } from '../ButtonNew/ButtonIcon/ButtonIcon';
+import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
+
+const RepeatableSettings = ({
+  isTextDirLTR,
+  fieldIsActive,
+  repeatPosition,
+  isLastRepeat
+}) => {
+  const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
+
+  return (
+    <div
+      className={`
+      text-neutral-primary
+      text-lg
+      leading-snug
+      flex
+      items-center
+      -my-3
+      ${isTextDirLTR ? 'ml-auto' : 'mr-auto'}
+    `}
+    >
+      <div
+        className={`
+        ${fieldIsActive ? '' : 'opacity-0'}
+        group-hover:opacity-100
+        transition-opacity
+        duration-200
+        ease-animation-curve
+        flex`}
+      >
+        {repeatPosition > 0 && (
+          <ButtonIconDanger name="trash" className="repeat-icon m-0" />
+        )}
+        {repeatPosition > 0 && (
+          <ButtonIcon name="arrowUp" className="repeat-icon m-0" />
+        )}
+        {!isLastRepeat && (
+          <ButtonIcon name="arrowDown" className="repeat-icon m-0" />
+        )}
+      </div>
+      <span className={`leading-8 my-2 ${isTextDirLTR ? 'ml-2' : 'mr-2'}`}>
+        {label}
+      </span>
+    </div>
+  );
+};
+
+RepeatableSettings.defaultProps = {
+  isTextDirLTR: true
+};
+
+RepeatableSettings.propTypes = {
+  isTextDirLTR: bool,
+  fieldIsActive: bool.isRequired,
+  repeatPosition: number.isRequired,
+  isLastRepeat: bool.isRequired
+};
+
+export { RepeatableSettings };

--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -1,123 +1,67 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import Linkify from 'linkifyjs/react';
 import Row from 'react-bootstrap/lib/Row';
-import Col from 'react-bootstrap/lib/Col';
 import { FieldValidations } from './FieldValidations';
 import { FieldActions } from './FieldActions';
-import ExpandingTextArea from '../ExpandingTextArea';
-import EditableTextWrapper from '../EditableTextWrapper';
 import { RepeatableSettings } from './RepeatableSettings';
+import { FieldLeft } from './FieldLeft';
+import { FieldMiddle } from './FieldMiddle';
+import { FieldInstructions } from './FieldInstructions';
+import { FieldLabel } from './FieldLabel';
+import FieldAside from './FieldAside';
+import { FieldInStructureEditModeProvider } from './FieldInStructureEditModeProvider';
 
-const Field = props => {
-  const classNames = cx(`group field field--${props.dir}`, {
-    field__editor: props.canEdit,
-    'has-formatting': props.hasFormatting,
-    'field-is-active': props.isActive,
-    'is-visually-disabled': props.disabled
+const Field = ({
+  dir,
+  inStructureEditMode,
+  hasFormatting,
+  isActive,
+  disabled,
+  fieldId,
+  children
+}) => {
+  const classNames = cx(`group field field--${dir}`, {
+    field__editor: inStructureEditMode,
+    'has-formatting': hasFormatting,
+    'field-is-active': isActive,
+    'is-visually-disabled': disabled
   });
 
-  const dataRowSize = props.canEdit ? 3 : 4;
-
   return (
-    <div className={classNames} data-group-id={props.fieldId} dir={props.dir}>
-      <Row>
-        <Col
-          xs={12}
-          sm={dataRowSize}
-          className={`field__data ${props.isRepeatable ? '' : 'pt-6'}`}
-        >
-          {props.isRepeatable && (
-            <RepeatableSettings
-              isTextDirLTR={props.dir === 'ltr'}
-              fieldIsActive={props.isActive}
-              isLastRepeat={props.isLastRepeat}
-              repeatPosition={props.repeatPosition}
-            />
-          )}
-          {!props.canEdit ? (
-            <div className="field__label">{props.label}</div>
-          ) : (
-            <EditableTextWrapper
-              value={props.label}
-              className="field__label"
-              onChange={value => props.labelChange(value)}
-              multiline
-              inputLabel={`edit field label: ${props.label}`}
-            >
-              {props.label}
-            </EditableTextWrapper>
-          )}
-          <FieldValidations validations={props.validations} />
-          <FieldActions actions={props.actions} />
-        </Col>
-
-        <Col xs={12} sm={8} className="field__content--wrapper">
-          <div className="field__content border border-solid border-neutral-90">
-            <div className="field__child">{props.children}</div>
-            {!props.canEdit ? (
-              props.instructions && (
-                <div className="field__instructions">
-                  <Linkify>{props.instructions}</Linkify>
-                </div>
-              )
-            ) : (
-              <ExpandingTextArea
-                type="text"
-                className="field__instructions"
-                handleOnChange={props.instructionChange}
-                value={props.instructions}
-                placeholder={props.instructionsPlaceholder}
-                minRows={props.instructionsMinRows}
-              />
-            )}
-          </div>
-        </Col>
-      </Row>
-    </div>
+    <FieldInStructureEditModeProvider inStructureEditMode={inStructureEditMode}>
+      <div className={classNames} data-group-id={fieldId} dir={dir}>
+        <Row>{children}</Row>
+      </div>
+    </FieldInStructureEditModeProvider>
   );
 };
 
+Field.Actions = FieldActions;
+Field.Aside = FieldAside;
+Field.Instructions = FieldInstructions;
+Field.Label = FieldLabel;
+Field.Left = FieldLeft;
+Field.Middle = FieldMiddle;
+Field.Validations = FieldValidations;
+Field.RepeatableSettings = RepeatableSettings;
+
 Field.propTypes = {
-  label: PropTypes.string,
-  children: PropTypes.shape(),
-  instructions: PropTypes.string,
-  disabled: PropTypes.bool,
-  canEdit: PropTypes.bool,
-  hasFormatting: PropTypes.bool,
-  actions: PropTypes.arrayOf(PropTypes.shape()),
-  validations: PropTypes.arrayOf(PropTypes.shape()),
-  fieldId: PropTypes.string.isRequired,
-  labelChange: PropTypes.func,
-  instructionChange: PropTypes.func,
-  isActive: PropTypes.bool,
-  instructionsPlaceholder: PropTypes.string,
-  instructionsMinRows: PropTypes.number,
+  inStructureEditMode: PropTypes.bool,
+  children: PropTypes.shape().isRequired,
   dir: PropTypes.string,
-  isRepeatable: PropTypes.bool,
-  repeatPosition: PropTypes.number,
-  isLastRepeat: PropTypes.bool
+  disabled: PropTypes.bool,
+  fieldId: PropTypes.string.isRequired,
+  hasFormatting: PropTypes.bool,
+  isActive: PropTypes.bool
 };
 
 Field.defaultProps = {
-  children: {},
-  label: '',
-  instructions: '',
-  disabled: false,
-  canEdit: false,
-  hasFormatting: false,
-  actions: [],
-  validations: [],
-  labelChange: () => {},
-  instructionChange: () => {},
-  isActive: false,
-  instructionsPlaceholder: 'Add field instructions here...',
-  instructionsMinRows: 1,
+  inStructureEditMode: false,
   dir: 'ltr',
-  isRepeatable: false,
-  repeatPosition: 0,
-  isLastRepeat: false
+  disabled: false,
+  hasFormatting: false,
+  isActive: false
 };
 
 export default Field;

--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -4,8 +4,8 @@ import cx from 'classnames';
 import Linkify from 'linkifyjs/react';
 import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
-import FieldValidations from './FieldValidations';
-import FieldActions from './FieldActions';
+import { FieldValidations } from './FieldValidations';
+import { FieldActions } from './FieldActions';
 import ExpandingTextArea from '../ExpandingTextArea';
 import EditableTextWrapper from '../EditableTextWrapper';
 import { RepeatableSettings } from './RepeatableSettings';
@@ -49,11 +49,8 @@ const Field = props => {
               {props.label}
             </EditableTextWrapper>
           )}
-          <FieldValidations
-            fieldId={props.fieldId}
-            validations={props.validations}
-          />
-          <FieldActions fieldId={props.fieldId} actions={props.actions} />
+          <FieldValidations validations={props.validations} />
+          <FieldActions actions={props.actions} />
         </Col>
 
         <Col xs={12} sm={8} className="field__content--wrapper">

--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -21,7 +21,7 @@ const Field = ({
   fieldId,
   children
 }) => {
-  const classNames = cx(`group field field--${dir}`, {
+  const classNames = cx(`field field--${dir}`, {
     field__editor: inStructureEditMode,
     'has-formatting': hasFormatting,
     'field-is-active': isActive,

--- a/lib/Field/index.js
+++ b/lib/Field/index.js
@@ -8,12 +8,13 @@ import FieldValidations from './FieldValidations';
 import FieldActions from './FieldActions';
 import ExpandingTextArea from '../ExpandingTextArea';
 import EditableTextWrapper from '../EditableTextWrapper';
+import { RepeatableSettings } from './RepeatableSettings';
 
 const Field = props => {
-  const classNames = cx(`field field--${props.dir}`, {
+  const classNames = cx(`group field field--${props.dir}`, {
     field__editor: props.canEdit,
     'has-formatting': props.hasFormatting,
-    'is-active': props.isActive,
+    'field-is-active': props.isActive,
     'is-visually-disabled': props.disabled
   });
 
@@ -22,7 +23,19 @@ const Field = props => {
   return (
     <div className={classNames} data-group-id={props.fieldId} dir={props.dir}>
       <Row>
-        <Col xs={12} sm={dataRowSize} className="field__data">
+        <Col
+          xs={12}
+          sm={dataRowSize}
+          className={`field__data ${props.isRepeatable ? '' : 'pt-6'}`}
+        >
+          {props.isRepeatable && (
+            <RepeatableSettings
+              isTextDirLTR={props.dir === 'ltr'}
+              fieldIsActive={props.isActive}
+              isLastRepeat={props.isLastRepeat}
+              repeatPosition={props.repeatPosition}
+            />
+          )}
           {!props.canEdit ? (
             <div className="field__label">{props.label}</div>
           ) : (
@@ -84,7 +97,10 @@ Field.propTypes = {
   isActive: PropTypes.bool,
   instructionsPlaceholder: PropTypes.string,
   instructionsMinRows: PropTypes.number,
-  dir: PropTypes.string
+  dir: PropTypes.string,
+  isRepeatable: PropTypes.bool,
+  repeatPosition: PropTypes.number,
+  isLastRepeat: PropTypes.bool
 };
 
 Field.defaultProps = {
@@ -101,7 +117,10 @@ Field.defaultProps = {
   isActive: false,
   instructionsPlaceholder: 'Add field instructions here...',
   instructionsMinRows: 1,
-  dir: 'ltr'
+  dir: 'ltr',
+  isRepeatable: false,
+  repeatPosition: 0,
+  isLastRepeat: false
 };
 
 export default Field;

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -4,6 +4,13 @@ import { action } from '@storybook/addon-actions';
 import { Field } from 'lib';
 import { boolean, radios, text, number } from '@storybook/addon-knobs';
 import StoryItem from '../../../stories/styleguide/StoryItem';
+import { FieldLeft } from '../FieldLeft';
+import { RepeatableSettings } from '../RepeatableSettings';
+import { FieldValidations } from '../FieldValidations';
+import { FieldActions } from '../FieldActions';
+import { FieldMiddle } from '../FieldMiddle';
+import { FieldInstructions } from '../FieldInstructions';
+import { FieldLabel } from '../FieldLabel';
 
 const mockValidations = [
   {
@@ -36,67 +43,84 @@ storiesOf('Components', module).add('Field', () => {
     },
     'ltr'
   );
-  const canEdit = boolean('Can edit', false);
-
+  const inStructureEditMode = boolean('Is in structure edit mode', false);
+  const isRepeatable = boolean('Is repeatable', true);
+  const isActive = boolean('Is active', true);
+  const label = text('Field label', 'Field label text');
+  const instructions = text(
+    'Instructions',
+    "Instruction text to help inform the user of what they're meant to write in this field. http://gathercontent.com"
+  );
+  const hasFormatting = boolean('Has formatting', true);
+  const disabled = boolean('Disabled', false);
+  const repeatPosition = number('Repeat position', 1);
+  const isLastRepeat = boolean('Is last repeat', false);
+  const fieldId = '123';
   return (
     <StoryItem
       title="Field"
       description="A field component provides supporting UI for gathering content. The child component should be responsible for handling the gathering experience but this component renders labels, actions and validations to support that experience."
     >
       <Field
-        fieldId="123"
-        actions={mockActions}
-        validations={mockValidations}
-        label={text('Field label', 'Field label text')}
-        instructions={text(
-          'Instructions',
-          "Instruction text to help inform the user of what they're meant to write in this field. http://gathercontent.com"
-        )}
-        hasFormatting={boolean('Has formatting', true)}
-        isActive={boolean('Is active', true)}
-        disabled={boolean('Disabled', false)}
-        canEdit={canEdit}
+        fieldId={fieldId}
+        hasFormatting={hasFormatting}
+        isActive={isActive}
+        disabled={disabled}
+        inStructureEditMode={inStructureEditMode}
         dir={dir}
-        isRepeatable={boolean('Is repeatable', true)}
-        repeatPosition={number('Repeat position', 1)}
-        isLastRepeat={boolean('Is last repeat', false)}
       >
-        {!canEdit ? (
-          <div>
-            <h1>Heading content</h1>
-            <p>
-              The fossil record indicates that birds evolved from feathered
-              ancestors within the theropod group, which are traditionally
-              placed within the saurischian dinosaurs, though a 2017 paper[4]
-              has put them in a proposed clade Ornithoscelida, along with the
-              Ornithischia.
-            </p>
-            <table>
-              <tbody>
-                <tr>
-                  <td>
-                    <p>
-                      <strong>Heading 1</strong>
-                    </p>
-                  </td>
-                  <td>
-                    <p>
-                      <strong>Heading 2</strong>
-                    </p>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <p>Cell 1</p>
-                  </td>
-                  <td>
-                    <p>Cell 2</p>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        ) : null}
+        <FieldLeft
+          className={isRepeatable && !inStructureEditMode ? '' : 'pt-6'}
+        >
+          {isRepeatable && !inStructureEditMode && (
+            <RepeatableSettings
+              isLastRepeat={isLastRepeat}
+              repeatPosition={repeatPosition}
+            />
+          )}
+          <FieldLabel label={label} />
+          <FieldValidations validations={mockValidations} />
+          <FieldActions actions={mockActions} />
+        </FieldLeft>
+        <FieldMiddle>
+          {!inStructureEditMode ? (
+            <div>
+              <h1>Heading content</h1>
+              <p>
+                The fossil record indicates that birds evolved from feathered
+                ancestors within the theropod group, which are traditionally
+                placed within the saurischian dinosaurs, though a 2017 paper[4]
+                has put them in a proposed clade Ornithoscelida, along with the
+                Ornithischia.
+              </p>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>
+                      <p>
+                        <strong>Heading 1</strong>
+                      </p>
+                    </td>
+                    <td>
+                      <p>
+                        <strong>Heading 2</strong>
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <p>Cell 1</p>
+                    </td>
+                    <td>
+                      <p>Cell 2</p>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+          <FieldInstructions instructions={instructions} />
+        </FieldMiddle>
       </Field>
     </StoryItem>
   );

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Field } from 'lib';
-import { boolean, radios, text } from '@storybook/addon-knobs';
+import { boolean, radios, text, number } from '@storybook/addon-knobs';
 import StoryItem from '../../../stories/styleguide/StoryItem';
 
 const mockValidations = [
@@ -57,6 +57,9 @@ storiesOf('Components', module).add('Field', () => {
         disabled={boolean('Disabled', false)}
         canEdit={canEdit}
         dir={dir}
+        isRepeatable={boolean('Is repeatable', true)}
+        repeatPosition={number('Repeat position', 1)}
+        isLastRepeat={boolean('Is last repeat', false)}
       >
         {!canEdit ? (
           <div>

--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -64,7 +64,6 @@ $field-data-p-line-height: 1.688rem !default;
 .field__data {
   display: flex;
   flex-flow: column;
-  padding-top: $field-spacing-base*1.5;
   text-align: right;
   font-size: $field-data-size;
 }
@@ -86,7 +85,7 @@ $field-data-p-line-height: 1.688rem !default;
   transition: opacity $animation-time-micro $animation-curve;
 
   .field:hover &,
-  .field.is-active & {
+  .field.field-is-active & {
     opacity: 1;
   }
 }
@@ -113,7 +112,7 @@ $field-data-p-line-height: 1.688rem !default;
   transition: all 0.2s ease;
 
   .field:not(.is-visually-disabled):not(.field__editor) &:hover,
-  .is-active & {
+  .field-is-active & {
     background: #FFFFFF;
     border: 1px solid $neutral-light;
     box-shadow: $shadow-shallow;
@@ -314,7 +313,7 @@ $field-data-p-line-height: 1.688rem !default;
   }
 }
 
-.field.has-formatting {
+.has-formatting .field__content {
   *:nth-child(1) {
     margin-top: 0;
   }

--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -80,7 +80,8 @@ $field-data-p-line-height: 1.688rem !default;
   flex-flow: column;
 }
 
-.field__actions {
+.field__actions,
+.field__repeatable-settings-controls {
   opacity: 0;
   transition: opacity $animation-time-micro $animation-curve;
 
@@ -434,6 +435,14 @@ $field-data-p-line-height: 1.688rem !default;
   .field__aside {
     right: 0;
   }
+
+  .field__repeatable-settings {
+    @apply ml-auto;
+  }
+
+  .field__repeatable-settings-label {
+    @apply ml-2;
+  }
 }
 
 .field--rtl {
@@ -446,5 +455,13 @@ $field-data-p-line-height: 1.688rem !default;
 
   .field__aside {
     left: 0;
+  }
+
+  .field__repeatable-settings {
+    @apply mr-auto;
+  }
+
+  .field__repeatable-settings-label {
+    @apply mr-2;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -111,9 +111,6 @@ module.exports = {
           '30': '#3E4D5C',
           '20': '#29333D'
         }
-      },
-      transitionTimingFunction: {
-        'animation-curve': 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
       }
     },
     maxHeight: {
@@ -181,8 +178,7 @@ module.exports = {
     padding: ['last'],
     gradients: ['responsive', 'hover'],
     backgroundColor: ['responsive', 'hover', 'focus', 'active'],
-    boxShadow: ['responsive', 'hover', 'focus', 'active'],
-    opacity: ['group-hover']
+    boxShadow: ['responsive', 'hover', 'focus', 'active']
   },
   plugins: [require('tailwindcss-plugins/gradients')],
   corePlugins: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -111,6 +111,9 @@ module.exports = {
           '30': '#3E4D5C',
           '20': '#29333D'
         }
+      },
+      transitionTimingFunction: {
+        'animation-curve': 'cubic-bezier(0.68, -0.55, 0.265, 1.55)',
       }
     },
     maxHeight: {
@@ -178,7 +181,8 @@ module.exports = {
     padding: ['last'],
     gradients: ['responsive', 'hover'],
     backgroundColor: ['responsive', 'hover', 'focus', 'active'],
-    boxShadow: ['responsive', 'hover', 'focus', 'active']
+    boxShadow: ['responsive', 'hover', 'focus', 'active'],
+    opacity: ['group-hover']
   },
   plugins: [require('tailwindcss-plugins/gradients')],
   corePlugins: {

--- a/tests/Field/Field.js
+++ b/tests/Field/Field.js
@@ -1,21 +1,13 @@
 import { React, shallow } from '../setup';
 import { Field } from '../../lib';
-import FieldActions from '../../lib/Field/FieldActions';
-import FieldValidations from '../../lib/Field/FieldValidations';
 import Button from '../../lib/Button';
-import ExpandingTextArea from '../../lib/ExpandingTextArea';
-import EditableTextWrapper from '../../lib/EditableTextWrapper';
 
 describe('Field', () => {
   let wrapper;
 
   beforeEach(() => {
     wrapper = shallow(
-      <Field
-        label="Test label"
-        instructions="Instructions test text"
-        fieldId="123"
-      >
+      <Field fieldId="123">
         <Button clickHandler={() => {}}>Hello world</Button>
       </Field>
     );
@@ -23,48 +15,9 @@ describe('Field', () => {
 
   afterEach(() => {});
 
-  test('renders an editing state and passes the relevant props', () => {
-    wrapper.setProps({
-      canEdit: true,
-      instructionsMinRows: 3,
-      instructionsPlaceholder: 'some text'
-    });
-    expect(wrapper.find(EditableTextWrapper)).toHaveLength(1);
-    expect(wrapper.find(EditableTextWrapper).prop('value')).toEqual(
-      'Test label'
-    );
-    expect(wrapper.find(ExpandingTextArea)).toHaveLength(1);
-    expect(wrapper.find(ExpandingTextArea).prop('minRows')).toEqual(3);
-    expect(wrapper.find(ExpandingTextArea).prop('placeholder')).toEqual(
-      'some text'
-    );
-  });
-
-  test('renders a label', () => {
-    expect(wrapper.contains('Test label')).toBe(true);
-  });
-
-  test('renders actions', () => {
-    expect(wrapper.find(FieldActions)).toHaveLength(1);
-  });
-
-  test('renders validations', () => {
-    expect(wrapper.find(FieldValidations)).toHaveLength(1);
-  });
-
   test('renders its children', () => {
     const children = wrapper.children();
     expect(children.find(Button)).toHaveLength(1);
-  });
-
-  test('renders instructions', () => {
-    expect(wrapper.contains('Instructions test text')).toBe(true);
-
-    wrapper.setProps({
-      instructions: ''
-    });
-
-    expect(wrapper.contains('Instructions test text')).toBe(false);
   });
 
   test('adds conditional classes for formatting', () => {
@@ -72,15 +25,7 @@ describe('Field', () => {
       hasFormatting: true,
       disabled: true
     });
-    expect(wrapper.hasClass('has-formatting')).toEqual(true);
-    expect(wrapper.hasClass('is-visually-disabled')).toEqual(true);
-  });
-
-  test('that fields do not render instructions when none are set', () => {
-    expect(wrapper.find('.field__instructions')).toHaveLength(1);
-    wrapper.setProps({
-      instructions: ''
-    });
-    expect(wrapper.find('.field__instructions')).toHaveLength(0);
+    expect(wrapper.find('div').hasClass('has-formatting')).toEqual(true);
+    expect(wrapper.find('div').hasClass('is-visually-disabled')).toEqual(true);
   });
 });


### PR DESCRIPTION
### 💬 Description
This creates a `RepeatableSettings` component, used by the field to manage, would you believe, repeatable field settings.

There's a Delete, Move Up / Down buttons, and a label which shows the numeric index.

I've had to make a couple of tweaks to our tailwind config worth mentioning, namely I've added an animation curve which matches our existing animation curve used elsewhere in the Field component (to animate the field actions coming in and out, otherwise it looks weird if different animation curves/durations are used!) I've also enabled the opacity group-hover utility, so we can get hover effects on parents passed down to children - super cool!

There's a bit more to add to get this fully matching the design (adding the "Add another"/"Limit reached button" but I'll save that for another PR.

### 🔗 Links
https://www.figma.com/file/HNH1EAEtLOVJRsydtdrxUq/Repeatable-Fields?node-id=14%3A1454

### 🚪 Start Points
Storybook, tweak those knobs!

### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
