### PR TITLE
Improve the label to form interactions

### DIFF
--- a/lib/TabsNew/Tab.js
+++ b/lib/TabsNew/Tab.js
@@ -38,6 +38,7 @@ function Tab({ children, id, index }) {
   );
 
   const sharedState = {
+    id,
     isActive,
     actionsAreActive,
     setActionsAreActive,

--- a/lib/TabsNew/Tab.js
+++ b/lib/TabsNew/Tab.js
@@ -24,10 +24,13 @@ function Tab({ children, id, index }) {
     }
   );
 
-  const wrapperClasses = cx(`flex relative group ${borderClasses}`, {
-    'bg-neutral-95 hover:bg-neutral-90': !isActive,
-    'bg-white': isActive
-  });
+  const wrapperClasses = cx(
+    `flex relative group overflow-hidden ${borderClasses}`,
+    {
+      'bg-neutral-95 hover:bg-neutral-90': !isActive,
+      'bg-white': isActive
+    }
+  );
 
   const tabClasses = cx(
     'flex items-center no-underline outline-none border-0 font-semi-bold h-full bg-transparent w-full px-2',

--- a/lib/TabsNew/TabNameForm.js
+++ b/lib/TabsNew/TabNameForm.js
@@ -9,9 +9,12 @@ export function TabNameForm({
   className,
   initialName,
   setActiveTab,
-  submitTabForm
+  submitTabForm,
+  placeholder
 }) {
-  const { setIsEditing, formInputRef } = useContext(TabContext);
+  const { id, isEditing, setIsEditing, formInputRef, isActive } = useContext(
+    TabContext
+  );
   const { tabsLength } = useContext(TabsContext);
   const [tabName, setTabName] = useState(initialName);
   const nameToSet = tabName.trim();
@@ -35,12 +38,26 @@ export function TabNameForm({
 
   const valueWithWhitespaceUnicode = tabName.replace(/ /g, '\u00a0');
 
-  const inputBorderClasses =
-    'border-solid border-transparent hover:border-neutral-90 focus:border-2 focus:border-blue-primary';
-  const inputClassName = cx(
-    inputBorderClasses,
-    'block rounded outline-none px-2 z-10 bg-transparent'
+  const sharedClassNames = cx(
+    'border-solid block rounded outline-none px-2 z-10 bg-transparent',
+    {
+      'border border-transparent hover:border-neutral-90': !isEditing,
+      'border-2 border-blue-primary': isEditing
+    }
   );
+
+  const labelClassNames = cx(
+    sharedClassNames,
+    'cursor-pointer px-0 max-w-full text-center',
+    {
+      'pointer-events-none': !isActive,
+      'invisible fixed': isEditing
+    }
+  );
+
+  const inputClassNames = cx(sharedClassNames, {
+    '-mt-8 absolute': !isEditing
+  });
 
   const resetTabForm = () => {
     setTabName(initialName);
@@ -70,17 +87,21 @@ export function TabNameForm({
         className="absolute w-full h-full border-0 bg-transparent outline-none"
       />
       <form
-        className={`${className} px-0`}
+        className={`${className} px-00`}
         onSubmit={e => {
           e.preventDefault();
           formInputRef.current.blur();
         }}
       >
         <Tabs.TabName className="flex justify-center items-center">
+          <label htmlFor={id} ref={contentRef} className={labelClassNames}>
+            {valueWithWhitespaceUnicode || placeholder}
+          </label>
           <input
+            id={id}
             type="text"
             value={tabName}
-            className={`border ${inputClassName}`}
+            className={inputClassNames}
             onChange={e => setTabName(e.target.value)}
             onFocus={e => {
               setIsEditing(true);
@@ -94,14 +115,9 @@ export function TabNameForm({
               width: inputWidth
             }}
             ref={formInputRef}
-            placeholder="Name this tab"
+            placeholder={placeholder}
+            disabled={!isActive}
           />
-          <div
-            ref={contentRef}
-            className={`border-2 ${inputClassName} invisible fixed`}
-          >
-            {valueWithWhitespaceUnicode}
-          </div>
         </Tabs.TabName>
         <ShortcutTrigger
           shortcutKey="Escape"
@@ -113,6 +129,7 @@ export function TabNameForm({
 }
 
 TabNameForm.propTypes = {
+  placeholder: string,
   initialName: string,
   className: string,
   setActiveTab: func.isRequired,
@@ -120,6 +137,7 @@ TabNameForm.propTypes = {
 };
 
 TabNameForm.defaultProps = {
+  placeholder: 'Name this tab',
   initialName: '',
   className: ''
 };

--- a/lib/TabsNew/TabNameForm.js
+++ b/lib/TabsNew/TabNameForm.js
@@ -87,7 +87,7 @@ export function TabNameForm({
         className="absolute w-full h-full border-0 bg-transparent outline-none"
       />
       <form
-        className={`${className} px-00`}
+        className={className}
         onSubmit={e => {
           e.preventDefault();
           formInputRef.current.blur();


### PR DESCRIPTION
### 💬 Description
For tabs, we don't want the form to be focused until the tab is active. We've also improved the usability by adding a label. This PR also fixes inconsistencies with the label / input classes.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
