### PR TITLE
Fix the bottom border colour for Topbars using the darker theme

### DIFF
--- a/lib/TopBar/styles.scss
+++ b/lib/TopBar/styles.scss
@@ -150,6 +150,7 @@ $top-bar-notification-height: 42px;
   &--dark {
     .top-bar__wrapper {
       background: $neutral-dark;
+      border-color: $neutral-dark;
       color: white;
     }
     .top-bar__action,


### PR DESCRIPTION
### 💬 Description
Topbars using the dark theme retain the lighter bottom border. This PR fixes that.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
