### PR TITLE
FieldNew repeatable updates

### DIFF
--- a/lib/Field/FieldContent.js
+++ b/lib/Field/FieldContent.js
@@ -8,7 +8,7 @@ export const ADDED = 'ADDED';
 export const DELETED = 'DELETED';
 export const MOVED_UP = 'MOVED_UP';
 export const MOVED_DOWN = 'MOVED_DOWN';
-export const UNCHANGED = 'UNCHAGED';
+export const UNCHANGED = 'UNCHANGED';
 
 export function FieldContent({ children, className, instructions, status }) {
   const { inStructureEditMode } = useContext(

--- a/lib/Field/FieldContent.js
+++ b/lib/Field/FieldContent.js
@@ -3,12 +3,12 @@ import { element, node, oneOf, string } from 'prop-types';
 import cx from 'classnames';
 import { FieldNew } from 'lib';
 
-export const ACTIVE = 'active';
-export const ADDED = 'added';
-export const DELETED = 'deleted';
-export const MOVED_UP = 'moved_up';
-export const MOVED_DOWN = 'moved_down';
-export const UNCHANGED = 'unchanged';
+export const ACTIVE = 'ACTIVE';
+export const ADDED = 'ADDED';
+export const DELETED = 'DELETED';
+export const MOVED_UP = 'MOVED_UP';
+export const MOVED_DOWN = 'MOVED_DOWN';
+export const UNCHANGED = 'UNCHAGED';
 
 export function FieldContent({ children, className, instructions, status }) {
   const { inStructureEditMode } = useContext(

--- a/lib/Field/FieldNew.js
+++ b/lib/Field/FieldNew.js
@@ -1,7 +1,15 @@
 import React, { createContext } from 'react';
 import { bool, node, oneOf, string } from 'prop-types';
 import cx from 'classnames';
-import { FieldContent } from './FieldContent';
+import {
+  FieldContent,
+  ACTIVE,
+  ADDED,
+  DELETED,
+  MOVED_UP,
+  MOVED_DOWN,
+  UNCHANGED
+} from './FieldContent';
 import { FieldMeta } from './FieldMeta';
 import { FieldLabel } from './FieldLabel';
 import { FieldInstructions } from './FieldInstructions';
@@ -54,3 +62,4 @@ FieldNew.RepeatableControls = FieldRepeatableControls;
 FieldNew.RepeatButton = FieldRepeatButton;
 FieldNew.ConnectorLine = FieldConnectorLine;
 FieldNew.InStructureEditModeContext = InStructureEditModeContext;
+FieldNew.statuses = { ACTIVE, ADDED, DELETED, MOVED_UP, MOVED_DOWN, UNCHANGED };

--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { bool } from 'prop-types';
+import { bool, func } from 'prop-types';
 import { ButtonSecondary } from '../ButtonNew/ButtonSecondary/ButtonSecondary';
 import Icon from '../Icon';
 import { FieldMainColumn } from './FieldMainColumn';
 
-export function FieldRepeatButton({ repeatLimitReached }) {
+export function FieldRepeatButton({ repeatLimitReached, repeatField }) {
   const button = repeatLimitReached ? (
     <ButtonSecondary disabled>Limit reached</ButtonSecondary>
   ) : (
-    <ButtonSecondary>
+    <ButtonSecondary onClick={repeatField}>
       <Icon name="plus" />
       <span className="w-2" />
       Add another
@@ -19,7 +19,8 @@ export function FieldRepeatButton({ repeatLimitReached }) {
 }
 
 FieldRepeatButton.propTypes = {
-  repeatLimitReached: bool
+  repeatLimitReached: bool,
+  repeatField: func.isRequired
 };
 
 FieldRepeatButton.defaultProps = {

--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -4,11 +4,11 @@ import { ButtonSecondary } from '../ButtonNew/ButtonSecondary/ButtonSecondary';
 import Icon from '../Icon';
 import { FieldMainColumn } from './FieldMainColumn';
 
-export function FieldRepeatButton({ repeatLimitReached, repeatField }) {
+export function FieldRepeatButton({ repeatLimitReached, onClick }) {
   const button = repeatLimitReached ? (
     <ButtonSecondary disabled>Limit reached</ButtonSecondary>
   ) : (
-    <ButtonSecondary onClick={repeatField}>
+    <ButtonSecondary onClick={onClick}>
       <Icon name="plus" />
       <span className="w-2" />
       Add another
@@ -20,7 +20,7 @@ export function FieldRepeatButton({ repeatLimitReached, repeatField }) {
 
 FieldRepeatButton.propTypes = {
   repeatLimitReached: bool,
-  repeatField: func.isRequired
+  onClick: func.isRequired
 };
 
 FieldRepeatButton.defaultProps = {

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, number } from 'prop-types';
+import { bool, func, number } from 'prop-types';
 import cx from 'classnames';
 import { ButtonIcon } from '../ButtonNew/ButtonIcon/ButtonIcon';
 import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
@@ -7,6 +7,9 @@ import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
 export function FieldRepeatableControls({
   repeatPosition,
   isLastRepeat,
+  deleteRepeatedField,
+  moveRepeatedFieldUp,
+  moveRepeatedFieldDown,
   isActive
 }) {
   const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
@@ -26,6 +29,7 @@ export function FieldRepeatableControls({
           name="trash"
           className={buttonClasses}
           size={ButtonIconDanger.sizes.sm}
+          onClick={deleteRepeatedField}
         />
       )}
       {repeatPosition > 0 && (
@@ -33,6 +37,7 @@ export function FieldRepeatableControls({
           name="arrowUp"
           className={buttonClasses}
           size={ButtonIcon.sizes.sm}
+          onClick={moveRepeatedFieldUp}
         />
       )}
       {!isLastRepeat && (
@@ -40,6 +45,7 @@ export function FieldRepeatableControls({
           name="arrowDown"
           className={buttonClasses}
           size={ButtonIcon.sizes.sm}
+          onClick={moveRepeatedFieldDown}
         />
       )}
       <span className="w-1" />
@@ -51,6 +57,9 @@ export function FieldRepeatableControls({
 FieldRepeatableControls.propTypes = {
   repeatPosition: number.isRequired,
   isLastRepeat: bool.isRequired,
+  deleteRepeatedField: func.isRequired,
+  moveRepeatedFieldUp: func.isRequired,
+  moveRepeatedFieldDown: func.isRequired,
   isActive: bool
 };
 

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -7,9 +7,9 @@ import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
 export function FieldRepeatableControls({
   repeatPosition,
   isLastRepeat,
-  deleteRepeatedField,
-  moveRepeatedFieldUp,
-  moveRepeatedFieldDown,
+  onDeleteRepeatedField,
+  onMoveRepeatedFieldUp,
+  onMoveRepeatedFieldDown,
   isActive
 }) {
   const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
@@ -29,7 +29,7 @@ export function FieldRepeatableControls({
           name="trash"
           className={buttonClasses}
           size={ButtonIconDanger.sizes.sm}
-          onClick={deleteRepeatedField}
+          onClick={onDeleteRepeatedField}
         />
       )}
       {repeatPosition > 0 && (
@@ -37,7 +37,7 @@ export function FieldRepeatableControls({
           name="arrowUp"
           className={buttonClasses}
           size={ButtonIcon.sizes.sm}
-          onClick={moveRepeatedFieldUp}
+          onClick={onMoveRepeatedFieldUp}
         />
       )}
       {!isLastRepeat && (
@@ -45,7 +45,7 @@ export function FieldRepeatableControls({
           name="arrowDown"
           className={buttonClasses}
           size={ButtonIcon.sizes.sm}
-          onClick={moveRepeatedFieldDown}
+          onClick={onMoveRepeatedFieldDown}
         />
       )}
       <span className="w-1" />
@@ -57,9 +57,9 @@ export function FieldRepeatableControls({
 FieldRepeatableControls.propTypes = {
   repeatPosition: number.isRequired,
   isLastRepeat: bool.isRequired,
-  deleteRepeatedField: func.isRequired,
-  moveRepeatedFieldUp: func.isRequired,
-  moveRepeatedFieldDown: func.isRequired,
+  onDeleteRepeatedField: func.isRequired,
+  onMoveRepeatedFieldUp: func.isRequired,
+  onMoveRepeatedFieldDown: func.isRequired,
   isActive: bool
 };
 

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -72,9 +72,9 @@ storiesOf('Components', module).add('Field', () => {
                 repeatPosition={0}
                 isLastRepeat={false}
                 isActive={status === FieldNew.statuses.ACTIVE}
-                deleteRepeatedField={action('delete repeated field')}
-                moveRepeatedFieldUp={action('move repeated field up')}
-                moveRepeatedFieldDown={action('move repeated field down')}
+                onDeleteRepeatedField={action('delete repeated field')}
+                onMoveRepeatedFieldUp={action('move repeated field up')}
+                onMoveRepeatedFieldDown={action('move repeated field down')}
               />
             )}
             <FieldNew.Label
@@ -158,9 +158,9 @@ storiesOf('Components', module).add('Field', () => {
                 repeatPosition={1}
                 isLastRepeat={false}
                 isActive={status === FieldNew.statuses.ACTIVE}
-                deleteRepeatedField={action('delete repeated field')}
-                moveRepeatedFieldUp={action('move repeated field up')}
-                moveRepeatedFieldDown={action('move repeated field down')}
+                onDeleteRepeatedField={action('delete repeated field')}
+                onMoveRepeatedFieldUp={action('move repeated field up')}
+                onMoveRepeatedFieldDown={action('move repeated field down')}
               />
             )}
             <FieldNew.Label
@@ -243,9 +243,9 @@ storiesOf('Components', module).add('Field', () => {
                 repeatPosition={2}
                 isLastRepeat
                 isActive={status === FieldNew.statuses.ACTIVE}
-                deleteRepeatedField={action('delete repeated field')}
-                moveRepeatedFieldUp={action('move repeated field up')}
-                moveRepeatedFieldDown={action('move repeated field down')}
+                onDeleteRepeatedField={action('delete repeated field')}
+                onMoveRepeatedFieldUp={action('move repeated field up')}
+                onMoveRepeatedFieldDown={action('move repeated field down')}
               />
             )}
             <FieldNew.Label

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -62,10 +62,7 @@ storiesOf('Components', module).add('Field', () => {
         description="A newer, Field component, can contain Content and Meta"
       >
         <FieldNew
-          className={cx({
-            'field-active': status === FieldNew.statuses.ACTIVE,
-            'mb-0': isRepeatable
-          })}
+          className={cx({ 'mb-0': isRepeatable })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
         >

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -318,7 +318,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.ConnectorLine />
               <FieldNew.RepeatButton
                 repeatLimitReached={boolean('Repeat limit reached', false)}
-                repeatField={action('repeat field')}
+                onClick={action('repeat field')}
               />
             </>
           )}

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -75,6 +75,9 @@ storiesOf('Components', module).add('Field', () => {
                 repeatPosition={0}
                 isLastRepeat={false}
                 isActive={status === FieldNew.statuses.ACTIVE}
+                deleteRepeatedField={action('delete repeated field')}
+                moveRepeatedFieldUp={action('move repeated field up')}
+                moveRepeatedFieldDown={action('move repeated field down')}
               />
             )}
             <FieldNew.Label
@@ -158,6 +161,9 @@ storiesOf('Components', module).add('Field', () => {
                 repeatPosition={1}
                 isLastRepeat={false}
                 isActive={status === FieldNew.statuses.ACTIVE}
+                deleteRepeatedField={action('delete repeated field')}
+                moveRepeatedFieldUp={action('move repeated field up')}
+                moveRepeatedFieldDown={action('move repeated field down')}
               />
             )}
             <FieldNew.Label
@@ -240,6 +246,9 @@ storiesOf('Components', module).add('Field', () => {
                 repeatPosition={2}
                 isLastRepeat
                 isActive={status === FieldNew.statuses.ACTIVE}
+                deleteRepeatedField={action('delete repeated field')}
+                moveRepeatedFieldUp={action('move repeated field up')}
+                moveRepeatedFieldDown={action('move repeated field down')}
               />
             )}
             <FieldNew.Label
@@ -312,6 +321,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.ConnectorLine />
               <FieldNew.RepeatButton
                 repeatLimitReached={boolean('Repeat limit reached', false)}
+                repeatField={action('repeat field')}
               />
             </>
           )}

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -5,14 +5,6 @@ import { Field, FieldNew } from 'lib';
 import { boolean, radios, select, text } from '@storybook/addon-knobs';
 import cx from 'classnames';
 import StoryItem from '../../../stories/styleguide/StoryItem';
-import {
-  ACTIVE,
-  ADDED,
-  DELETED,
-  MOVED_DOWN,
-  MOVED_UP,
-  UNCHANGED
-} from '../FieldContent';
 
 const mockValidations = [
   {
@@ -58,15 +50,8 @@ storiesOf('Components', module).add('Field', () => {
   );
   const status = select(
     'Status',
-    {
-      Unchanged: UNCHANGED,
-      Active: ACTIVE,
-      Added: ADDED,
-      Deleted: DELETED,
-      'Moved up': MOVED_UP,
-      'Moved Down': MOVED_DOWN
-    },
-    UNCHANGED
+    FieldNew.statuses,
+    FieldNew.statuses.UNCHANGED
   );
 
   const isRepeatable = boolean('Is repeatable?', true);
@@ -78,7 +63,7 @@ storiesOf('Components', module).add('Field', () => {
       >
         <FieldNew
           className={cx({
-            'field-active': status === ACTIVE,
+            'field-active': status === FieldNew.statuses.ACTIVE,
             'mb-0': isRepeatable
           })}
           dir={dir}
@@ -89,7 +74,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.RepeatableControls
                 repeatPosition={0}
                 isLastRepeat={false}
-                isActive={status === ACTIVE}
+                isActive={status === FieldNew.statuses.ACTIVE}
               />
             )}
             <FieldNew.Label
@@ -161,7 +146,7 @@ storiesOf('Components', module).add('Field', () => {
         </FieldNew>
         <FieldNew
           className={cx({
-            'field-active': status === ACTIVE,
+            'field-active': status === FieldNew.statuses.ACTIVE,
             'mb-0': isRepeatable
           })}
           dir={dir}
@@ -172,7 +157,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.RepeatableControls
                 repeatPosition={1}
                 isLastRepeat={false}
-                isActive={status === ACTIVE}
+                isActive={status === FieldNew.statuses.ACTIVE}
               />
             )}
             <FieldNew.Label
@@ -243,7 +228,9 @@ storiesOf('Components', module).add('Field', () => {
           {isRepeatable && <FieldNew.ConnectorLine />}
         </FieldNew>
         <FieldNew
-          className={cx({ 'field-active': status === ACTIVE })}
+          className={cx({
+            'field-active': status === FieldNew.statuses.ACTIVE
+          })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
         >
@@ -252,7 +239,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.RepeatableControls
                 repeatPosition={2}
                 isLastRepeat
-                isActive={status === ACTIVE}
+                isActive={status === FieldNew.statuses.ACTIVE}
               />
             )}
             <FieldNew.Label


### PR DESCRIPTION
Export the field status consts from FieldNew so these can be accessed from the app:
ACTIVE, ADDED, DELETED, MOVED_UP, MOVED_DOWN, UNCHANGED

And add the button handlers to repeatable field controls/repeat button - didn't actually need these until we tried to port to the app 😄 

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
