### PR TITLE
ButtonBase children function

### DIFF
--- a/lib/ButtonNew/ButtonBase.js
+++ b/lib/ButtonNew/ButtonBase.js
@@ -29,6 +29,10 @@ function ButtonBase({
     }
   );
 
+  if (typeof children === 'function') {
+    return children(classes);
+  }
+
   return (
     <button className={classes} {...rest}>
       {loading && !loaderRight && (

--- a/lib/ButtonNew/common.js
+++ b/lib/ButtonNew/common.js
@@ -1,4 +1,4 @@
-import { string, node, bool, func } from 'prop-types';
+import { string, node, bool, func, oneOfType } from 'prop-types';
 import { omit } from 'lodash';
 
 export const sizes = {
@@ -15,7 +15,7 @@ export const getSizeClasses = size => {
 };
 
 export const propTypes = {
-  children: node.isRequired,
+  children: oneOfType([node, func]).isRequired,
   className: string,
   type: string,
   loading: bool,


### PR DESCRIPTION
### 💬 Description
ButtonBase now accepts a function as a child, and it will pass through the styles to that function. That means I could render an `<a>` with the `ButtonTertiary` styles and everything is hunky dory.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
