### PR TITLE
Add the Repeable field controls component

### DIFF
--- a/lib/Field/FieldNew.js
+++ b/lib/Field/FieldNew.js
@@ -7,6 +7,7 @@ import { FieldLabel } from './FieldLabel';
 import { FieldInstructions } from './FieldInstructions';
 import FieldValidations from './FieldValidations';
 import FieldActions from './FieldActions';
+import { FieldRepeatableControls } from './FieldRepeatableControls';
 
 const InStructureEditModeContext = createContext({
   inStructureEditMode: false
@@ -47,4 +48,5 @@ FieldNew.Label = FieldLabel;
 FieldNew.Instructions = FieldInstructions;
 FieldNew.Validations = FieldValidations;
 FieldNew.Actions = FieldActions;
+FieldNew.RepeatableControls = FieldRepeatableControls;
 FieldNew.InStructureEditModeContext = InStructureEditModeContext;

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -7,20 +7,18 @@ export function FieldRepeatableControls({ repeatPosition, isLastRepeat }) {
   const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
 
   return (
-    <div className="flex flex-row-reverse">
-      <div className="flex">
-        {repeatPosition > 0 && (
-          <ButtonIconDanger name="trash" className="mx-1 repeat-icon" />
-        )}
-        {repeatPosition > 0 && (
-          <ButtonIcon name="arrowUp" className="mx-1 repeat-icon" />
-        )}
-        {!isLastRepeat && (
-          <ButtonIcon name="arrowDown" className="mx-1 repeat-icon" />
-        )}
-        <span className="w-1" />
-        <span className="leading-8 text-neutral-primary text-lg">{label}</span>
-      </div>
+    <div className="flex justify-end">
+      {repeatPosition > 0 && (
+        <ButtonIconDanger name="trash" className="mx-1 repeat-icon" />
+      )}
+      {repeatPosition > 0 && (
+        <ButtonIcon name="arrowUp" className="mx-1 repeat-icon" />
+      )}
+      {!isLastRepeat && (
+        <ButtonIcon name="arrowDown" className="mx-1 repeat-icon" />
+      )}
+      <span className="w-1" />
+      <span className="leading-8 text-neutral-primary text-lg">{label}</span>
     </div>
   );
 }

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -1,22 +1,31 @@
 import React from 'react';
-import { bool, number } from 'prop-types';
+import { bool, number, string } from 'prop-types';
+import cx from 'classnames';
 import { ButtonIcon } from '../ButtonNew/ButtonIcon/ButtonIcon';
 import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
 
-export function FieldRepeatableControls({ repeatPosition, isLastRepeat }) {
+export function FieldRepeatableControls({
+  repeatPosition,
+  isLastRepeat,
+  isActive,
+  className
+}) {
   const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
 
+  const classes = cx(
+    className,
+    'flex justify-end',
+    'transition ease-animation-curve duration-200',
+    {
+      'opacity-0 group-hover:opacity-100': !isActive
+    }
+  );
+
   return (
-    <div className="flex justify-end">
-      {repeatPosition > 0 && (
-        <ButtonIconDanger name="trash" className="mx-1 repeat-icon" />
-      )}
-      {repeatPosition > 0 && (
-        <ButtonIcon name="arrowUp" className="mx-1 repeat-icon" />
-      )}
-      {!isLastRepeat && (
-        <ButtonIcon name="arrowDown" className="mx-1 repeat-icon" />
-      )}
+    <div className={classes}>
+      {repeatPosition > 0 && <ButtonIconDanger name="trash" className="mx-1" />}
+      {repeatPosition > 0 && <ButtonIcon name="arrowUp" className="mx-1" />}
+      {!isLastRepeat && <ButtonIcon name="arrowDown" className="mx-1" />}
       <span className="w-1" />
       <span className="leading-8 text-neutral-primary text-lg">{label}</span>
     </div>
@@ -25,5 +34,12 @@ export function FieldRepeatableControls({ repeatPosition, isLastRepeat }) {
 
 FieldRepeatableControls.propTypes = {
   repeatPosition: number.isRequired,
-  isLastRepeat: bool.isRequired
+  isLastRepeat: bool.isRequired,
+  isActive: bool,
+  className: string
+};
+
+FieldRepeatableControls.defaultProps = {
+  isActive: false,
+  className: ''
 };

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { bool, number } from 'prop-types';
+import { ButtonIcon } from '../ButtonNew/ButtonIcon/ButtonIcon';
+import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
+
+export function FieldRepeatableControls({ repeatPosition, isLastRepeat }) {
+  const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
+
+  return (
+    <div className="flex flex-row-reverse">
+      <div className="flex">
+        {repeatPosition > 0 && (
+          <ButtonIconDanger name="trash" className="mx-1 repeat-icon" />
+        )}
+        {repeatPosition > 0 && (
+          <ButtonIcon name="arrowUp" className="mx-1 repeat-icon" />
+        )}
+        {!isLastRepeat && (
+          <ButtonIcon name="arrowDown" className="mx-1 repeat-icon" />
+        )}
+        <span className="w-1" />
+        <span className="leading-8 text-neutral-primary text-lg">{label}</span>
+      </div>
+    </div>
+  );
+}
+
+FieldRepeatableControls.propTypes = {
+  repeatPosition: number.isRequired,
+  isLastRepeat: bool.isRequired
+};

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -86,6 +86,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.RepeatableControls
                 repeatPosition={number('Repeat position', 1)}
                 isLastRepeat={boolean('Is last', false)}
+                isActive={status === ACTIVE}
               />
             )}
             <FieldNew.Label

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Field, FieldNew } from 'lib';
-import { boolean, radios, select, text } from '@storybook/addon-knobs';
+import { boolean, radios, select, text, number } from '@storybook/addon-knobs';
 import cx from 'classnames';
 import StoryItem from '../../../stories/styleguide/StoryItem';
 import {
@@ -69,6 +69,7 @@ storiesOf('Components', module).add('Field', () => {
     UNCHANGED
   );
 
+  const isRepeatable = boolean('Is repeatable?', true);
   return (
     <>
       <StoryItem
@@ -81,10 +82,17 @@ storiesOf('Components', module).add('Field', () => {
           inStructureEditMode={inStructureEditMode}
         >
           <FieldNew.Meta>
+            {isRepeatable && (
+              <FieldNew.RepeatableControls
+                repeatPosition={number('Repeat position', 1)}
+                isLastRepeat={boolean('Is last', false)}
+              />
+            )}
             <FieldNew.Label
               className={cx({
                 'text-right': dir === 'ltr',
-                'text-left': dir === 'rtl'
+                'text-left': dir === 'rtl',
+                'pt-8': !isRepeatable
               })}
             >
               {label}

--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -464,19 +464,4 @@ $field-data-p-line-height: 1.688rem !default;
       display: flex;
     }
   }
-
-  .repeat-icon {
-    opacity: 0;
-    transition: opacity $animation-time-micro $animation-curve;
-  }
-  &:hover {
-    .repeat-icon {
-      opacity: 1;
-    }
-  }
-  &.field-active {
-    .repeat-icon {
-      opacity: 1;
-    }
-  }
 }

--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -464,4 +464,19 @@ $field-data-p-line-height: 1.688rem !default;
       display: flex;
     }
   }
+
+  .repeat-icon {
+    opacity: 0;
+    transition: opacity $animation-time-micro $animation-curve;
+  }
+  &:hover {
+    .repeat-icon {
+      opacity: 1;
+    }
+  }
+  &.field-active {
+    .repeat-icon {
+      opacity: 1;
+    }
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -119,6 +119,9 @@ module.exports = {
           '30': '#3E4D5C',
           '20': neutral20
         }
+      },
+      transitionTimingFunction: {
+        'animation-curve': 'cubic-bezier(0.68, -0.55, 0.265, 1.55)'
       }
     },
     maxHeight: {
@@ -185,7 +188,8 @@ module.exports = {
   variants: {
     padding: ['responsive', 'last'],
     gradients: ['responsive', 'hover'],
-    backgroundColor: ['responsive', 'hover', 'focus', 'active', 'group-hover'],
+    backgroundColor: ['responsive', 'group-hover', 'hover', 'focus', 'active'],
+    opacity: ['responsive', 'group-hover', 'hover', 'focus'],
     boxShadow: ['responsive', 'hover', 'focus', 'active']
   },
   plugins: [require('tailwindcss-plugins/gradients')],


### PR DESCRIPTION
### 💬 Description
This will add a row above the field label, which contains the buttons to delete and reorder repeatable fields. It should only show when hovering over the field, or when the field is in an active state.
The repeat position determines which button should show, as well as calculating the repeat position label text, e.g. "01", "02", "03"...

### 🔗 Links
https://www.figma.com/file/HNH1EAEtLOVJRsydtdrxUq/Repeatable-Fields

### 📹 GIF (optional)
![Screen Recording 2020-05-15 at 09 34 am](https://user-images.githubusercontent.com/3472717/82029717-4c21e180-968f-11ea-85f7-dcde8624545b.gif)


### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
