### PR TITLE
Update/refactor button border styles

### DIFF
--- a/lib/ButtonNew/ButtonBase.js
+++ b/lib/ButtonNew/ButtonBase.js
@@ -17,10 +17,10 @@ function ButtonBase({
   ...rest
 }) {
   const classes = cx(
-    'border-0 leading-4 rounded font-display font-semi-bold inline-flex items-center focus:outline-none',
+    'leading-4 rounded font-display font-semi-bold inline-flex items-center focus:outline-none',
     className,
     {
-      'rounded-r-none mr-0 border-r': connectedRight,
+      'rounded-r-none mr-0': connectedRight,
       'rounded-l-none ml-0': connectedLeft,
 
       'text-base py-3 px-4': size && size === sizes.md,

--- a/lib/ButtonNew/ButtonBase.js
+++ b/lib/ButtonNew/ButtonBase.js
@@ -17,7 +17,7 @@ function ButtonBase({
   ...rest
 }) {
   const classes = cx(
-    'leading-4 rounded font-display font-semi-bold inline-flex items-center focus:outline-none',
+    'border border-solid leading-4 rounded font-display font-semi-bold inline-flex items-center focus:outline-none',
     className,
     {
       'rounded-r-none mr-0': connectedRight,

--- a/lib/ButtonNew/ButtonIcon/ButtonIcon.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIcon.js
@@ -34,7 +34,7 @@ function ButtonIcon({
     'items-center justify-center',
     {
       [nonDisabledClasses]: !disabled,
-      'opacity-30': disabled,
+      'opacity-30 border-transparent': disabled,
       'rounded-small': size === sizes.sm
     },
     getSizeClasses(size)

--- a/lib/ButtonNew/ButtonIcon/ButtonIcon.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIcon.js
@@ -19,11 +19,12 @@ function ButtonIcon({
   ...rest
 }) {
   const nonDisabledClasses = cx(
-    'bg-transparent',
-    'focus:shadow-button-icon-focus',
+    'bg-transparent border-transparent',
+    'focus:border-blue-primary focus:shadow-button-icon-focus',
     {
-      'hover:bg-neutral-95 active:bg-blue-90': !active,
-      'bg-blue-90': active
+      'hover:bg-neutral-95 hover:border-neutral-95': !active,
+      'active:bg-blue-90 active:border-blue-90 active:shadow-none': !active,
+      'bg-blue-90 border-blue-90': active
     }
   );
 

--- a/lib/ButtonNew/ButtonIcon/ButtonIconBubble.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIconBubble.js
@@ -13,16 +13,18 @@ const ButtonIconBubble = ({
   size,
   ...rest
 }) => {
-  const classes = cx(
-    className,
-    'border border-solid shadow rounded-full p-3 inherit-color-icon',
-    {
-      'border-neutral-90 text-neutral-primary': !active,
-      'border-blue-primary bg-blue-90 text-blue-primary': active,
-      'bg-neutral-95': disabled,
-      'hover:border-blue-primary hover:bg-blue-95 hover:text-blue-primary active:border-blue-primary active:bg-blue-90 active:text-blue-primary focus:border-blue-primary focus:shadow-button-icon-bubble-focus': !disabled
-    }
+  const nonDisabledClasses = cx(
+    'hover:border-blue-primary hover:bg-blue-95 hover:text-blue-primary',
+    'active:border-blue-primary active:bg-blue-90 active:text-blue-primary active:shadow-none',
+    'focus:border-blue-primary focus:shadow-button-icon-bubble-focus'
   );
+
+  const classes = cx(className, 'shadow rounded-full p-3 inherit-color-icon', {
+    'border-neutral-90 text-neutral-primary': !active,
+    'border-blue-primary bg-blue-90 text-blue-primary': active,
+    'bg-neutral-95': disabled,
+    [nonDisabledClasses]: !disabled
+  });
 
   return (
     <ButtonBase className={classes} disabled={disabled} size={false} {...rest}>

--- a/lib/ButtonNew/ButtonIcon/ButtonIconDanger.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIconDanger.js
@@ -18,12 +18,13 @@ function ButtonIconDanger({
   ...rest
 }) {
   const nonDisabledClasses = cx(
-    'bg-white',
+    'bg-white border-white',
     'inherit-color-icon text-red-primary',
-    'focus:shadow-button-icon-danger-focus',
+    'focus:border-red-primary focus:shadow-button-icon-danger-focus',
     {
-      'hover:bg-red-95 active:bg-red-90': !active,
-      'bg-red-90': active
+      'active:bg-red-90 active:border-red-90 active:shadow-none': !active,
+      'hover:bg-red-95 hover:border-red-95': !active,
+      'bg-red-90 border-red-90': active
     }
   );
 
@@ -33,7 +34,7 @@ function ButtonIconDanger({
     'items-center justify-center',
     {
       [nonDisabledClasses]: !disabled,
-      'opacity-30': disabled,
+      'opacity-30 border-transparent': disabled,
       'rounded-small': size === sizes.sm
     },
     getSizeClasses(size)

--- a/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
+++ b/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
@@ -10,9 +10,9 @@ function ButtonPrimary({
   connectedRight,
   ...rest
 }) {
-  const disabledClasses = cx('text-neutral-primary bg-neutral-95', {
-    'border-neutral-80': connectedRight
-  });
+  const disabledClasses = cx(
+    'text-neutral-primary bg-neutral-95 border-neutral-95'
+  );
 
   const nonDisabledClasses = cx(
     'text-white bg-blue-primary border-blue-primary',
@@ -20,7 +20,7 @@ function ButtonPrimary({
     'hover:bg-blue-60 hover:border-blue-primary',
     'focus:border-white focus:shadow-button-primary-focus relative focus:z-50',
     {
-      'border-blue-40': connectedRight
+      'border-r-blue-40': connectedRight
     }
   );
 

--- a/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
+++ b/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
@@ -19,7 +19,7 @@ function ButtonPrimary({
 
   const nonDisabledClasses = cx(
     'text-white bg-blue-primary border-blue-primary',
-    'active:bg-blue-40 active:border-blue-30',
+    'active:bg-blue-40 active:border-blue-30 active:shadow-none',
     'hover:bg-blue-60 hover:border-blue-primary',
     'focus:border-white focus:shadow-button-primary-focus relative focus:z-50',
     {

--- a/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
+++ b/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
@@ -11,7 +11,10 @@ function ButtonPrimary({
   ...rest
 }) {
   const disabledClasses = cx(
-    'text-neutral-primary bg-neutral-95 border-neutral-95'
+    'text-neutral-primary bg-neutral-95 border-neutral-95',
+    {
+      'border-r-neutral-90': connectedRight
+    }
   );
 
   const nonDisabledClasses = cx(

--- a/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
+++ b/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
@@ -18,7 +18,7 @@ function ButtonPrimary({
     'text-white bg-blue-primary border-blue-primary',
     'active:bg-blue-40 active:border-blue-30',
     'hover:bg-blue-60 hover:border-blue-primary',
-    'focus:shadow-button-primary-focus relative focus:z-50',
+    'focus:border-white focus:shadow-button-primary-focus relative focus:z-50',
     {
       'border-blue-40': connectedRight
     }

--- a/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
+++ b/lib/ButtonNew/ButtonPrimary/ButtonPrimary.js
@@ -15,9 +15,9 @@ function ButtonPrimary({
   });
 
   const nonDisabledClasses = cx(
-    'text-white bg-blue-primary',
-    'active:bg-blue-40 active:shadow-button-primary-active',
-    'hover:bg-blue-60 hover:shadow-button-primary-hover',
+    'text-white bg-blue-primary border-blue-primary',
+    'active:bg-blue-40 active:border-blue-30',
+    'hover:bg-blue-60 hover:border-blue-primary',
     'focus:shadow-button-primary-focus relative focus:z-50',
     {
       'border-blue-40': connectedRight

--- a/lib/ButtonNew/ButtonPrimary/ButtonPrimaryDanger.js
+++ b/lib/ButtonNew/ButtonPrimary/ButtonPrimaryDanger.js
@@ -10,17 +10,15 @@ function ButtonPrimaryDanger({
   connectedRight,
   ...rest
 }) {
-  const disabledClasses = cx('text-neutral-primary bg-neutral-90', {
-    'border-neutral-80': connectedRight
-  });
+  const disabledClasses = cx('text-neutral-primary bg-neutral-90', {});
 
   const nonDisabledClasses = cx(
-    'text-white bg-red-primary ',
-    'hover:bg-red-60 hover:shadow-button-primary-danger-hover',
-    'active:bg-red-40 active:shadow-button-primary-danger-active',
-    'focus:shadow-button-primary-danger-focus relative focus:z-50',
+    'text-white bg-red-primary border-red-primary',
+    'hover:bg-red-60',
+    'active:bg-red-40 active:border-red-30',
+    'focus:border-white focus:shadow-button-primary-danger-focus relative focus:z-50',
     {
-      'border-red-40': connectedRight
+      'border-r-red-40': connectedRight
     }
   );
 

--- a/lib/ButtonNew/ButtonPrimary/ButtonPrimaryDanger.js
+++ b/lib/ButtonNew/ButtonPrimary/ButtonPrimaryDanger.js
@@ -10,7 +10,12 @@ function ButtonPrimaryDanger({
   connectedRight,
   ...rest
 }) {
-  const disabledClasses = cx('text-neutral-primary bg-neutral-90', {});
+  const disabledClasses = cx(
+    'text-neutral-primary bg-neutral-95 border-neutral-95',
+    {
+      'border-r-neutral-90': connectedRight
+    }
+  );
 
   const nonDisabledClasses = cx(
     'text-white bg-red-primary border-red-primary',

--- a/lib/ButtonNew/ButtonPrimary/ButtonPrimaryDanger.js
+++ b/lib/ButtonNew/ButtonPrimary/ButtonPrimaryDanger.js
@@ -20,7 +20,7 @@ function ButtonPrimaryDanger({
   const nonDisabledClasses = cx(
     'text-white bg-red-primary border-red-primary',
     'hover:bg-red-60',
-    'active:bg-red-40 active:border-red-30',
+    'active:bg-red-40 active:border-red-30 active:shadow-none',
     'focus:border-white focus:shadow-button-primary-danger-focus relative focus:z-50',
     {
       'border-r-red-40': connectedRight

--- a/lib/ButtonNew/ButtonSecondary/ButtonSecondary.js
+++ b/lib/ButtonNew/ButtonSecondary/ButtonSecondary.js
@@ -14,7 +14,7 @@ function ButtonSecondary({ children, className, disabled, ...rest }) {
 
   const classes = cx(
     'inherit-color-icon',
-    'border border-solid border-neutral-90',
+    'border-neutral-90',
     'focus:border-blue-primary focus:shadow-button-secondary-focus',
     disabled ? disabledClasses : nonDisabledClasses,
     className

--- a/lib/ButtonNew/ButtonTertiary/ButtonTertiary.js
+++ b/lib/ButtonNew/ButtonTertiary/ButtonTertiary.js
@@ -6,9 +6,10 @@ import { propTypes, defaultProps, sizes } from '../common';
 
 function ButtonTertiary({ children, className, disabled, active, ...rest }) {
   const nonDisabledClasses = cx(
-    'hover:bg-neutral-95',
-    'active:bg-neutral-90',
-    'focus:shadow-button-tertiary-focus',
+    'border-white',
+    'hover:bg-neutral-95 hover:border-neutral-95',
+    'active:bg-neutral-90 active:border-neutral-90 active:shadow-none',
+    'focus:border-neutral-20 focus:shadow-button-tertiary-focus',
     'text-neutral-20 bg-transparent',
     {
       'bg-neutral-90': active

--- a/lib/ButtonNew/ButtonTertiary/ButtonTertiary.js
+++ b/lib/ButtonNew/ButtonTertiary/ButtonTertiary.js
@@ -18,7 +18,7 @@ function ButtonTertiary({ children, className, disabled, active, ...rest }) {
 
   const classes = cx(className, {
     [nonDisabledClasses]: !disabled,
-    'text-neutral-primary bg-neutral-95': disabled
+    'text-neutral-primary bg-neutral-95 border-neutral-95': disabled
   });
 
   return (

--- a/lib/ButtonNew/ButtonTertiary/ButtonTertiaryDanger.js
+++ b/lib/ButtonNew/ButtonTertiary/ButtonTertiaryDanger.js
@@ -13,7 +13,7 @@ function ButtonTertiaryDanger({ children, className, disabled, ...rest }) {
   );
 
   const classes = cx(className, {
-    'text-neutral-primary border-neutral-90': disabled,
+    'text-neutral-primary bg-neutral-95 border-neutral-95': disabled,
     [nonDisabledClasses]: !disabled
   });
 

--- a/lib/ButtonNew/ButtonTertiary/ButtonTertiaryDanger.js
+++ b/lib/ButtonNew/ButtonTertiary/ButtonTertiaryDanger.js
@@ -5,11 +5,11 @@ import { propTypes, defaultProps, sizes } from '../common';
 
 function ButtonTertiaryDanger({ children, className, disabled, ...rest }) {
   const nonDisabledClasses = cx(
-    'bg-white',
+    'bg-white border-white',
     'text-red-primary',
-    'hover:bg-red-95',
-    'active:bg-red-90',
-    'focus:shadow-button-tertiary-danger-focus'
+    'hover:bg-red-95 hover:border-red-95',
+    'active:border-red-90 active:bg-red-90 active:shadow-none',
+    'focus:border-red-primary focus:shadow-button-tertiary-danger-focus'
   );
 
   const classes = cx(className, {

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "react-svg-inline": "^1.2.0",
     "svg-url-loader": "^3.0.0",
     "tailwindcss": "^1.2.0",
+    "tailwindcss-border-styles": "^1.0.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,8 +36,6 @@ module.exports = {
 
       'blue-focus-sm': `0px 0px 0px 3px ${blue80}`,
 
-      'button-primary-hover': `0px 0px 0px 1px ${bluePrimary}`,
-      'button-primary-active': `0px 0px 0px 1px ${blue30}`,
       'button-primary-focus': `0px 0px 0px 1px white, 0px 0px 0px 3px ${blue80}`,
 
       'button-primary-danger-hover': `0px 0px 0px 1px ${redPrimary}`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,7 +40,6 @@ module.exports = {
       'blue-focus-sm': `0px 0px 0px 3px ${blue80}`,
 
       'button-primary-focus': `0px 0px 0px 3px ${blue80}`,
-
       'button-primary-danger-focus': `0px 0px 0px 3px ${red80}`,
 
       'button-secondary-focus': `0px 0px 0px 3px ${blue80}`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,7 +48,7 @@ module.exports = {
       'button-tertiary-focus': `0px 0px 0px 3px ${neutral80}`,
       'button-tertiary-danger-focus': `0px 0px 0px 3px ${red80}`,
 
-      'button-icon-focus': `0px 0px 0px 1px ${bluePrimary}, 0px 0px 0px 3px ${blue80}`,
+      'button-icon-focus': `0px 0px 0px 3px ${blue80}`,
       'button-icon-danger-focus': `0px 0px 0px 1px ${redPrimary}, 0px 0px 0px 3px ${red80}`,
       'button-icon-bubble-focus': `0px 0px 0px 3px ${blue80}`,
       'bottom-inset': 'inset 0px -4px 4px rgba(0, 0, 0, 0.06)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,8 +45,8 @@ module.exports = {
 
       'button-secondary-focus': `0px 0px 0px 3px ${blue80}`,
 
-      'button-tertiary-focus': `0px 0px 0px 1px ${neutral20}, 0px 0px 0px 3px ${neutral80}`,
-      'button-tertiary-danger-focus': `0px 0px 0px 1px ${redPrimary}, 0px 0px 0px 3px ${red80}`,
+      'button-tertiary-focus': `0px 0px 0px 3px ${neutral80}`,
+      'button-tertiary-danger-focus': `0px 0px 0px 3px ${red80}`,
 
       'button-icon-focus': `0px 0px 0px 1px ${bluePrimary}, 0px 0px 0px 3px ${blue80}`,
       'button-icon-danger-focus': `0px 0px 0px 1px ${redPrimary}, 0px 0px 0px 3px ${red80}`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,9 +41,7 @@ module.exports = {
 
       'button-primary-focus': `0px 0px 0px 3px ${blue80}`,
 
-      'button-primary-danger-hover': `0px 0px 0px 1px ${redPrimary}`,
-      'button-primary-danger-active': `0px 0px 0px 1px ${red30}`,
-      'button-primary-danger-focus': `0px 0px 0px 1px white, 0px 0px 0px 3px ${red80}`,
+      'button-primary-danger-focus': `0px 0px 0px 3px ${red80}`,
 
       'button-secondary-focus': `0px 0px 0px 3px ${blue80}`,
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,8 +49,9 @@ module.exports = {
       'button-tertiary-danger-focus': `0px 0px 0px 3px ${red80}`,
 
       'button-icon-focus': `0px 0px 0px 3px ${blue80}`,
-      'button-icon-danger-focus': `0px 0px 0px 1px ${redPrimary}, 0px 0px 0px 3px ${red80}`,
+      'button-icon-danger-focus': `0px 0px 0px 3px ${red80}`,
       'button-icon-bubble-focus': `0px 0px 0px 3px ${blue80}`,
+
       'bottom-inset': 'inset 0px -4px 4px rgba(0, 0, 0, 0.06)',
       'top-inset': 'inset 0px 4px 4px rgba(0, 0, 0, 0.06)',
       none: 'none'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,9 @@ const neutral90 = '#E1E6EB';
 module.exports = {
   important: true,
   theme: {
+    borderStyles: {
+      colors: true
+    },
     fontFamily: {
       display: ['IBM Plex Sans', 'sans-serif'],
       body: ['IBM Plex Sans', 'sans-serif']
@@ -139,8 +142,8 @@ module.exports = {
         '30': '7.5rem'
       },
       spacing: {
-        '05': '0.375rem',
-      },
+        '05': '0.375rem'
+      }
     },
     maxHeight: {
       '0': '0',
@@ -208,16 +211,8 @@ module.exports = {
         'rgba(#fff, 0) 0%',
         'rgba(255,255,255,1) 50%'
       ],
-      'blur-grey-90-right': [
-        'to right',
-        'rgba(#E1E6EB, 0)',
-        '#E1E6EB 50%'
-      ],
-      'blur-grey-95-right': [
-        'to right',
-        'rgba(#F0F2F5, 0)',
-        '#F0F2F5 50%'
-      ]
+      'blur-grey-90-right': ['to right', 'rgba(#E1E6EB, 0)', '#E1E6EB 50%'],
+      'blur-grey-95-right': ['to right', 'rgba(#F0F2F5, 0)', '#F0F2F5 50%']
     }
   },
   variants: {
@@ -245,7 +240,10 @@ module.exports = {
     textColor: ['responsive', 'group-hover', 'hover', 'focus'],
     justifyContent: ['group-hover']
   },
-  plugins: [require('tailwindcss-plugins/gradients')],
+  plugins: [
+    require('tailwindcss-plugins/gradients'),
+    require('tailwindcss-border-styles')()
+  ],
   corePlugins: {
     preflight: false,
     container: false

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,7 +36,7 @@ module.exports = {
 
       'blue-focus-sm': `0px 0px 0px 3px ${blue80}`,
 
-      'button-primary-focus': `0px 0px 0px 1px white, 0px 0px 0px 3px ${blue80}`,
+      'button-primary-focus': `0px 0px 0px 3px ${blue80}`,
 
       'button-primary-danger-hover': `0px 0px 0px 1px ${redPrimary}`,
       'button-primary-danger-active': `0px 0px 0px 1px ${red30}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11756,6 +11756,13 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tailwindcss-border-styles@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tailwindcss-border-styles/-/tailwindcss-border-styles-1.0.1.tgz#d254734cabff116af0c6974457eceb4620f3d7cc"
+  integrity sha512-sG5o00EcoNEKulrCbe/2uBGAL6hO4BeQpUYvdsk0S4elouEACzD0LWMoH8ZIrBu2PD016N4sdioIqFHe/upDZg==
+  dependencies:
+    lodash "^4.17.15"
+
 tailwindcss-plugins@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/tailwindcss-plugins/-/tailwindcss-plugins-0.3.0.tgz#20ec0192a0681c4e2efbb6e5654b767bea388e94"


### PR DESCRIPTION
### 💬 Description
We weren't happy with the way that we created borders on our new GCDS Buttons, mostly because of the overuse of box shadows. After a chat we decided on two rules for buttons:
- Buttons should always have a border
- Any border (eg focus outline) outside of the first border can be box-shadow

This PR applies these two rules.

First, we updated `<ButtonBase />` to always have a border, then we styled the descendant button components to work with this new border.

We have added the `tailwindcss-border-styles` plugin, which creates helper classes that allow you to set the color of a border on a specified side, eg. `border-r-white`.
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
