### PR TITLE
Creating a blue line for dragging tabs

### DIFF
--- a/lib/TabsNew/TabsDragLine.js
+++ b/lib/TabsNew/TabsDragLine.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { string, bool } from 'prop-types';
+
+export function TabsDragLine({ side, firstTab }) {
+  const leftPosition = firstTab ? '0' : '-2px';
+
+  return (
+    <span
+      style={{
+        left: side === 'left' ? leftPosition : 'unset',
+        right: side === 'right' ? '0' : 'unset'
+      }}
+      className={`${
+        side === 'whole'
+          ? 'border-2 w-full top-0 left-0'
+          : 'border-t-0 border-b-0 border-l border-r'
+      } absolute border-blue-primary border-solid top-0 h-full`}
+    />
+  );
+}
+
+TabsDragLine.propTypes = {
+  side: string.isRequired,
+  firstTab: bool
+};
+
+TabsDragLine.defaultProps = {
+  firstTab: false
+};

--- a/lib/TabsNew/index.js
+++ b/lib/TabsNew/index.js
@@ -3,6 +3,7 @@ import { node, string } from 'prop-types';
 import { TabsBase } from './TabsBase';
 import { TabsActionGroup } from './TabsActionGroup';
 import { TabsGroup } from './TabsGroup';
+import { TabsDragLine } from './TabsDragLine';
 
 function Tabs({ children, className }) {
   return <div className={`relative ${className}`}>{children}</div>;
@@ -11,6 +12,7 @@ function Tabs({ children, className }) {
 Tabs.Base = TabsBase;
 Tabs.ActionGroup = TabsActionGroup;
 Tabs.Group = TabsGroup;
+Tabs.DragLine = TabsDragLine;
 
 export { Tabs };
 


### PR DESCRIPTION
### 💬 Description
A utility span component to render a blue line for dragging and hovering over a tab. It supports a left line, right line or a whole border.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
