### PR TITLE
Allow a user to control whether the different repeatable field controls should be included

### DIFF
--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, func, number } from 'prop-types';
+import { bool, func, number, shape } from 'prop-types';
 import cx from 'classnames';
 import { ButtonIcon } from '../ButtonNew/ButtonIcon/ButtonIcon';
 import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
@@ -10,7 +10,8 @@ export function FieldRepeatableControls({
   onDeleteRepeatedField,
   onMoveRepeatedFieldUp,
   onMoveRepeatedFieldDown,
-  isActive
+  isActive,
+  controls
 }) {
   const label = `${repeatPosition < 9 ? '0' : ''}${repeatPosition + 1}`;
 
@@ -24,7 +25,7 @@ export function FieldRepeatableControls({
 
   return (
     <div className="flex justify-end">
-      {repeatPosition > 0 && (
+      {repeatPosition > 0 && controls.trash && (
         <ButtonIconDanger
           name="trash"
           className={buttonClasses}
@@ -32,7 +33,7 @@ export function FieldRepeatableControls({
           onClick={onDeleteRepeatedField}
         />
       )}
-      {repeatPosition > 0 && (
+      {repeatPosition > 0 && controls.reorder && (
         <ButtonIcon
           name="arrowUp"
           className={buttonClasses}
@@ -40,7 +41,7 @@ export function FieldRepeatableControls({
           onClick={onMoveRepeatedFieldUp}
         />
       )}
-      {!isLastRepeat && (
+      {!isLastRepeat && controls.reorder && (
         <ButtonIcon
           name="arrowDown"
           className={buttonClasses}
@@ -60,9 +61,17 @@ FieldRepeatableControls.propTypes = {
   onDeleteRepeatedField: func.isRequired,
   onMoveRepeatedFieldUp: func.isRequired,
   onMoveRepeatedFieldDown: func.isRequired,
-  isActive: bool
+  isActive: bool,
+  controls: shape({
+    trash: bool.isRequired,
+    reorder: bool.isRequired
+  })
 };
 
 FieldRepeatableControls.defaultProps = {
-  isActive: false
+  isActive: false,
+  controls: {
+    trash: true,
+    reorder: true
+  }
 };

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -54,6 +54,12 @@ storiesOf('Components', module).add('Field', () => {
     FieldNew.statuses.UNCHANGED
   );
 
+  const controlsReorder = boolean(
+    'Include move up and move down controls',
+    true
+  );
+  const controlsTrash = boolean('Include trash control', true);
+
   const isRepeatable = boolean('Is repeatable?', true);
   return (
     <>
@@ -75,6 +81,10 @@ storiesOf('Components', module).add('Field', () => {
                 onDeleteRepeatedField={action('delete repeated field')}
                 onMoveRepeatedFieldUp={action('move repeated field up')}
                 onMoveRepeatedFieldDown={action('move repeated field down')}
+                controls={{
+                  reorder: controlsReorder,
+                  trash: controlsTrash
+                }}
               />
             )}
             <FieldNew.Label
@@ -161,6 +171,10 @@ storiesOf('Components', module).add('Field', () => {
                 onDeleteRepeatedField={action('delete repeated field')}
                 onMoveRepeatedFieldUp={action('move repeated field up')}
                 onMoveRepeatedFieldDown={action('move repeated field down')}
+                controls={{
+                  reorder: controlsReorder,
+                  trash: controlsTrash
+                }}
               />
             )}
             <FieldNew.Label
@@ -246,6 +260,10 @@ storiesOf('Components', module).add('Field', () => {
                 onDeleteRepeatedField={action('delete repeated field')}
                 onMoveRepeatedFieldUp={action('move repeated field up')}
                 onMoveRepeatedFieldDown={action('move repeated field down')}
+                controls={{
+                  reorder: controlsReorder,
+                  trash: controlsTrash
+                }}
               />
             )}
             <FieldNew.Label


### PR DESCRIPTION
### 💬 Description

When showing fields for revisions, we'll want to omit the repeatable controls entirely. 

Adding some granularity here to allow _some_ controls to be omitted, although not required right now, seems sensible and could be useful in the future (for example when a user does not have permission to delete a field, but could reorder it)

### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_

### 📹 GIF (optional)
https://share.getcloudapp.com/GGuov2mo

### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
