### PR TITLE
Only update state if component is still mounted

### DIFF
--- a/lib/Field/useLoader.js
+++ b/lib/Field/useLoader.js
@@ -1,15 +1,30 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export function useLoader(action, isInitiallyLoading = false) {
   const [isLoading, setIsLoading] = useState(isInitiallyLoading);
+
+  const isMounted = useRef(true);
+
+  useEffect(
+    () => () => {
+      isMounted.current = false;
+    },
+    []
+  );
 
   const actionLoader = async () => {
     if (isLoading) {
       return;
     }
+
     setIsLoading(true);
+
     await action();
-    setIsLoading(false);
+
+    if (isMounted.current) {
+      setIsLoading(false);
+    }
   };
+
   return [isLoading, actionLoader];
 }


### PR DESCRIPTION
### 💬 Description
`setIsLoading()` comes from `useState()` which will trigger a rerender when called. If the component has been unmounted already, this will throw a warning about memory leaks. We only really want to call `setIsLoading()` if the component is still mounted. So we'll `useRef` to a boolean to keep track of whether the component `isMounted`, and use a `useEffect` to update `isMounted` when the component is unmounted.

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
