### PR TITLE
Fix usage of tabs readable class name

### DIFF
--- a/lib/TabsNew/index.js
+++ b/lib/TabsNew/index.js
@@ -42,7 +42,7 @@ function Tabs({ children, className, tabsLength, activeTabId }) {
             setScrollPosition('middle');
           }
         }}
-        className={`tabs relative ${className} ${scrollPosition}`}
+        className={`tabs-new relative ${className} ${scrollPosition}`}
       >
         {children}
         {tabsLength > 24 && (


### PR DESCRIPTION
### 💬 Description
Tabs was already being used as a legit class! So now it's `tabs-new`

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
