### PR TITLE
Increasing the z-index of action groups to appear over the fade

### DIFF
--- a/lib/TabsNew/TabsActionGroup.js
+++ b/lib/TabsNew/TabsActionGroup.js
@@ -3,7 +3,9 @@ import { node, string } from 'prop-types';
 
 function TabsActionGroup({ children, className }) {
   return (
-    <div className={`tabs-action-group absolute right-0 mr-8 ${className}`}>
+    <div
+      className={`tabs-action-group absolute right-0 mr-8 z-10 ${className}`}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
### 💬 Description
The title says it all, but heres a longer explanation.

The New Tab button's focus state is behind the fade, so increasing it's z-index is going to place it infront and on top of that fade.

<img width="212" alt="Screenshot 2020-06-22 at 14 47 44" src="https://user-images.githubusercontent.com/33638789/85295097-5ce82300-b497-11ea-90aa-165be2442245.png">

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
