### PR TITLE
Adds a prop to control whether TooltipWrappers are tabbable

### DIFF
--- a/lib/TooltipWrapper/index.js
+++ b/lib/TooltipWrapper/index.js
@@ -53,6 +53,8 @@ class TooltipWrapper extends Component {
       }
     );
 
+    const tabIndex = this.props.tabbable ? 0 : -1;
+
     return (
       <OverlayTrigger
         {...rest}
@@ -62,7 +64,11 @@ class TooltipWrapper extends Component {
           this.tooltipOverlay = tooltipOverlay;
         }}
       >
-        <span className={wrapperChildClassNames} tabIndex="0" role="button">
+        <span
+          className={wrapperChildClassNames}
+          tabIndex={tabIndex}
+          role="button"
+        >
           {children}
         </span>
       </OverlayTrigger>
@@ -82,7 +88,8 @@ TooltipWrapper.propTypes = {
   alignLeft: PropTypes.bool,
   clickable: PropTypes.bool,
   manual: PropTypes.bool,
-  show: PropTypes.bool
+  show: PropTypes.bool,
+  tabbable: PropTypes.bool
 };
 
 TooltipWrapper.defaultProps = {
@@ -95,7 +102,8 @@ TooltipWrapper.defaultProps = {
   alignLeft: false,
   clickable: false,
   manual: false,
-  show: null
+  show: null,
+  tabbable: true
 };
 
 export default TooltipWrapper;


### PR DESCRIPTION
### 💬 Description
We dont always want our tooltip wrappers to be tabbable, for example if you have a dropdown and each dropdown action has a tooltip you have to tab twice in order to get past the tooltip to reach the button.