### PR TITLE
Feature/repeatable buttons loader

### DIFF
--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -1,19 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { bool, func } from 'prop-types';
 import { ButtonSecondary } from '../ButtonNew/ButtonSecondary/ButtonSecondary';
 import Icon from '../Icon';
 import { FieldMainColumn } from './FieldMainColumn';
+import { useLoader } from './useLoader';
 
 export function FieldRepeatButton({ repeatLimitReached, onClick }) {
-  const [loading, setLoading] = useState(false);
-
-  const onClickLoader = () => {
-    if (loading) {
-      return;
-    }
-    setLoading(true);
-    onClick(() => setLoading(false));
-  };
+  const [loading, onClickLoader] = useLoader(onClick);
 
   const button = repeatLimitReached ? (
     <ButtonSecondary disabled>Limit reached</ButtonSecondary>

--- a/lib/Field/FieldRepeatButton.js
+++ b/lib/Field/FieldRepeatButton.js
@@ -1,16 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { bool, func } from 'prop-types';
 import { ButtonSecondary } from '../ButtonNew/ButtonSecondary/ButtonSecondary';
 import Icon from '../Icon';
 import { FieldMainColumn } from './FieldMainColumn';
 
 export function FieldRepeatButton({ repeatLimitReached, onClick }) {
+  const [loading, setLoading] = useState(false);
+
+  const onClickLoader = () => {
+    if (loading) {
+      return;
+    }
+    setLoading(true);
+    onClick(() => setLoading(false));
+  };
+
   const button = repeatLimitReached ? (
     <ButtonSecondary disabled>Limit reached</ButtonSecondary>
   ) : (
-    <ButtonSecondary onClick={onClick}>
-      <Icon name="plus" />
-      <span className="w-2" />
+    <ButtonSecondary onClick={onClickLoader} loading={loading}>
+      {!loading && <Icon name="plus" className="mr-2" />}
       Add another
     </ButtonSecondary>
   );

--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -3,6 +3,7 @@ import { bool, func, number, shape } from 'prop-types';
 import cx from 'classnames';
 import { ButtonIcon } from '../ButtonNew/ButtonIcon/ButtonIcon';
 import { ButtonIconDanger } from '../ButtonNew/ButtonIcon/ButtonIconDanger';
+import { useLoader } from './useLoader';
 
 export function FieldRepeatableControls({
   repeatPosition,
@@ -23,30 +24,40 @@ export function FieldRepeatableControls({
     }
   );
 
+  const [isDeleting, onDeleteRepeatedFieldLoader] = useLoader(
+    onDeleteRepeatedField
+  );
+  const [isMovingUp, onMoveRepeatedFieldUpLoader] = useLoader(
+    onMoveRepeatedFieldUp
+  );
+  const [isMovingDown, onMoveRepeatedFieldDownLoader] = useLoader(
+    onMoveRepeatedFieldDown
+  );
+
   return (
     <div className="flex justify-end">
       {repeatPosition > 0 && controls.trash && (
         <ButtonIconDanger
-          name="trash"
+          name={isDeleting ? 'loader16' : 'trash'}
           className={buttonClasses}
           size={ButtonIconDanger.sizes.sm}
-          onClick={onDeleteRepeatedField}
+          onClick={onDeleteRepeatedFieldLoader}
         />
       )}
       {repeatPosition > 0 && controls.reorder && (
         <ButtonIcon
-          name="arrowUp"
+          name={isMovingUp ? 'loader16' : 'arrowUp'}
           className={buttonClasses}
           size={ButtonIcon.sizes.sm}
-          onClick={onMoveRepeatedFieldUp}
+          onClick={onMoveRepeatedFieldUpLoader}
         />
       )}
       {!isLastRepeat && controls.reorder && (
         <ButtonIcon
-          name="arrowDown"
+          name={isMovingDown ? 'loader16' : 'arrowDown'}
           className={buttonClasses}
           size={ButtonIcon.sizes.sm}
-          onClick={onMoveRepeatedFieldDown}
+          onClick={onMoveRepeatedFieldDownLoader}
         />
       )}
       <span className="w-1" />

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -54,16 +54,16 @@ storiesOf('Components', module).add('Field', () => {
     FieldNew.statuses.UNCHANGED
   );
 
-  const actionWithCallback = (name, timeout = 1500) => callback => {
+  const actionWithDuration = (name, timeout = 1500) => () => {
     action(name)();
-    setTimeout(callback, timeout);
+    return new Promise(resolve => setTimeout(resolve, timeout));
   };
 
   const sharedRepeatableFieldControls = {
     isActive: status === FieldNew.statuses.ACTIVE,
-    onDeleteRepeatedField: actionWithCallback('delete repeated field'),
-    onMoveRepeatedFieldUp: actionWithCallback('move repeated field up'),
-    onMoveRepeatedFieldDown: actionWithCallback('move repeated field down'),
+    onDeleteRepeatedField: actionWithDuration('delete repeated field'),
+    onMoveRepeatedFieldUp: actionWithDuration('move repeated field up'),
+    onMoveRepeatedFieldDown: actionWithDuration('move repeated field down'),
     controls: {
       reorder: boolean('Include move up and move down controls', true),
       trash: boolean('Include trash control', true)
@@ -325,10 +325,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.ConnectorLine />
               <FieldNew.RepeatButton
                 repeatLimitReached={boolean('Repeat limit reached', false)}
-                onClick={callback => {
-                  action('repeat field')();
-                  setTimeout(callback, 2000);
-                }}
+                onClick={actionWithDuration('repeat field')}
               />
             </>
           )}

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -336,7 +336,10 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.ConnectorLine />
               <FieldNew.RepeatButton
                 repeatLimitReached={boolean('Repeat limit reached', false)}
-                onClick={action('repeat field')}
+                onClick={callback => {
+                  action('repeat field')();
+                  setTimeout(callback, 2000);
+                }}
               />
             </>
           )}

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -54,11 +54,21 @@ storiesOf('Components', module).add('Field', () => {
     FieldNew.statuses.UNCHANGED
   );
 
-  const controlsReorder = boolean(
-    'Include move up and move down controls',
-    true
-  );
-  const controlsTrash = boolean('Include trash control', true);
+  const actionWithCallback = (name, timeout = 1500) => callback => {
+    action(name)();
+    setTimeout(callback, timeout);
+  };
+
+  const sharedRepeatableFieldControls = {
+    isActive: status === FieldNew.statuses.ACTIVE,
+    onDeleteRepeatedField: actionWithCallback('delete repeated field'),
+    onMoveRepeatedFieldUp: actionWithCallback('move repeated field up'),
+    onMoveRepeatedFieldDown: actionWithCallback('move repeated field down'),
+    controls: {
+      reorder: boolean('Include move up and move down controls', true),
+      trash: boolean('Include trash control', true)
+    }
+  };
 
   const isRepeatable = boolean('Is repeatable?', true);
   return (
@@ -77,14 +87,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.RepeatableControls
                 repeatPosition={0}
                 isLastRepeat={false}
-                isActive={status === FieldNew.statuses.ACTIVE}
-                onDeleteRepeatedField={action('delete repeated field')}
-                onMoveRepeatedFieldUp={action('move repeated field up')}
-                onMoveRepeatedFieldDown={action('move repeated field down')}
-                controls={{
-                  reorder: controlsReorder,
-                  trash: controlsTrash
-                }}
+                {...sharedRepeatableFieldControls}
               />
             )}
             <FieldNew.Label
@@ -167,14 +170,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.RepeatableControls
                 repeatPosition={1}
                 isLastRepeat={false}
-                isActive={status === FieldNew.statuses.ACTIVE}
-                onDeleteRepeatedField={action('delete repeated field')}
-                onMoveRepeatedFieldUp={action('move repeated field up')}
-                onMoveRepeatedFieldDown={action('move repeated field down')}
-                controls={{
-                  reorder: controlsReorder,
-                  trash: controlsTrash
-                }}
+                {...sharedRepeatableFieldControls}
               />
             )}
             <FieldNew.Label
@@ -256,14 +252,7 @@ storiesOf('Components', module).add('Field', () => {
               <FieldNew.RepeatableControls
                 repeatPosition={2}
                 isLastRepeat
-                isActive={status === FieldNew.statuses.ACTIVE}
-                onDeleteRepeatedField={action('delete repeated field')}
-                onMoveRepeatedFieldUp={action('move repeated field up')}
-                onMoveRepeatedFieldDown={action('move repeated field down')}
-                controls={{
-                  reorder: controlsReorder,
-                  trash: controlsTrash
-                }}
+                {...sharedRepeatableFieldControls}
               />
             )}
             <FieldNew.Label

--- a/lib/Field/useLoader.js
+++ b/lib/Field/useLoader.js
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+export function useLoader(action, isInitiallyLoading = false) {
+  const [isLoading, setIsLoading] = useState(isInitiallyLoading);
+
+  const actionLoader = () => {
+    if (isLoading) {
+      return;
+    }
+    setIsLoading(true);
+    action(() => setIsLoading(false));
+  };
+  return [isLoading, actionLoader];
+}

--- a/lib/Field/useLoader.js
+++ b/lib/Field/useLoader.js
@@ -3,12 +3,13 @@ import { useState } from 'react';
 export function useLoader(action, isInitiallyLoading = false) {
   const [isLoading, setIsLoading] = useState(isInitiallyLoading);
 
-  const actionLoader = () => {
+  const actionLoader = async () => {
     if (isLoading) {
       return;
     }
     setIsLoading(true);
-    action(() => setIsLoading(false));
+    await action();
+    setIsLoading(false);
   };
   return [isLoading, actionLoader];
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,3 +142,4 @@ export { OptionMenu } from './OptionMenu/OptionMenu';
 export ButtonIconBubble from './ButtonNew/ButtonIcon/ButtonIconBubble';
 export { Layout } from './Layout';
 export { Select } from './Select/Select';
+export { useLoader } from './Field/useLoader';


### PR DESCRIPTION
### 💬 Description
When someone repeats/moves/deletes a repeatable field in the content editor we should show a loading state on the button.

I've introduced a `useLoader(action, initialState = false)` hook as an abstraction over the isLoading state - this is where the magic happens... 
It basically is a wrapper around a `useState()` and `isLoading` boolean, and returns a tuple of `isLoading :bool` and `actionLoader: func`. It takes a callable `action` - this is what we want to be called when we trigger `actionLoader`.

When we first trigger `actionLoader`, say by passing it to a button onClick handler, we set the state of `isLoading` to `true` and call `action`.

Any further calls to `actionLoader` are ignored, for as long as `isLoading` is `true` - this prevents double/multiple clicking errors.

The return value from triggering `actionLoader` is a function, than when called will revert the state of `isLoading` back to `false`. See the storybook for a fuller example.

This could potentially be abstracted even further in the future into a `<ButtonWithLoader>` component, or composable `withLoader()` function... but don't want to prematurely do that. Not sure the best place for this hook to live, seems like it _may_ be a useful pattern in other places?

### 📹 GIF (optional)

![Screen Recording 2020-06-12 at 06 55 pm](https://user-images.githubusercontent.com/3472717/84533980-0fbec100-ace1-11ea-9cf1-358e5540f60f.gif)

### 🚪 Start Points
The first couple of commits

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
