### PR TITLE
Adding new autoposition side prop

### DIFF
--- a/lib/Dropdown/DropdownContent.js
+++ b/lib/Dropdown/DropdownContent.js
@@ -55,7 +55,7 @@ class DropdownContent extends Component {
         : newPos;
     }
 
-    return bounds.right;
+    return this.props.autoPositionLeft ? bounds.left : bounds.right;
   };
 
   getStyle = () => {
@@ -154,7 +154,8 @@ DropdownContent.propTypes = {
   top: PropTypes.bool,
   fixRight: PropTypes.bool,
   full: PropTypes.bool,
-  noBorder: PropTypes.bool
+  noBorder: PropTypes.bool,
+  autoPositionLeft: PropTypes.bool
 };
 
 DropdownContent.defaultProps = {
@@ -165,7 +166,8 @@ DropdownContent.defaultProps = {
   top: false,
   fixRight: false,
   full: false,
-  noBorder: false
+  noBorder: false,
+  autoPositionLeft: false
 };
 
 export default DropdownContent;


### PR DESCRIPTION
### 💬 Description
Just a new prop to decide where you want your autopositioned dropdown to appear. It used to default to the right of the trigger, but now we can align it to the left with this prop!

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
