### PR TITLE
Extra margin and z-index in tabs

### DIFF
--- a/lib/TabsNew/TabAside.js
+++ b/lib/TabsNew/TabAside.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import { TabContext } from './Tab';
 
 function TabAside({ children }) {
-  const { isActive, isEditing } = useContext(TabContext);
+  const { isActive, isEditing, actionsAreActive } = useContext(TabContext);
 
   const asideClassNames = cx(
     'absolute right-0 top-0 bottom-0 flex items-center justify-end pointer-events-none z-10',
@@ -13,7 +13,8 @@ function TabAside({ children }) {
       'bg-blur-grey-95-right group-hover:bg-blur-grey-90-right': !isActive,
       'w-10 group-hover:w-16': children && !isActive,
       'w-16 pr-2': children && isActive,
-      'w-10': !children
+      'w-10': !children,
+      'z-20': actionsAreActive
     }
   );
 

--- a/lib/TabsNew/TabsActionGroup.js
+++ b/lib/TabsNew/TabsActionGroup.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { node, string } from 'prop-types';
 
 function TabsActionGroup({ children, className }) {
-  return <div className={`absolute right-0 mr-4 ${className}`}>{children}</div>;
+  return <div className={`absolute right-0 mr-8 ${className}`}>{children}</div>;
 }
 
 export { TabsActionGroup };


### PR DESCRIPTION
### 💬 Description
Two fixes here:

- When the dropdown is active, we need to increase the z-index so they appear over the other tabs.

- The tabs actions should also have more of a right margin to move it further from the scroll bar.


### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
