### PR TITLE
Stop TabsScrollShadow effecting the hit area of the Tabs behind it

### DIFF
--- a/lib/TabsNew/TabsScrollShadow.js
+++ b/lib/TabsNew/TabsScrollShadow.js
@@ -6,7 +6,7 @@ import { useSpring, animated } from 'react-spring';
 export function TabsScrollShadow({ scrollPosition }) {
   const props = useSpring({ opacity: 1, from: { opacity: 0 } });
 
-  const className = cx('absolute w-full h-4 -mr-4 ', {
+  const className = cx('absolute w-full h-4 -mr-4 pointer-events-none', {
     'top-0 shadow-top-inset': scrollPosition === 'bottom',
     'bottom-0 shadow-bottom-inset': scrollPosition === 'top'
   });


### PR DESCRIPTION
### 💬 Description
Easy one

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
