### PR TITLE
Adds defaultActiveColor={false} to ProgressButton spinner icon

### DIFF
--- a/lib/ProgressButton/index.js
+++ b/lib/ProgressButton/index.js
@@ -51,7 +51,11 @@ class ProgressButton extends Component {
         <span className={classes}>
           {this.props.spinnerText || this.props.value}
         </span>
-        <Icon className="progress-button__icon" name="loader" />
+        <Icon
+          className="progress-button__icon"
+          name="loader"
+          defaultActiveColor={false}
+        />
       </span>
     );
   }


### PR DESCRIPTION
### 💬 Description
Our progress button spinner was rendering as blue when the button was active, when it should have been white.

This PR fixes this.

I checked every instance of progress button manually, and that probably still wont catch all cases - we need heatmap testing!
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
