### PR TITLE
Fixing a conversations border focus

### DIFF
--- a/lib/Conversation/Conversation.js
+++ b/lib/Conversation/Conversation.js
@@ -9,7 +9,7 @@ function Conversation({ className, children, isOpen, isFocussed, ...rest }) {
   const innerClassName = cx(`${className} relative rounded w-full group`, {
     'shadow-small bg-white': isOpen,
     'cursor-pointer hover:bg-neutral-95 conversation__inactive': !isOpen,
-    'shadow-button-secondary-focus border border-solid border-primary-blue':
+    'shadow-button-secondary-focus border border-solid border-blue-primary':
       !isOpen && isFocussed,
     'border border-solid border-neutral-90': !isFocussed || isOpen
   });


### PR DESCRIPTION
### 💬 Description
The border for a focused conversation should be `border-blue-primary` and not `border-primary-blue`. Whoops!

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
