### PR TITLE
Add example for renaming via a dropdown action

### DIFF
--- a/lib/TabsNew/TabNameForm.js
+++ b/lib/TabsNew/TabNameForm.js
@@ -55,13 +55,14 @@ export function TabNameForm({
     sharedClassNames,
     'cursor-pointer px-0 max-w-full text-center',
     {
+      '-mt-8 absolute': isActive,
       'pointer-events-none': !isActive,
       'invisible fixed': isEditing
     }
   );
 
   const inputClassNames = cx(sharedClassNames, 'tab-name-input', {
-    '-mt-8 absolute': !isEditing
+    '-mt-8 absolute': !isActive
   });
 
   const resetTabForm = () => {
@@ -122,7 +123,6 @@ export function TabNameForm({
             }}
             ref={formInputRef}
             placeholder={placeholder}
-            disabled={!isActive}
           />
         </Tabs.TabName>
         <ShortcutTrigger

--- a/lib/TabsNew/TabNameForm.js
+++ b/lib/TabsNew/TabNameForm.js
@@ -12,9 +12,14 @@ export function TabNameForm({
   submitTabForm,
   placeholder
 }) {
-  const { id, isEditing, setIsEditing, formInputRef, isActive } = useContext(
-    TabContext
-  );
+  const {
+    id,
+    isEditing,
+    setIsEditing,
+    formInputRef,
+    isActive,
+    setActionsAreActive
+  } = useContext(TabContext);
   const { tabsLength } = useContext(TabsContext);
   const [tabName, setTabName] = useState(initialName);
   const nameToSet = tabName.trim();
@@ -109,6 +114,7 @@ export function TabNameForm({
             }}
             onBlur={() => {
               submitForm();
+              setActionsAreActive(false);
               setIsEditing(false);
             }}
             style={{

--- a/stories/components/Tabs.js
+++ b/stories/components/Tabs.js
@@ -1,10 +1,26 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { storiesOf } from '@storybook/react';
 import { v4 } from 'uuid';
 import { boolean, number, select } from "@storybook/addon-knobs";
 import faker from 'faker';
 import { ButtonSecondary, Tabs } from 'lib';
 import Dropdown from '../../lib/Dropdown';
+import { TabContext } from "../../lib/TabsNew/Tab";
+
+function RenameTabActionExample() {
+  const { formInputRef } = useContext(TabContext);
+
+  return (
+    <Dropdown.ActionGroup className="text-neutral-20 font-normal">
+      <Dropdown.Action
+        className="text-neutral-20 weight-roman"
+        action={() => formInputRef.current.focus()}
+      >
+        Action text
+      </Dropdown.Action>
+    </Dropdown.ActionGroup>
+  )
+}
 
 // eslint-disable-next-line react/prop-types
 function TabsStory({ tabs, dragSide, dragIndex, editable }) {
@@ -51,14 +67,7 @@ function TabsStory({ tabs, dragSide, dragIndex, editable }) {
                     <Tabs.TabAside>
                       {editable && (
                         <Tabs.TabOptions>
-                          <Dropdown.ActionGroup className="text-neutral-20 font-normal">
-                            <Dropdown.Action
-                              className="text-neutral-20 weight-roman"
-                              action={() => {}}
-                            >
-                              Action text
-                            </Dropdown.Action>
-                          </Dropdown.ActionGroup>
+                          <RenameTabActionExample />
                         </Tabs.TabOptions>
                       )}
                     </Tabs.TabAside>


### PR DESCRIPTION
### 💬 Description
It wasn't clear how we can use a dropdown action to focus the tab name form so this PR adds to the story to make that clearer.

It also fixes an issue where we weren't setting the actions to close after hiding blurring the input causing a strange background colour issue with the options cog.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
