### PR TITLE
Removes yarn test from pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "yarn run test"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
### 💬 Description
PR to stop us running tests on the pre-push hook.

If we are all happy for this to go, then we'll kill it. If not, give this a downvote and we can keep it 👍 
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
