### PR TITLE
Conversation styling fixes

### DIFF
--- a/lib/Comment/Comment.js
+++ b/lib/Comment/Comment.js
@@ -17,11 +17,11 @@ import { CommentDeleteConfirmation } from './CommentDeleteConfirmation';
 function Comment({ children, className, ...rest }) {
   const { isOpen } = useContext(CommentContext);
   const classNames = cx('comment relative p-3', className, {
-    'border-t first:border-0 border-solid border-neutral-95': isOpen
+    'border-t-0 border-l-0 border-r-0 border-b border-solid border-neutral-95': isOpen
   });
 
   return (
-    <div className={`comment relative p-3 ${classNames}`} {...rest}>
+    <div className={classNames} {...rest}>
       {children}
     </div>
   );

--- a/lib/Comment/Comment.js
+++ b/lib/Comment/Comment.js
@@ -17,8 +17,7 @@ import { CommentDeleteConfirmation } from './CommentDeleteConfirmation';
 function Comment({ children, className, ...rest }) {
   const { isOpen } = useContext(CommentContext);
   const classNames = cx('comment relative p-3', className, {
-    'mb-2': !isOpen,
-    'border-t-0 border-l-0 border-r-0 border-b border-solid border-neutral-95': isOpen
+    'border-t first:border-0 border-solid border-neutral-95': isOpen
   });
 
   return (

--- a/lib/Comment/Comment.js
+++ b/lib/Comment/Comment.js
@@ -17,9 +17,8 @@ import { CommentDeleteConfirmation } from './CommentDeleteConfirmation';
 function Comment({ children, className, ...rest }) {
   const { isOpen, showBorders } = useContext(CommentContext);
   const classNames = cx('comment relative p-3', className, {
-    'border-t-0 border-l-0 border-r-0 border-b border-solid border-neutral-95':
-      isOpen || showBorders,
-    'group-hover:border-neutral-90': !isOpen && showBorders
+    'border-t-0 border-l-0 border-r-0 border-b border-solid border-neutral-90':
+      isOpen || showBorders
   });
 
   return (

--- a/lib/Comment/Comment.js
+++ b/lib/Comment/Comment.js
@@ -15,9 +15,11 @@ import { CommentContext, CommentProvider } from './CommentProvider';
 import { CommentDeleteConfirmation } from './CommentDeleteConfirmation';
 
 function Comment({ children, className, ...rest }) {
-  const { isOpen } = useContext(CommentContext);
+  const { isOpen, showBorders } = useContext(CommentContext);
   const classNames = cx('comment relative p-3', className, {
-    'border-t-0 border-l-0 border-r-0 border-b border-solid border-neutral-95': isOpen
+    'border-t-0 border-l-0 border-r-0 border-b border-solid border-neutral-95':
+      isOpen || showBorders,
+    'group-hover:border-neutral-90': !isOpen && showBorders
   });
 
   return (

--- a/lib/Comment/CommentActions.js
+++ b/lib/Comment/CommentActions.js
@@ -20,6 +20,7 @@ function CommentActions({ onEditClick, onRemoveClick }) {
                   active={showContent}
                   size={ButtonIcon.sizes.sm}
                   onClick={toggleShowContent}
+                  title="Edit or delete this comment"
                 />
               )}
             </Dropdown.Trigger>

--- a/lib/Comment/CommentActions.js
+++ b/lib/Comment/CommentActions.js
@@ -13,13 +13,14 @@ function CommentActions({ onEditClick, onRemoveClick }) {
       <Dropdown id="comment-actions">
         {({ showContent }) => (
           <>
-            <Dropdown.Trigger title="Edit or delete this comment">
+            <Dropdown.Trigger>
               {({ toggleShowContent }) => (
                 <ButtonIcon
                   name="menuDotted"
                   active={showContent}
                   size={ButtonIcon.sizes.sm}
                   onClick={toggleShowContent}
+                  title="Edit or delete this comment"
                 />
               )}
             </Dropdown.Trigger>

--- a/lib/Comment/CommentActions.js
+++ b/lib/Comment/CommentActions.js
@@ -13,14 +13,13 @@ function CommentActions({ onEditClick, onRemoveClick }) {
       <Dropdown id="comment-actions">
         {({ showContent }) => (
           <>
-            <Dropdown.Trigger>
+            <Dropdown.Trigger title="Edit or delete this comment">
               {({ toggleShowContent }) => (
                 <ButtonIcon
                   name="menuDotted"
                   active={showContent}
                   size={ButtonIcon.sizes.sm}
                   onClick={toggleShowContent}
-                  title="Edit or delete this comment"
                 />
               )}
             </Dropdown.Trigger>

--- a/lib/Comment/CommentProvider.js
+++ b/lib/Comment/CommentProvider.js
@@ -8,7 +8,8 @@ function CommentProvider({
   isOpen,
   isEditing: editing,
   isDeleting: deleting,
-  hasFailed: failed
+  hasFailed: failed,
+  showBorders
 }) {
   const [isEditing, setIsEditing] = useState(editing);
   const [isDeleting, setIsDeleting] = useState(deleting);
@@ -16,6 +17,7 @@ function CommentProvider({
 
   const sharedState = {
     isOpen,
+    showBorders,
     isEditing,
     setIsEditing,
     isDeleting,
@@ -34,6 +36,7 @@ function CommentProvider({
 CommentProvider.propTypes = {
   children: node.isRequired,
   isOpen: bool.isRequired,
+  showBorders: bool,
   isDeleting: bool,
   isEditing: bool,
   hasFailed: bool
@@ -42,7 +45,8 @@ CommentProvider.propTypes = {
 CommentProvider.defaultProps = {
   isDeleting: false,
   isEditing: false,
-  hasFailed: false
+  hasFailed: false,
+  showBorders: false
 };
 
 export { CommentProvider, CommentContext };

--- a/lib/Conversation/stories/ConversationBodyForStory.js
+++ b/lib/Conversation/stories/ConversationBodyForStory.js
@@ -19,7 +19,7 @@ function ConversationBodyForStory({ isOpen, commentHasFailedToSave }) {
 
   const comments = commentsToMap.map((c, index) => (
     <div key={c.id}>
-      <Comment.Provider isOpen={isOpen}>
+      <Comment.Provider isOpen={isOpen} showBorders={mockComments.length === 2}>
         <ExistingCommentExample
           comment={c}
           isFirst={index === 0}
@@ -27,7 +27,7 @@ function ConversationBodyForStory({ isOpen, commentHasFailedToSave }) {
         />
       </Comment.Provider>
 
-      {!isOpen && index === 0 && mockComments.length > 1 && (
+      {!isOpen && index === 0 && numberOfRepliesInbetween > 0 && (
         <Comment.ReplyCount count={numberOfRepliesInbetween} />
       )}
     </div>


### PR DESCRIPTION
### 💬 Description
This PR fixes a few styling issues with the new conversations refactor;

- Adds borders when there are only 2 comments in a thread
- Fixes border colours on comments
- Fixes story reply count usage (it was showing when there were no hidden replies)

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
