### PR TITLE
Add the purple pill to gather-ui - used for the BETA pill

### DIFF
--- a/lib/Pill/PillPurple.js
+++ b/lib/Pill/PillPurple.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { propTypes, defaultProps } from './common';
+import PillBase from './PillBase';
+
+const PillPurple = ({ className, children, ...rest }) => (
+  <PillBase
+    className={`bg-purple-90 text-purple-primary font-semi-bold inherit-color-icon ${className}`}
+    {...rest}
+  >
+    {children}
+  </PillBase>
+);
+
+PillPurple.propTypes = propTypes;
+
+PillPurple.defaultProps = defaultProps;
+
+export default PillPurple;

--- a/lib/Pill/common.js
+++ b/lib/Pill/common.js
@@ -19,5 +19,6 @@ export const defaultProps = {
 export const types = {
   default: 'default',
   red: 'red',
-  green: 'green'
+  green: 'green',
+  purple: 'purple'
 };

--- a/lib/Pill/index.js
+++ b/lib/Pill/index.js
@@ -4,6 +4,7 @@ import { propTypes, defaultProps, types, sizes } from './common';
 import PillDefault from './PillDefault';
 import PillRed from './PillRed';
 import PillGreen from './PillGreen';
+import PillPurple from './PillPurple';
 
 const Pill = ({ type, children, ...rest }) => {
   const getPill = () => {
@@ -12,6 +13,8 @@ const Pill = ({ type, children, ...rest }) => {
         return PillRed;
       case types.green:
         return PillGreen;
+      case types.purple:
+        return PillPurple;
       default:
         return PillDefault;
     }


### PR DESCRIPTION
### 💬 Description
We have a green and red `<Pill>` component, this just adds a purple variation - used for the BETA pill 

### 🔗 Links
https://www.figma.com/file/66iSurBAx32DWrJymo9NKL/GCDS-%E2%80%93-Web-UI?node-id=3450%3A3

### 📹 GIF (optional)
![Screenshot 2020-06-10 at 14 57 44](https://user-images.githubusercontent.com/3472717/84276897-c4fb4880-ab2a-11ea-89d5-c98f2be35a8f.png)

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
