### PR TITLE
Add a render prop for Tab.Item

### DIFF
--- a/lib/Tabs/TabsItem.js
+++ b/lib/Tabs/TabsItem.js
@@ -17,6 +17,10 @@ const TabItem = ({ children, id, options, className }, context) => {
     className
   );
 
+  if (typeof children === 'function') {
+    return children(classNames, tabIsActive);
+  }
+
   return (
     <span
       className={classNames}

--- a/lib/Tabs/index.js
+++ b/lib/Tabs/index.js
@@ -21,13 +21,14 @@ class Tabs extends Component {
   };
 
   static propTypes = {
-    onTabChange: PropTypes.func.isRequired,
+    onTabChange: PropTypes.func,
     children: PropTypes.arrayOf(PropTypes.node).isRequired,
     activeTabId: PropTypes.string,
     editable: PropTypes.bool
   };
 
   static defaultProps = {
+    onTabChange: () => {},
     activeTabId: null,
     editable: false
   };


### PR DESCRIPTION
### 💬 Description
At times we may want to use other components as children `Tabs.Item`, so to allow this we have allowed the `children` prop to be a function...this follows the render prop pattern.

It doesn't cause a breaking change so will be released as a patch.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
