### PR TITLE
Added a new prop to handle the height of a layout

### DIFF
--- a/lib/Layout/index.js
+++ b/lib/Layout/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { node, string } from 'prop-types';
+import { node, string, bool } from 'prop-types';
+import cx from 'classnames';
 import { Body } from './Body';
 import { Footer } from './Footer';
 import { Header } from './Header';
@@ -9,21 +10,22 @@ import { Sidebar } from '../Sidebar/Sidebar';
 import { InlineSidebar } from './InlineSidebar';
 import { Section } from './Section';
 
-function Layout({ children, className }) {
-  return (
-    <div className={`h-screen flex flex-col overflow-x-hidden ${className}`}>
-      {children}
-    </div>
-  );
+function Layout({ children, className, fullScreen }) {
+  const layoutClassName = cx('flex flex-col overflow-x-hidden', className, {
+    'h-screen': fullScreen
+  });
+  return <div className={layoutClassName}>{children}</div>;
 }
 
 Layout.propTypes = {
   children: node.isRequired,
-  className: string
+  className: string,
+  fullScreen: bool
 };
 
 Layout.defaultProps = {
-  className: ''
+  className: '',
+  fullScreen: true
 };
 
 Layout.Header = Header;


### PR DESCRIPTION
### 💬 Description
Our layout was a bit too rigid, it always had the height set the same as the view height. It meant we couldn't use it in other places that have similar layouts.

I originally tried just passing `h-full` into the `className` prop, but this is tailwind and it don't override. Instead I've added a prop that defaults to `true` (So there's no other refactoring), that will set that height to full screen.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
