### PR TITLE
Adds background white to the menu item options

### DIFF
--- a/lib/OptionMenu/MenuItem.js
+++ b/lib/OptionMenu/MenuItem.js
@@ -5,7 +5,13 @@ import Icon from '../Icon';
 
 function MenuItem({ text, iconName, selected, className, ...rest }) {
   const classes = cx(
-    `${className} mb-1 rounded-small w-48 border-0 flex items-center py-1 px-2 hover:bg-neutral-95 focus:outline-none focus:shadow-blue-focus-sm`,
+    className,
+    'bg-white hover:bg-neutral-95',
+    'rounded-small w-48 border-0',
+    'py-1 px-2',
+    'mb-1',
+    'flex items-center',
+    'focus:outline-none focus:shadow-blue-focus-sm',
     {
       'text-neutral-20': !selected,
       'text-blue-primary': selected


### PR DESCRIPTION
### 💬 Description
Adds white background to the menu item.

Previously it had no background color, and as a result it would intermittently inherit the default browser background color for buttons, which is grey.
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
