### PR TITLE
Alter the calculations for TabNameForm

### DIFF
--- a/lib/TabsNew/Tab.js
+++ b/lib/TabsNew/Tab.js
@@ -24,10 +24,13 @@ function Tab({ children, id, index }) {
     }
   );
 
-  const wrapperClasses = cx(`flex relative group ${borderClasses}`, {
-    'bg-neutral-95 hover:bg-neutral-90': !isActive,
-    'bg-white': isActive
-  });
+  const wrapperClasses = cx(
+    `flex relative group overflow-hidden ${borderClasses}`,
+    {
+      'bg-neutral-95 hover:bg-neutral-90': !isActive,
+      'bg-white': isActive
+    }
+  );
 
   const tabClasses = cx(
     'flex items-center no-underline outline-none border-0 font-semi-bold h-full bg-transparent w-full px-2',
@@ -38,6 +41,7 @@ function Tab({ children, id, index }) {
   );
 
   const sharedState = {
+    id,
     isActive,
     actionsAreActive,
     setActionsAreActive,

--- a/lib/TabsNew/TabAside.js
+++ b/lib/TabsNew/TabAside.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import { TabContext } from './Tab';
 
 function TabAside({ children }) {
-  const { isActive, isEditing } = useContext(TabContext);
+  const { isActive, isEditing, actionsAreActive } = useContext(TabContext);
 
   const asideClassNames = cx(
     'absolute right-0 top-0 bottom-0 flex items-center justify-end pointer-events-none z-10',
@@ -13,7 +13,8 @@ function TabAside({ children }) {
       'bg-blur-grey-95-right group-hover:bg-blur-grey-90-right': !isActive,
       'w-10 group-hover:w-16': children && !isActive,
       'w-16 pr-2': children && isActive,
-      'w-10': !children
+      'w-10': !children,
+      'z-20': actionsAreActive
     }
   );
 

--- a/lib/TabsNew/TabAside.js
+++ b/lib/TabsNew/TabAside.js
@@ -13,22 +13,17 @@ function TabAside({ children }) {
       'bg-blur-grey-95-right group-hover:bg-blur-grey-90-right': !isActive,
       'w-10 group-hover:w-16': children && !isActive,
       'w-16 pr-2': children && isActive,
-      'w-10': !children,
+      'w-10': !children
     }
   );
 
-  const innerClassNames = cx(
-    'flex items-center pointer-events-auto h-full',
-    {
-      'mr-2': children && !isActive,
-    }
-  );
+  const innerClassNames = cx('flex items-center pointer-events-auto', {
+    'mr-2': children && !isActive
+  });
 
   return isEditing ? null : (
     <div className={asideClassNames}>
-      <div className={innerClassNames}>
-        {children}
-      </div>
+      <div className={innerClassNames}>{children}</div>
     </div>
   );
 }

--- a/lib/TabsNew/TabNameForm.js
+++ b/lib/TabsNew/TabNameForm.js
@@ -9,9 +9,12 @@ export function TabNameForm({
   className,
   initialName,
   setActiveTab,
-  submitTabForm
+  submitTabForm,
+  placeholder
 }) {
-  const { setIsEditing, formInputRef } = useContext(TabContext);
+  const { id, isEditing, setIsEditing, formInputRef, isActive } = useContext(
+    TabContext
+  );
   const { tabsLength } = useContext(TabsContext);
   const [tabName, setTabName] = useState(initialName);
   const nameToSet = tabName.trim();
@@ -35,12 +38,26 @@ export function TabNameForm({
 
   const valueWithWhitespaceUnicode = tabName.replace(/ /g, '\u00a0');
 
-  const inputBorderClasses =
-    'border-solid border-transparent hover:border-neutral-90 focus:border-2 focus:border-blue-primary';
-  const inputClassName = cx(
-    inputBorderClasses,
-    'block rounded outline-none px-2 z-10 bg-transparent'
+  const sharedClassNames = cx(
+    'border-solid block rounded outline-none px-2 z-10 bg-transparent',
+    {
+      'border border-transparent hover:border-neutral-90': !isEditing,
+      'border-2 border-blue-primary': isEditing
+    }
   );
+
+  const labelClassNames = cx(
+    sharedClassNames,
+    'cursor-pointer px-0 max-w-full text-center',
+    {
+      'pointer-events-none': !isActive,
+      'invisible fixed': isEditing
+    }
+  );
+
+  const inputClassNames = cx(sharedClassNames, {
+    '-mt-8 absolute': !isEditing
+  });
 
   const resetTabForm = () => {
     setTabName(initialName);
@@ -70,17 +87,21 @@ export function TabNameForm({
         className="absolute w-full h-full border-0 bg-transparent outline-none"
       />
       <form
-        className={`${className} px-0`}
+        className={className}
         onSubmit={e => {
           e.preventDefault();
           formInputRef.current.blur();
         }}
       >
         <Tabs.TabName className="flex justify-center items-center">
+          <label htmlFor={id} ref={contentRef} className={labelClassNames}>
+            {valueWithWhitespaceUnicode || placeholder}
+          </label>
           <input
+            id={id}
             type="text"
             value={tabName}
-            className={`border ${inputClassName}`}
+            className={inputClassNames}
             onChange={e => setTabName(e.target.value)}
             onFocus={e => {
               setIsEditing(true);
@@ -94,14 +115,9 @@ export function TabNameForm({
               width: inputWidth
             }}
             ref={formInputRef}
-            placeholder="Name this tab"
+            placeholder={placeholder}
+            disabled={!isActive}
           />
-          <div
-            ref={contentRef}
-            className={`border-2 ${inputClassName} invisible fixed`}
-          >
-            {valueWithWhitespaceUnicode}
-          </div>
         </Tabs.TabName>
         <ShortcutTrigger
           shortcutKey="Escape"
@@ -113,6 +129,7 @@ export function TabNameForm({
 }
 
 TabNameForm.propTypes = {
+  placeholder: string,
   initialName: string,
   className: string,
   setActiveTab: func.isRequired,
@@ -120,6 +137,7 @@ TabNameForm.propTypes = {
 };
 
 TabNameForm.defaultProps = {
+  placeholder: 'Name this tab',
   initialName: '',
   className: ''
 };

--- a/lib/TabsNew/TabNameForm.js
+++ b/lib/TabsNew/TabNameForm.js
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-  Fragment
-} from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { string, func } from 'prop-types';
 import cx from 'classnames';
 import { TabContext } from './Tab';
@@ -24,22 +18,28 @@ export function TabNameForm({
 
   const contentRef = useRef(null);
   const [inputWidth, setInputWidth] = useState(null);
-  const placeholderWidth = 120;
+  const placeholderWidth = 122;
 
   useEffect(() => {
     if (contentRef.current) {
+      const padding = 1;
       const parentWidth = contentRef.current.parentNode.offsetWidth;
       const newWidth = contentRef.current.offsetWidth;
       const newInputWidth = newWidth >= parentWidth ? parentWidth : newWidth;
 
-      setInputWidth(`${tabName === '' ? placeholderWidth : newInputWidth}px`);
+      setInputWidth(
+        `${tabName === '' ? placeholderWidth : newInputWidth + padding}px`
+      );
     }
   }, [tabName, tabsLength]);
 
   const valueWithWhitespaceUnicode = tabName.replace(/ /g, '\u00a0');
 
+  const inputBorderClasses =
+    'border-solid border-transparent hover:border-neutral-90 focus:border-2 focus:border-blue-primary';
   const inputClassName = cx(
-    'border-solid border-transparent border outline hover:border-neutral-90 focus:border-2 focus:border-blue-primary rounded outline-none px-2 z-10 bg-transparent'
+    inputBorderClasses,
+    'block rounded outline-none px-2 z-10 bg-transparent'
   );
 
   const resetTabForm = () => {
@@ -63,7 +63,7 @@ export function TabNameForm({
   };
 
   return (
-    <Fragment>
+    <>
       <button
         type="button"
         onClick={setActiveTab}
@@ -76,11 +76,11 @@ export function TabNameForm({
           formInputRef.current.blur();
         }}
       >
-        <Tabs.TabName className="flex justify-center items-center px-2">
+        <Tabs.TabName className="flex justify-center items-center">
           <input
             type="text"
             value={tabName}
-            className={inputClassName}
+            className={`border ${inputClassName}`}
             onChange={e => setTabName(e.target.value)}
             onFocus={e => {
               setIsEditing(true);
@@ -96,7 +96,10 @@ export function TabNameForm({
             ref={formInputRef}
             placeholder="Name this tab"
           />
-          <div ref={contentRef} className={`${inputClassName} invisible fixed`}>
+          <div
+            ref={contentRef}
+            className={`border-2 ${inputClassName} invisible fixed`}
+          >
             {valueWithWhitespaceUnicode}
           </div>
         </Tabs.TabName>
@@ -105,7 +108,7 @@ export function TabNameForm({
           onShortcutTrigger={resetTabForm}
         />
       </form>
-    </Fragment>
+    </>
   );
 }
 

--- a/lib/TabsNew/TabOptions.js
+++ b/lib/TabsNew/TabOptions.js
@@ -44,6 +44,7 @@ function TabOptions({ children }) {
                   }}
                   size={ButtonIcon.sizes.sm}
                   className={iconClassNames}
+                  active={showContent}
                 />
               )}
             </Dropdown.Trigger>

--- a/lib/TabsNew/TabsActionGroup.js
+++ b/lib/TabsNew/TabsActionGroup.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { node, string } from 'prop-types';
 
 function TabsActionGroup({ children, className }) {
-  return <div className={`absolute right-0 mr-4 ${className}`}>{children}</div>;
+  return <div className={`absolute right-0 mr-8 ${className}`}>{children}</div>;
 }
 
 export { TabsActionGroup };

--- a/stories/components/Tabs.js
+++ b/stories/components/Tabs.js
@@ -44,6 +44,7 @@ function TabsStory({ tabs, dragSide, dragIndex, editable }) {
                           e.preventDefault();
                           setActiveTabId(t.id);
                         }}
+                        submitTabForm={() => {}}
                       />
                     )}
 
@@ -86,7 +87,7 @@ function TabsStory({ tabs, dragSide, dragIndex, editable }) {
 }
 
 storiesOf('Components', module).add('Tabs', () => {
-  const editable = boolean('EDIT DAT SHIT', false);
+  const editable = boolean('Is editable', true);
   const tabsNumber = number('Total number of tabs', 3);
   const groupId = 'Drag And Drop';
 


### PR DESCRIPTION
### 💬 Description
This PR fixes a number of issues with tabs;

- when focusing on `TabFormForm` the input width was set incorrectly for the placeholder
- when changing the value in `TabFormForm` the input width was set incorrectly due to the clone not having borders.
- fixes a bug with the story that stopped the `isEditing` context being correctly set when saving the form.
- updates the active prop to the dropdown trigger
- fixes issue where area above and below trigger wasn't clickable

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
