### PR TITLE
Feature/more repeatable field controls

### DIFF
--- a/lib/Field/FieldConnectorLine.js
+++ b/lib/Field/FieldConnectorLine.js
@@ -1,7 +1,10 @@
 import React from 'react';
+import { FieldMainColumn } from './FieldMainColumn';
 
 export function FieldConnectorLine() {
   return (
-    <span className="h-10 border-l border-0 border-solid border-neutral-90" />
+    <FieldMainColumn>
+      <span className="h-10 border-l border-0 border-solid border-neutral-90" />
+    </FieldMainColumn>
   );
 }

--- a/lib/Field/FieldConnectorLine.js
+++ b/lib/Field/FieldConnectorLine.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export function FieldConnectorLine() {
+  return (
+    <span className="h-10 border-l border-0 border-solid border-neutral-90" />
+  );
+}

--- a/lib/Field/FieldContent.js
+++ b/lib/Field/FieldContent.js
@@ -32,9 +32,9 @@ export function FieldContent({ children, className, instructions, status }) {
           'border border-neutral-90': status === ACTIVE,
           'border border-neutral-90 bg-neutral-98 group-hover:bg-white':
             status === UNCHANGED,
-          'border-3 border-green-primary bg-green-98': status === ADDED,
-          'border-3 border-red-primary bg-red-98': status === DELETED,
-          'border-3 border-purple-primary bg-purple-98':
+          'border-2 border-green-primary bg-green-98': status === ADDED,
+          'border-2 border-red-primary bg-red-98': status === DELETED,
+          'border-2 border-purple-primary bg-purple-98':
             status === MOVED_DOWN || status === MOVED_UP
         }
       )}

--- a/lib/Field/FieldMainColumn.js
+++ b/lib/Field/FieldMainColumn.js
@@ -1,0 +1,36 @@
+import React, { useContext } from 'react';
+import { FieldNew } from 'lib';
+import cx from 'classnames';
+import { node, string } from 'prop-types';
+
+export function FieldMainColumn({ children, className }) {
+  const { inStructureEditMode } = useContext(
+    FieldNew.InStructureEditModeContext
+  );
+
+  return (
+    <div
+      className={cx(
+        className,
+        'col-span-12 md:col-span-8',
+        'col-start-1',
+        'flex flex-col items-center',
+        {
+          'md:col-start-5': !inStructureEditMode,
+          'md:col-start-4': inStructureEditMode
+        }
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+FieldMainColumn.propTypes = {
+  children: node.isRequired,
+  className: string
+};
+
+FieldMainColumn.defaultProps = {
+  className: ''
+};

--- a/lib/Field/FieldNew.js
+++ b/lib/Field/FieldNew.js
@@ -19,7 +19,7 @@ export function FieldNew({ children, className, dir, inStructureEditMode }) {
     <InStructureEditModeContext.Provider value={{ inStructureEditMode }}>
       <div
         className={cx(
-          'group grid grid-cols-12 col-gap-5 field field-new has-formatting',
+          'group grid grid-cols-12 col-gap-8 field field-new has-formatting',
           className
         )}
         dir={dir}

--- a/lib/Field/FieldNew.js
+++ b/lib/Field/FieldNew.js
@@ -9,6 +9,8 @@ import FieldValidations from './FieldValidations';
 import FieldActions from './FieldActions';
 import { FieldRepeatableControls } from './FieldRepeatableControls';
 import { FieldRepeatButton } from './FieldRepeatButton';
+import { FieldConnectorLine } from './FieldConnectorLine';
+import { FieldMainColumn } from './FieldMainColumn';
 
 const InStructureEditModeContext = createContext({
   inStructureEditMode: false
@@ -51,4 +53,6 @@ FieldNew.Validations = FieldValidations;
 FieldNew.Actions = FieldActions;
 FieldNew.RepeatableControls = FieldRepeatableControls;
 FieldNew.RepeatButton = FieldRepeatButton;
+FieldNew.ConnectorLine = FieldConnectorLine;
+FieldNew.MainColumn = FieldMainColumn;
 FieldNew.InStructureEditModeContext = InStructureEditModeContext;

--- a/lib/Field/FieldNew.js
+++ b/lib/Field/FieldNew.js
@@ -10,7 +10,6 @@ import FieldActions from './FieldActions';
 import { FieldRepeatableControls } from './FieldRepeatableControls';
 import { FieldRepeatButton } from './FieldRepeatButton';
 import { FieldConnectorLine } from './FieldConnectorLine';
-import { FieldMainColumn } from './FieldMainColumn';
 
 const InStructureEditModeContext = createContext({
   inStructureEditMode: false
@@ -54,5 +53,4 @@ FieldNew.Actions = FieldActions;
 FieldNew.RepeatableControls = FieldRepeatableControls;
 FieldNew.RepeatButton = FieldRepeatButton;
 FieldNew.ConnectorLine = FieldConnectorLine;
-FieldNew.MainColumn = FieldMainColumn;
 FieldNew.InStructureEditModeContext = InStructureEditModeContext;

--- a/lib/Field/FieldNew.js
+++ b/lib/Field/FieldNew.js
@@ -8,6 +8,7 @@ import { FieldInstructions } from './FieldInstructions';
 import FieldValidations from './FieldValidations';
 import FieldActions from './FieldActions';
 import { FieldRepeatableControls } from './FieldRepeatableControls';
+import { FieldRepeatButton } from './FieldRepeatButton';
 
 const InStructureEditModeContext = createContext({
   inStructureEditMode: false
@@ -49,4 +50,5 @@ FieldNew.Instructions = FieldInstructions;
 FieldNew.Validations = FieldValidations;
 FieldNew.Actions = FieldActions;
 FieldNew.RepeatableControls = FieldRepeatableControls;
+FieldNew.RepeatButton = FieldRepeatButton;
 FieldNew.InStructureEditModeContext = InStructureEditModeContext;

--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -1,60 +1,25 @@
-import React, { useContext } from 'react';
-import { bool, string } from 'prop-types';
-import cx from 'classnames';
-import { FieldNew } from 'lib';
+import React from 'react';
+import { bool } from 'prop-types';
 import { ButtonSecondary } from '../ButtonNew/ButtonSecondary/ButtonSecondary';
 import Icon from '../Icon';
 
-function ConnectorLine() {
-  return (
-    <span className="h-10 border-l border-0 border-solid border-neutral-90 " />
-  );
-}
-
-export function FieldRepeatButton({
-  isLastRepeat,
-  repeatLimitReached,
-  className
-}) {
-  const { inStructureEditMode } = useContext(
-    FieldNew.InStructureEditModeContext
-  );
+export function FieldRepeatButton({ repeatLimitReached }) {
+  if (repeatLimitReached) {
+    return <ButtonSecondary disabled>Limit reached</ButtonSecondary>;
+  }
 
   return (
-    <div
-      className={cx(
-        className,
-        'col-span-12 md:col-span-8',
-        'col-start-1',
-        'flex flex-col items-center',
-        {
-          'md:col-start-5': !inStructureEditMode,
-          'md:col-start-4': inStructureEditMode
-        }
-      )}
-    >
-      {<ConnectorLine />}
-      {isLastRepeat &&
-        (repeatLimitReached ? (
-          <ButtonSecondary disabled>Limit reached</ButtonSecondary>
-        ) : (
-          <ButtonSecondary>
-            <Icon name="plus" className="mr-2" />
-            Add another
-          </ButtonSecondary>
-        ))}
-    </div>
+    <ButtonSecondary>
+      <Icon name="plus" className="mr-2" />
+      Add another
+    </ButtonSecondary>
   );
 }
 
 FieldRepeatButton.propTypes = {
-  isLastRepeat: bool,
-  repeatLimitReached: bool,
-  className: string
+  repeatLimitReached: bool
 };
 
 FieldRepeatButton.defaultProps = {
-  isLastRepeat: false,
-  repeatLimitReached: false,
-  className: ''
+  repeatLimitReached: false
 };

--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -10,7 +10,8 @@ export function FieldRepeatButton({ repeatLimitReached }) {
 
   return (
     <ButtonSecondary>
-      <Icon name="plus" className="mr-2" />
+      <Icon name="plus" />
+      <span className="w-2" />
       Add another
     </ButtonSecondary>
   );

--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -1,0 +1,60 @@
+import React, { useContext } from 'react';
+import { bool, string } from 'prop-types';
+import cx from 'classnames';
+import { FieldNew } from 'lib';
+import { ButtonSecondary } from '../ButtonNew/ButtonSecondary/ButtonSecondary';
+import Icon from '../Icon';
+
+function ConnectorLine() {
+  return (
+    <span className="h-8 border-l border-0 border-solid border-neutral-90 " />
+  );
+}
+
+export function FieldRepeatButton({
+  isLastRepeat,
+  repeatLimitReached,
+  className
+}) {
+  const { inStructureEditMode } = useContext(
+    FieldNew.InStructureEditModeContext
+  );
+
+  return (
+    <div
+      className={cx(
+        className,
+        'col-span-12 md:col-span-8',
+        'col-start-1',
+        'flex flex-col items-center',
+        {
+          'md:col-start-5': !inStructureEditMode,
+          'md:col-start-4': inStructureEditMode
+        }
+      )}
+    >
+      {<ConnectorLine />}
+      {isLastRepeat &&
+        (repeatLimitReached ? (
+          <ButtonSecondary disabled>Limit reached</ButtonSecondary>
+        ) : (
+          <ButtonSecondary>
+            <Icon name="plus" className="mr-2" />
+            Add another
+          </ButtonSecondary>
+        ))}
+    </div>
+  );
+}
+
+FieldRepeatButton.propTypes = {
+  isLastRepeat: bool,
+  repeatLimitReached: bool,
+  className: string
+};
+
+FieldRepeatButton.defaultProps = {
+  isLastRepeat: false,
+  repeatLimitReached: false,
+  className: ''
+};

--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -7,7 +7,7 @@ import Icon from '../Icon';
 
 function ConnectorLine() {
   return (
-    <span className="h-8 border-l border-0 border-solid border-neutral-90 " />
+    <span className="h-10 border-l border-0 border-solid border-neutral-90 " />
   );
 }
 

--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -2,19 +2,20 @@ import React from 'react';
 import { bool } from 'prop-types';
 import { ButtonSecondary } from '../ButtonNew/ButtonSecondary/ButtonSecondary';
 import Icon from '../Icon';
+import { FieldMainColumn } from './FieldMainColumn';
 
 export function FieldRepeatButton({ repeatLimitReached }) {
-  if (repeatLimitReached) {
-    return <ButtonSecondary disabled>Limit reached</ButtonSecondary>;
-  }
-
-  return (
+  const button = repeatLimitReached ? (
+    <ButtonSecondary disabled>Limit reached</ButtonSecondary>
+  ) : (
     <ButtonSecondary>
       <Icon name="plus" />
       <span className="w-2" />
       Add another
     </ButtonSecondary>
   );
+
+  return <FieldMainColumn>{button}</FieldMainColumn>;
 }
 
 FieldRepeatButton.propTypes = {

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -30,7 +30,7 @@ export function FieldRepeatableControls({
       {!isLastRepeat && (
         <ButtonIcon name="arrowDown" className={buttonClasses} />
       )}
-      <span className="w-1" />
+      <span className="w-2" />
       <span className="leading-8 text-neutral-primary text-lg">{label}</span>
     </div>
   );

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -22,16 +22,16 @@ export function FieldRepeatableControls({
   return (
     <div className="flex justify-end">
       {repeatPosition > 0 && (
-        <ButtonIconDanger name="trash" className={buttonClasses} />
+        <ButtonIconDanger name="trash" className={buttonClasses} size="sm" />
       )}
       {repeatPosition > 0 && (
-        <ButtonIcon name="arrowUp" className={buttonClasses} />
+        <ButtonIcon name="arrowUp" className={buttonClasses} size="sm" />
       )}
       {!isLastRepeat && (
-        <ButtonIcon name="arrowDown" className={buttonClasses} />
+        <ButtonIcon name="arrowDown" className={buttonClasses} size="sm" />
       )}
-      <span className="w-2" />
-      <span className="leading-8 text-neutral-primary text-lg">{label}</span>
+      <span className="w-1" />
+      <span className="leading-6 text-neutral-primary text-lg">{label}</span>
     </div>
   );
 }

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -22,13 +22,25 @@ export function FieldRepeatableControls({
   return (
     <div className="flex justify-end">
       {repeatPosition > 0 && (
-        <ButtonIconDanger name="trash" className={buttonClasses} size="sm" />
+        <ButtonIconDanger
+          name="trash"
+          className={buttonClasses}
+          size={ButtonIconDanger.sizes.sm}
+        />
       )}
       {repeatPosition > 0 && (
-        <ButtonIcon name="arrowUp" className={buttonClasses} size="sm" />
+        <ButtonIcon
+          name="arrowUp"
+          className={buttonClasses}
+          size={ButtonIcon.sizes.sm}
+        />
       )}
       {!isLastRepeat && (
-        <ButtonIcon name="arrowDown" className={buttonClasses} size="sm" />
+        <ButtonIcon
+          name="arrowDown"
+          className={buttonClasses}
+          size={ButtonIcon.sizes.sm}
+        />
       )}
       <span className="w-1" />
       <span className="leading-6 text-neutral-primary text-lg">{label}</span>

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, number, string } from 'prop-types';
+import { bool, number } from 'prop-types';
 import cx from 'classnames';
 import { ButtonIcon } from '../ButtonNew/ButtonIcon/ButtonIcon';
 import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
@@ -7,14 +7,12 @@ import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
 export function FieldRepeatableControls({
   repeatPosition,
   isLastRepeat,
-  isActive,
-  className
+  isActive
 }) {
   const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
 
-  const classes = cx(
-    className,
-    'flex justify-end',
+  const buttonClasses = cx(
+    'mx-1',
     'transition ease-animation-curve duration-200',
     {
       'opacity-0 group-hover:opacity-100': !isActive
@@ -22,10 +20,16 @@ export function FieldRepeatableControls({
   );
 
   return (
-    <div className={classes}>
-      {repeatPosition > 0 && <ButtonIconDanger name="trash" className="mx-1" />}
-      {repeatPosition > 0 && <ButtonIcon name="arrowUp" className="mx-1" />}
-      {!isLastRepeat && <ButtonIcon name="arrowDown" className="mx-1" />}
+    <div className="flex justify-end">
+      {repeatPosition > 0 && (
+        <ButtonIconDanger name="trash" className={buttonClasses} />
+      )}
+      {repeatPosition > 0 && (
+        <ButtonIcon name="arrowUp" className={buttonClasses} />
+      )}
+      {!isLastRepeat && (
+        <ButtonIcon name="arrowDown" className={buttonClasses} />
+      )}
       <span className="w-1" />
       <span className="leading-8 text-neutral-primary text-lg">{label}</span>
     </div>
@@ -35,11 +39,9 @@ export function FieldRepeatableControls({
 FieldRepeatableControls.propTypes = {
   repeatPosition: number.isRequired,
   isLastRepeat: bool.isRequired,
-  isActive: bool,
-  className: string
+  isActive: bool
 };
 
 FieldRepeatableControls.defaultProps = {
-  isActive: false,
-  className: ''
+  isActive: false
 };

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -157,11 +157,7 @@ storiesOf('Components', module).add('Field', () => {
               <div className="p-3" />
             )}
           </FieldNew.Content>
-          {isRepeatable && (
-            <FieldNew.MainColumn>
-              <FieldNew.ConnectorLine />
-            </FieldNew.MainColumn>
-          )}
+          {isRepeatable && <FieldNew.ConnectorLine />}
         </FieldNew>
         <FieldNew
           className={cx({
@@ -244,11 +240,7 @@ storiesOf('Components', module).add('Field', () => {
               <div className="p-3" />
             )}
           </FieldNew.Content>
-          {isRepeatable && (
-            <FieldNew.MainColumn>
-              <FieldNew.ConnectorLine />
-            </FieldNew.MainColumn>
-          )}
+          {isRepeatable && <FieldNew.ConnectorLine />}
         </FieldNew>
         <FieldNew
           className={cx({ 'field-active': status === ACTIVE })}
@@ -329,12 +321,12 @@ storiesOf('Components', module).add('Field', () => {
             )}
           </FieldNew.Content>
           {isRepeatable && (
-            <FieldNew.MainColumn>
+            <>
               <FieldNew.ConnectorLine />
               <FieldNew.RepeatButton
                 repeatLimitReached={boolean('Repeat limit reached', false)}
               />
-            </FieldNew.MainColumn>
+            </>
           )}
         </FieldNew>
       </StoryItem>

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Field, FieldNew } from 'lib';
-import { boolean, radios, select, text, number } from '@storybook/addon-knobs';
+import { boolean, radios, select, text } from '@storybook/addon-knobs';
 import cx from 'classnames';
 import StoryItem from '../../../stories/styleguide/StoryItem';
 import {
@@ -70,7 +70,6 @@ storiesOf('Components', module).add('Field', () => {
   );
 
   const isRepeatable = boolean('Is repeatable?', true);
-  const isLastRepeat = boolean('Is last repeat', true);
   return (
     <>
       <StoryItem
@@ -78,15 +77,15 @@ storiesOf('Components', module).add('Field', () => {
         description="A newer, Field component, can contain Content and Meta"
       >
         <FieldNew
-          className={cx({ 'field-active': status === ACTIVE })}
+          className={cx({ 'field-active': status === ACTIVE }, 'mb-0')}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
         >
           <FieldNew.Meta>
             {isRepeatable && (
               <FieldNew.RepeatableControls
-                repeatPosition={number('Repeat position', 1)}
-                isLastRepeat={isLastRepeat}
+                repeatPosition={0}
+                isLastRepeat={false}
                 isActive={status === ACTIVE}
               />
             )}
@@ -158,7 +157,177 @@ storiesOf('Components', module).add('Field', () => {
           {isRepeatable && (
             <FieldNew.RepeatButton
               repeatLimitReached={boolean('Repeat limit reached', false)}
-              isLastRepeat={isLastRepeat}
+              isLastRepeat={false}
+            />
+          )}
+        </FieldNew>
+        <FieldNew
+          className={cx({ 'field-active': status === ACTIVE }, 'mb-0')}
+          dir={dir}
+          inStructureEditMode={inStructureEditMode}
+        >
+          <FieldNew.Meta>
+            {isRepeatable && (
+              <FieldNew.RepeatableControls
+                repeatPosition={1}
+                isLastRepeat={false}
+                isActive={status === ACTIVE}
+              />
+            )}
+            <FieldNew.Label
+              className={cx({
+                'text-right': dir === 'ltr',
+                'text-left': dir === 'rtl',
+                'pt-8': !isRepeatable
+              })}
+            >
+              {label}
+            </FieldNew.Label>
+            <FieldNew.Validations
+              validations={mockValidations}
+              fieldId="123"
+              className="flex-col items-end"
+            />
+            <FieldNew.Actions
+              actions={mockActions}
+              fieldId="123"
+              className="items-end"
+            />
+          </FieldNew.Meta>
+          <FieldNew.Content
+            instructions={
+              <FieldNew.Instructions>{instructions}</FieldNew.Instructions>
+            }
+            status={status}
+          >
+            {!inStructureEditMode ? (
+              <div>
+                <h1>Heading content</h1>
+                <p>
+                  The fossil record indicates that birds evolved from feathered
+                  ancestors within the theropod group, which are traditionally
+                  placed within the saurischian dinosaurs, though a 2017
+                  paper[4] has put them in a proposed clade Ornithoscelida,
+                  along with the Ornithischia.
+                </p>
+                <table>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <p>
+                          <strong>Heading 1</strong>
+                        </p>
+                      </td>
+                      <td>
+                        <p>
+                          <strong>Heading 2</strong>
+                        </p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p>Cell 1</p>
+                      </td>
+                      <td>
+                        <p>Cell 2</p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="p-3" />
+            )}
+          </FieldNew.Content>
+          {isRepeatable && (
+            <FieldNew.RepeatButton
+              repeatLimitReached={boolean('Repeat limit reached', false)}
+              isLastRepeat={false}
+            />
+          )}
+        </FieldNew>
+        <FieldNew
+          className={cx({ 'field-active': status === ACTIVE })}
+          dir={dir}
+          inStructureEditMode={inStructureEditMode}
+        >
+          <FieldNew.Meta>
+            {isRepeatable && (
+              <FieldNew.RepeatableControls
+                repeatPosition={2}
+                isLastRepeat
+                isActive={status === ACTIVE}
+              />
+            )}
+            <FieldNew.Label
+              className={cx({
+                'text-right': dir === 'ltr',
+                'text-left': dir === 'rtl',
+                'pt-8': !isRepeatable
+              })}
+            >
+              {label}
+            </FieldNew.Label>
+            <FieldNew.Validations
+              validations={mockValidations}
+              fieldId="123"
+              className="flex-col items-end"
+            />
+            <FieldNew.Actions
+              actions={mockActions}
+              fieldId="123"
+              className="items-end"
+            />
+          </FieldNew.Meta>
+          <FieldNew.Content
+            instructions={
+              <FieldNew.Instructions>{instructions}</FieldNew.Instructions>
+            }
+            status={status}
+          >
+            {!inStructureEditMode ? (
+              <div>
+                <h1>Heading content</h1>
+                <p>
+                  The fossil record indicates that birds evolved from feathered
+                  ancestors within the theropod group, which are traditionally
+                  placed within the saurischian dinosaurs, though a 2017
+                  paper[4] has put them in a proposed clade Ornithoscelida,
+                  along with the Ornithischia.
+                </p>
+                <table>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <p>
+                          <strong>Heading 1</strong>
+                        </p>
+                      </td>
+                      <td>
+                        <p>
+                          <strong>Heading 2</strong>
+                        </p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p>Cell 1</p>
+                      </td>
+                      <td>
+                        <p>Cell 2</p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="p-3" />
+            )}
+          </FieldNew.Content>
+          {isRepeatable && (
+            <FieldNew.RepeatButton
+              repeatLimitReached={boolean('Repeat limit reached', false)}
+              isLastRepeat
             />
           )}
         </FieldNew>

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -70,6 +70,7 @@ storiesOf('Components', module).add('Field', () => {
   );
 
   const isRepeatable = boolean('Is repeatable?', true);
+  const isLastRepeat = boolean('Is last repeat', true);
   return (
     <>
       <StoryItem
@@ -85,7 +86,7 @@ storiesOf('Components', module).add('Field', () => {
             {isRepeatable && (
               <FieldNew.RepeatableControls
                 repeatPosition={number('Repeat position', 1)}
-                isLastRepeat={boolean('Is last', false)}
+                isLastRepeat={isLastRepeat}
                 isActive={status === ACTIVE}
               />
             )}
@@ -154,6 +155,12 @@ storiesOf('Components', module).add('Field', () => {
               <div className="p-3" />
             )}
           </FieldNew.Content>
+          {isRepeatable && (
+            <FieldNew.RepeatButton
+              repeatLimitReached={boolean('Repeat limit reached', false)}
+              isLastRepeat={isLastRepeat}
+            />
+          )}
         </FieldNew>
       </StoryItem>
       <StoryItem

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -77,7 +77,10 @@ storiesOf('Components', module).add('Field', () => {
         description="A newer, Field component, can contain Content and Meta"
       >
         <FieldNew
-          className={cx({ 'field-active': status === ACTIVE }, 'mb-0')}
+          className={cx({
+            'field-active': status === ACTIVE,
+            'mb-0': isRepeatable
+          })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
         >
@@ -155,14 +158,16 @@ storiesOf('Components', module).add('Field', () => {
             )}
           </FieldNew.Content>
           {isRepeatable && (
-            <FieldNew.RepeatButton
-              repeatLimitReached={boolean('Repeat limit reached', false)}
-              isLastRepeat={false}
-            />
+            <FieldNew.MainColumn>
+              <FieldNew.ConnectorLine />
+            </FieldNew.MainColumn>
           )}
         </FieldNew>
         <FieldNew
-          className={cx({ 'field-active': status === ACTIVE }, 'mb-0')}
+          className={cx({
+            'field-active': status === ACTIVE,
+            'mb-0': isRepeatable
+          })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
         >
@@ -240,10 +245,9 @@ storiesOf('Components', module).add('Field', () => {
             )}
           </FieldNew.Content>
           {isRepeatable && (
-            <FieldNew.RepeatButton
-              repeatLimitReached={boolean('Repeat limit reached', false)}
-              isLastRepeat={false}
-            />
+            <FieldNew.MainColumn>
+              <FieldNew.ConnectorLine />
+            </FieldNew.MainColumn>
           )}
         </FieldNew>
         <FieldNew
@@ -325,10 +329,12 @@ storiesOf('Components', module).add('Field', () => {
             )}
           </FieldNew.Content>
           {isRepeatable && (
-            <FieldNew.RepeatButton
-              repeatLimitReached={boolean('Repeat limit reached', false)}
-              isLastRepeat
-            />
+            <FieldNew.MainColumn>
+              <FieldNew.ConnectorLine />
+              <FieldNew.RepeatButton
+                repeatLimitReached={boolean('Repeat limit reached', false)}
+              />
+            </FieldNew.MainColumn>
           )}
         </FieldNew>
       </StoryItem>

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -93,7 +93,7 @@ storiesOf('Components', module).add('Field', () => {
               className={cx({
                 'text-right': dir === 'ltr',
                 'text-left': dir === 'rtl',
-                'pt-8': !isRepeatable
+                'pt-6': !isRepeatable
               })}
             >
               {label}
@@ -178,7 +178,7 @@ storiesOf('Components', module).add('Field', () => {
               className={cx({
                 'text-right': dir === 'ltr',
                 'text-left': dir === 'rtl',
-                'pt-8': !isRepeatable
+                'pt-6': !isRepeatable
               })}
             >
               {label}
@@ -263,7 +263,7 @@ storiesOf('Components', module).add('Field', () => {
               className={cx({
                 'text-right': dir === 'ltr',
                 'text-left': dir === 'rtl',
-                'pt-8': !isRepeatable
+                'pt-6': !isRepeatable
               })}
             >
               {label}


### PR DESCRIPTION
### 💬 Description
I _think_ this may be the last of the repeatable field PRs, thanks for your help and patience!

This adds the vertical line between repeatable fields, and the "Add another" or "Limit reached" buttons at the bottom of the last repeated field.

I've also added 2 more fields to the story, for a bit more context. You can see the vertical spacer between all fields, and notice that we don't get the "trash" or "move up" button on the first field, and we don't get the "move down" button on the last repeated field.

I've had to override the bottom margin on the <FieldNew> to get the next field to join to the previous field (when repeated). Do you think this is fine? Another option I though was to not set an explicit margin on the <FieldNew> but set a negative margin (the size of the vertical bar) so the next elements would rise up to meet the line - but that also seems a bit hacky? 

### 🔗 Links
https://www.figma.com/file/HNH1EAEtLOVJRsydtdrxUq/Repeatable-Fields?node-id=0%3A1

### 📹 GIF (optional)

![Screen Recording 2020-05-19 at 11 32 am](https://user-images.githubusercontent.com/3472717/82316394-a17a2d80-99c4-11ea-96cb-0be1cd800b80.gif)

### 🚪 Start Points

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
