### PR TITLE
Add states to new fields

### DIFF
--- a/lib/Field/FieldContent.js
+++ b/lib/Field/FieldContent.js
@@ -1,9 +1,15 @@
 import React, { useContext } from 'react';
-import { element, node, string } from 'prop-types';
+import { element, node, oneOf, string } from 'prop-types';
 import cx from 'classnames';
 import { FieldNew } from 'lib';
 
-export function FieldContent({ children, className, instructions }) {
+export const ADDED = 'added';
+export const DELETED = 'deleted';
+export const MOVED_UP = 'moved_up';
+export const MOVED_DOWN = 'moved_down';
+export const UNCHANGED = 'unchanged';
+
+export function FieldContent({ children, className, instructions, state }) {
   const { inStructureEditMode } = useContext(
     FieldNew.InStructureEditModeContext
   );
@@ -14,13 +20,18 @@ export function FieldContent({ children, className, instructions }) {
         className,
         'col-span-12 md:col-span-8',
         'col-start-1',
-        'border border-solid border-neutral-90',
+        'border-solid',
         'rounded',
         'shadow',
         {
           'p-6': !inStructureEditMode,
           'md:col-start-5': !inStructureEditMode,
-          'md:col-start-4': inStructureEditMode
+          'md:col-start-4': inStructureEditMode,
+          'border border-neutral-90': state === UNCHANGED,
+          'border-3 border-green-primary bg-green-98': state === ADDED,
+          'border-3 border-red-primary bg-red-98': state === DELETED,
+          'border-3 border-purple-primary bg-purple-98':
+            state === MOVED_DOWN || state === MOVED_UP
         }
       )}
     >
@@ -33,10 +44,12 @@ export function FieldContent({ children, className, instructions }) {
 FieldContent.propTypes = {
   children: node.isRequired,
   className: string,
-  instructions: element
+  instructions: element,
+  state: oneOf([ADDED, DELETED, MOVED_UP, MOVED_DOWN, UNCHANGED])
 };
 
 FieldContent.defaultProps = {
   className: '',
-  instructions: null
+  instructions: null,
+  state: UNCHANGED
 };

--- a/lib/Field/FieldContent.js
+++ b/lib/Field/FieldContent.js
@@ -3,6 +3,7 @@ import { element, node, oneOf, string } from 'prop-types';
 import cx from 'classnames';
 import { FieldNew } from 'lib';
 
+export const ACTIVE = 'active';
 export const ADDED = 'added';
 export const DELETED = 'deleted';
 export const MOVED_UP = 'moved_up';
@@ -23,11 +24,14 @@ export function FieldContent({ children, className, instructions, state }) {
         'border-solid',
         'rounded',
         'shadow',
+        'transition-all, transition-ease duration-200',
         {
           'p-6': !inStructureEditMode,
           'md:col-start-5': !inStructureEditMode,
           'md:col-start-4': inStructureEditMode,
-          'border border-neutral-90': state === UNCHANGED,
+          'border border-neutral-90': state === ACTIVE,
+          'border border-neutral-90 bg-neutral-98 group-hover:bg-white':
+            state === UNCHANGED,
           'border-3 border-green-primary bg-green-98': state === ADDED,
           'border-3 border-red-primary bg-red-98': state === DELETED,
           'border-3 border-purple-primary bg-purple-98':
@@ -45,7 +49,7 @@ FieldContent.propTypes = {
   children: node.isRequired,
   className: string,
   instructions: element,
-  state: oneOf([ADDED, DELETED, MOVED_UP, MOVED_DOWN, UNCHANGED])
+  state: oneOf([ACTIVE, ADDED, DELETED, MOVED_UP, MOVED_DOWN, UNCHANGED])
 };
 
 FieldContent.defaultProps = {

--- a/lib/Field/FieldContent.js
+++ b/lib/Field/FieldContent.js
@@ -10,7 +10,7 @@ export const MOVED_UP = 'moved_up';
 export const MOVED_DOWN = 'moved_down';
 export const UNCHANGED = 'unchanged';
 
-export function FieldContent({ children, className, instructions, state }) {
+export function FieldContent({ children, className, instructions, status }) {
   const { inStructureEditMode } = useContext(
     FieldNew.InStructureEditModeContext
   );
@@ -29,13 +29,13 @@ export function FieldContent({ children, className, instructions, state }) {
           'p-6': !inStructureEditMode,
           'md:col-start-5': !inStructureEditMode,
           'md:col-start-4': inStructureEditMode,
-          'border border-neutral-90': state === ACTIVE,
+          'border border-neutral-90': status === ACTIVE,
           'border border-neutral-90 bg-neutral-98 group-hover:bg-white':
-            state === UNCHANGED,
-          'border-3 border-green-primary bg-green-98': state === ADDED,
-          'border-3 border-red-primary bg-red-98': state === DELETED,
+            status === UNCHANGED,
+          'border-3 border-green-primary bg-green-98': status === ADDED,
+          'border-3 border-red-primary bg-red-98': status === DELETED,
           'border-3 border-purple-primary bg-purple-98':
-            state === MOVED_DOWN || state === MOVED_UP
+            status === MOVED_DOWN || status === MOVED_UP
         }
       )}
     >
@@ -49,11 +49,11 @@ FieldContent.propTypes = {
   children: node.isRequired,
   className: string,
   instructions: element,
-  state: oneOf([ACTIVE, ADDED, DELETED, MOVED_UP, MOVED_DOWN, UNCHANGED])
+  status: oneOf([ACTIVE, ADDED, DELETED, MOVED_UP, MOVED_DOWN, UNCHANGED])
 };
 
 FieldContent.defaultProps = {
   className: '',
   instructions: null,
-  state: UNCHANGED
+  status: UNCHANGED
 };

--- a/lib/Field/FieldNew.js
+++ b/lib/Field/FieldNew.js
@@ -17,7 +17,7 @@ export function FieldNew({ children, className, dir, inStructureEditMode }) {
     <InStructureEditModeContext.Provider value={{ inStructureEditMode }}>
       <div
         className={cx(
-          'grid grid-cols-12 gap-4 field field-new has-formatting',
+          'group grid grid-cols-12 col-gap-5 field field-new has-formatting',
           className
         )}
         dir={dir}

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -6,6 +6,7 @@ import { boolean, radios, select, text } from '@storybook/addon-knobs';
 import cx from 'classnames';
 import StoryItem from '../../../stories/styleguide/StoryItem';
 import {
+  ACTIVE,
   ADDED,
   DELETED,
   MOVED_DOWN,
@@ -47,7 +48,10 @@ storiesOf('Components', module).add('Field', () => {
   const inStructureEditMode = boolean('In Structure Edit Mode', false);
 
   const label = text('Field label', 'Field label text');
-  const isActive = boolean('Is active', true);
+  const isActive = boolean(
+    'Is active (only used by old component, use the state selector for NewField)',
+    true
+  );
   const instructions = text(
     'Instructions',
     "Instruction text to help inform the user of what they're meant to write in this field. http://gathercontent.com"
@@ -56,6 +60,7 @@ storiesOf('Components', module).add('Field', () => {
     'State',
     {
       Unchanged: UNCHANGED,
+      Active: ACTIVE,
       Added: ADDED,
       Deleted: DELETED,
       'Moved up': MOVED_UP,
@@ -71,11 +76,11 @@ storiesOf('Components', module).add('Field', () => {
         description="A newer, Field component, can contain Content and Meta"
       >
         <FieldNew
-          className={cx({ 'field-active': isActive })}
+          className={cx({ 'field-active': state === ACTIVE })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
         >
-          <FieldNew.Meta className="">
+          <FieldNew.Meta>
             <FieldNew.Label
               className={cx({
                 'text-right': dir === 'ltr',

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -56,8 +56,8 @@ storiesOf('Components', module).add('Field', () => {
     'Instructions',
     "Instruction text to help inform the user of what they're meant to write in this field. http://gathercontent.com"
   );
-  const state = select(
-    'State',
+  const status = select(
+    'Status',
     {
       Unchanged: UNCHANGED,
       Active: ACTIVE,
@@ -76,7 +76,7 @@ storiesOf('Components', module).add('Field', () => {
         description="A newer, Field component, can contain Content and Meta"
       >
         <FieldNew
-          className={cx({ 'field-active': state === ACTIVE })}
+          className={cx({ 'field-active': status === ACTIVE })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
         >
@@ -104,7 +104,7 @@ storiesOf('Components', module).add('Field', () => {
             instructions={
               <FieldNew.Instructions>{instructions}</FieldNew.Instructions>
             }
-            state={state}
+            status={status}
           >
             {!inStructureEditMode ? (
               <div>

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -2,9 +2,16 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Field, FieldNew } from 'lib';
-import { boolean, radios, text } from '@storybook/addon-knobs';
+import { boolean, radios, select, text } from '@storybook/addon-knobs';
 import cx from 'classnames';
 import StoryItem from '../../../stories/styleguide/StoryItem';
+import {
+  ADDED,
+  DELETED,
+  MOVED_DOWN,
+  MOVED_UP,
+  UNCHANGED
+} from '../FieldContent';
 
 const mockValidations = [
   {
@@ -45,6 +52,18 @@ storiesOf('Components', module).add('Field', () => {
     'Instructions',
     "Instruction text to help inform the user of what they're meant to write in this field. http://gathercontent.com"
   );
+  const state = select(
+    'State',
+    {
+      Unchanged: UNCHANGED,
+      Added: ADDED,
+      Deleted: DELETED,
+      'Moved up': MOVED_UP,
+      'Moved Down': MOVED_DOWN
+    },
+    UNCHANGED
+  );
+
   return (
     <>
       <StoryItem
@@ -80,6 +99,7 @@ storiesOf('Components', module).add('Field', () => {
             instructions={
               <FieldNew.Instructions>{instructions}</FieldNew.Instructions>
             }
+            state={state}
           >
             {!inStructureEditMode ? (
               <div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -185,7 +185,7 @@ module.exports = {
   variants: {
     padding: ['responsive', 'last'],
     gradients: ['responsive', 'hover'],
-    backgroundColor: ['responsive', 'hover', 'focus', 'active'],
+    backgroundColor: ['responsive', 'hover', 'focus', 'active', 'group-hover'],
     boxShadow: ['responsive', 'hover', 'focus', 'active']
   },
   plugins: [require('tailwindcss-plugins/gradients')],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -61,6 +61,7 @@ module.exports = {
           '20': '#002C66'
         },
         red: {
+          '98': '#FFF6F5',
           '95': '#FCE8EA',
           '90': '#FFD0CC',
           '80': red80,
@@ -72,6 +73,7 @@ module.exports = {
           '20': '#5C0A11'
         },
         green: {
+          '98': '#F7FDF7',
           '95': '#EBF9EB',
           '90': '#D7F4D7',
           '80': '#B0E8B0',
@@ -94,6 +96,7 @@ module.exports = {
           '20': '#635303'
         },
         purple: {
+          '98': '#F9F6FE',
           '95': '#F1E8FC',
           '90': '#E2D1FA',
           '80': '#C5A3F5',


### PR DESCRIPTION
### 💬 Description
Where previously we just had an `isActive` toggle (which greyed out the background when false) we will now show when fields have been added, deleted or moved.

The FieldNew takes a `state` prop, which is one of
`ACTIVE`
`ADDED`
`DELETED`
`MOVED_UP`
`MOVED_DOWN`
`UNCHANGED`

You can toggle between these in the storybook.
 
### 🔗 Links
https://www.figma.com/file/Q3f2o4VMBAb0RAbESE1Fat/Revisions?node-id=149%3A1850

### 📹 GIF (optional)
![Screen Recording 2020-05-15 at 09 29 am](https://user-images.githubusercontent.com/3472717/82029336-c6059b00-968e-11ea-84c6-89f5cbc82b5d.gif)


### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
