### PR TITLE
Fix tab gradients in safari

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -204,7 +204,7 @@ module.exports = {
       ],
       'blur-white-right': [
         'to right',
-        'rgba(255,255,255,1) 0%',
+        'rgba(#fff, 0) 0%',
         'rgba(255,255,255,1) 50%'
       ],
       'blur-grey-90-right': [

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -204,17 +204,17 @@ module.exports = {
       ],
       'blur-white-right': [
         'to right',
-        'rgba(255,255,255,0) 0%',
+        'rgba(255,255,255,1) 0%',
         'rgba(255,255,255,1) 50%'
       ],
       'blur-grey-90-right': [
         'to right',
-        'rgba(255,255,255,0) 0%',
+        'rgba(#E1E6EB, 0)',
         '#E1E6EB 50%'
       ],
       'blur-grey-95-right': [
         'to right',
-        'rgba(255,255,255,0) 0%',
+        'rgba(#F0F2F5, 0)',
         '#F0F2F5 50%'
       ]
     }


### PR DESCRIPTION
### 💬 Description
Using a different colour to the one at the other end of the gradient even if it's transparent causes issues in safari. This PR fixes that by setting both ends of the gradient to the same colour.

Here's some material I found on the issue: https://ambientimpact.com/web/snippets/safari-bug-with-gradients-that-fade-to-transparent

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
