### PR TITLE
Alter small ButtonIcon border radius

### DIFF
--- a/lib/ButtonNew/ButtonIcon/ButtonIcon.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIcon.js
@@ -26,7 +26,8 @@ function ButtonIcon({ className, disabled, name, active, size, ...rest }) {
     'items-center justify-center',
     {
       [nonDisabledClasses]: !disabled,
-      'opacity-50': disabled
+      'opacity-50': disabled,
+      'rounded-small': size === sizes.sm
     },
     getSizeClasses(size)
   );

--- a/lib/ButtonNew/ButtonIcon/ButtonIconDanger.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIconDanger.js
@@ -33,7 +33,8 @@ function ButtonIconDanger({
     'items-center justify-center',
     {
       [nonDisabledClasses]: !disabled,
-      'opacity-50': disabled
+      'opacity-50': disabled,
+      'rounded-small': size === sizes.sm
     },
     getSizeClasses(size)
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,10 +23,10 @@ module.exports = {
       bold: 600
     },
     borderRadius: {
-      none: 0,
-      small: '4px',
       default: '6px',
-      full: '100%'
+      small: '4px',
+      full: '100%',
+      none: 0
     },
     boxShadow: {
       small: '0px 2px 4px rgba(0, 0, 0, 0.06)',


### PR DESCRIPTION
### 💬 Description
Match GCDS designs for the border radius on small ButtonIcons

The order in the config controls what overrides what, which is why i've rejigged!