### PR TITLE
update icon default colour and ButtonIcon disabled opacity

### DIFF
--- a/lib/ButtonNew/ButtonIcon/ButtonIcon.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIcon.js
@@ -26,7 +26,7 @@ function ButtonIcon({ className, disabled, name, active, size, ...rest }) {
     'items-center justify-center',
     {
       [nonDisabledClasses]: !disabled,
-      'opacity-50': disabled
+      'opacity-30': disabled
     },
     getSizeClasses(size)
   );

--- a/lib/ButtonNew/ButtonIcon/ButtonIconDanger.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIconDanger.js
@@ -33,7 +33,7 @@ function ButtonIconDanger({
     'items-center justify-center',
     {
       [nonDisabledClasses]: !disabled,
-      'opacity-50': disabled
+      'opacity-30': disabled
     },
     getSizeClasses(size)
   );

--- a/lib/Icon/styles.scss
+++ b/lib/Icon/styles.scss
@@ -2,7 +2,7 @@
    Config
    ========================================================================== */
 $icon-display: inline-block !default;
-$icon-default-color: $neutral-base !default;
+$icon-default-color: #678099 !default;
 $icon-hover-color: $color-brand-green !default;
 $icon-active-color: $color-brand-blue !default;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -131,6 +131,9 @@ module.exports = {
       },
       transitionTimingFunction: {
         'animation-curve': 'cubic-bezier(0.68, -0.55, 0.265, 1.55)'
+      },
+      opacity: {
+        '30': 0.3
       }
     },
     maxHeight: {


### PR DESCRIPTION
### 💬 Description
Icon default colours now use the new neutral primary colour, unfortunately I've had to do this the old fashioned way as a sass variable. Once everything is tailwindy we can make this nicer.

Also a new opacity setting and applying that to ButtonIcons