### PR TITLE
Revert "Fix/Fix BoundaryClickWatcher to no longer require prop `ignoreClass`"

### DIFF
--- a/lib/BoundaryClickWatcher/README.md
+++ b/lib/BoundaryClickWatcher/README.md
@@ -14,9 +14,10 @@ BoundaryClickWatcher uses the render callback pattern and returns a boolean.
 | alwaysListen          | bool          | `false`       | No       | If true the click event listener is added on mount instead of being added when handleInnerClick is called. |
 | onMouseEnter          | Function      | `() {};`      | No       | Executes when the user's mouse enters the boundary. |
 | onMouseLeave          | Function      | `() {};`      | No       | Executes when the user's leaves the boundary.       |
+| ignoreClass          | String      | `submit-button cancel-button`      | No       | Class of element to ignore if clicked. Used to stop outsideClickHandler being triggered when clicking an element that is immediately removed from the DOM after being clicked. Multiple classes can be added in the same string.       |
 
 ```
-<BoundaryClickWatcher insideClickHandler={someFunc} outsideClickHandler={someOtherFunc} alwaysListen={false}>
+<BoundaryClickWatcher insideClickHandler={someFunc} outsideClickHandler={someOtherFunc} alwaysListen={false} ignoreClass="button shared-item__dropdown__cancel-button">
   {(boundaryIsActive) => {
     return (
       <MyComponent

--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -1,23 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const getElementPath = targetElement => {
-  let path = [targetElement];
-
-  const addParentToPath = element => {
-    const { parentElement } = element;
-
-    if (parentElement) {
-      path = [...path, parentElement];
-      return addParentToPath(parentElement);
-    }
-
-    return path;
-  };
-
-  return addParentToPath(targetElement);
-};
-
 class BoundaryClickWatcher extends Component {
   static propTypes = {
     insideClickHandler: PropTypes.func,
@@ -27,6 +10,7 @@ class BoundaryClickWatcher extends Component {
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
+    ignoreClass: PropTypes.string,
     BoundaryElement: PropTypes.string
   };
 
@@ -37,16 +21,13 @@ class BoundaryClickWatcher extends Component {
     onMouseLeave() {},
     className: '',
     alwaysListen: false,
+    ignoreClass: null,
     BoundaryElement: 'div'
   };
 
   constructor(props) {
     super(props);
-    this.state = {
-      boundaryIsActive: false,
-      boundaryIsFocussed: false,
-      clickedElementPath: []
-    };
+    this.state = { boundaryIsActive: false, boundaryIsFocussed: false };
     this.handleClick = this.handleClick.bind(this);
     this.addDocumentEventListener = this.addDocumentEventListener.bind(this);
     this.removeDocumentEventListener = this.removeDocumentEventListener.bind(
@@ -68,18 +49,12 @@ class BoundaryClickWatcher extends Component {
     this.removeDocumentEventListener();
   }
 
-  handleMouseDown = ({ target }) => {
-    this.setState({ clickedElementPath: getElementPath(target) });
-  };
-
   addDocumentEventListener() {
     document.addEventListener('click', this.handleClick);
-    document.addEventListener('mousedown', this.handleMouseDown);
   }
 
   removeDocumentEventListener() {
     document.removeEventListener('click', this.handleClick);
-    document.removeEventListener('mousedown', this.handleMouseDown);
   }
 
   handleInnerClick() {
@@ -103,22 +78,29 @@ class BoundaryClickWatcher extends Component {
   }
 
   handleClick(event) {
+    const { ignoreClass } = this.props;
     const { target } = event;
-    const {
-      container,
-      state: { clickedElementPath }
-    } = this;
 
-    const targetIsContainer = target === container;
-    const elementPathContainsContainer =
-      clickedElementPath.indexOf(container) !== -1;
-    const containerContainsFocus =
-      container && container.contains(document.activeElement);
+    const targetIsContainer = target !== this.container;
+    let containerDoesNotContainTarget = false;
+    let containerDoesNotContainFocus = false;
+    if (this.container) {
+      containerDoesNotContainTarget = !this.container.contains(target);
+      containerDoesNotContainFocus = !this.container.contains(
+        document.activeElement
+      );
+    }
+
+    const ignoreClasses = ignoreClass ? ignoreClass.match(/\S+/g) : [];
+    const targetHasIgnoreClass = ignoreClasses.some(className =>
+      target.classList.contains(className)
+    );
 
     const userHasClickedOutside =
-      !targetIsContainer &&
-      !elementPathContainsContainer &&
-      !containerContainsFocus;
+      targetIsContainer &&
+      containerDoesNotContainTarget &&
+      containerDoesNotContainFocus &&
+      !targetHasIgnoreClass;
 
     if (userHasClickedOutside) {
       this.handleOuterClick(event);

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -32,6 +32,7 @@ class Dropdown extends Component {
     onToggle: PropTypes.func,
     onHide: PropTypes.func,
     className: PropTypes.string,
+    ignoreClass: PropTypes.string,
     autoPosition: PropTypes.bool,
     block: PropTypes.bool,
     persistShow: PropTypes.bool
@@ -41,6 +42,7 @@ class Dropdown extends Component {
     onToggle: () => {},
     onHide: () => {},
     className: '',
+    ignoreClass: null,
     autoPosition: false,
     block: false,
     persistShow: false
@@ -122,6 +124,7 @@ class Dropdown extends Component {
           this.setShowContent(false);
           this.props.onHide();
         }}
+        ignoreClass={this.props.ignoreClass}
       >
         {typeof children === 'function'
           ? children({


### PR DESCRIPTION
Reverts gathercontent/gather-ui#711

Reverting these changes as they break our tests.

We test clicking things with `fireEvent.click`, which does not fire the mousedown event, which this PR depends on.