### PR TITLE
Creating generic class for pseudo border

### DIFF
--- a/styles/helpers/_borders.scss
+++ b/styles/helpers/_borders.scss
@@ -1,0 +1,17 @@
+.multiple-borders-blue-2px {
+  @include before-border(
+    2px,
+    solid,
+    theme('colors.blue.primary'),
+    theme('borderRadius.default')
+  );
+}
+
+.multiple-borders-grey-1px {
+  @include before-border(
+    1px,
+    solid,
+    theme('colors.neutral.90'),
+    theme('borderRadius.default')
+  );
+}

--- a/styles/helpers/_borders.scss
+++ b/styles/helpers/_borders.scss
@@ -1,4 +1,4 @@
-.multiple-borders-blue-2px {
+.pseudo-border-blue-2px {
   @include before-border(
     2px,
     solid,
@@ -7,7 +7,16 @@
   );
 }
 
-.multiple-borders-grey-1px {
+.pseudo-border-red-2px {
+  @include before-border(
+    2px,
+    solid,
+    theme('colors.red.primary'),
+    theme('borderRadius.default')
+  );
+}
+
+.pseudo-border-grey-1px {
   @include before-border(
     1px,
     solid,

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -1,4 +1,4 @@
-@import "tailwind";
+@import 'tailwind';
 
 /* ==========================================================================
    @ Settings
@@ -56,6 +56,7 @@
 @import 'helpers/selected';
 @import 'helpers/forms';
 @import 'helpers/lists';
+@import 'helpers/borders';
 
 /* ==========================================================================
    @ Overrides


### PR DESCRIPTION
### 💬 Description
There have been a few designs lately that have required both a 2px blue border (for focus) and a 1px grey border (for blur) on inputs. We have previously had workarounds that involved fun times with padding. I then remembered we fixed it for hierarchy many moons ago. This PR takes that fix and makes a generic class in helpers that can be used elsewhere!

It now also uses the tailwind theme for colours, wahay!

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
