### PR TITLE
Turns off defaultActiveColor for approved tick icon in workflow dropdown

### DIFF
--- a/lib/ApprovedLabel/index.js
+++ b/lib/ApprovedLabel/index.js
@@ -24,6 +24,7 @@ const ApprovedLabel = ({ approvedBy }) => {
         text={text}
         types={['green']}
         textTypes={['green']}
+        defaultActiveColor={false}
       />
     </TooltipWrapper>
   );

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     {
       "name": "Alex Smith",
       "email": "alex@gathercontent.com"
+    },
+    {
+      "name": "David Hollins",
+      "email": "david@gathercontent.com"
     }
   ],
   "scripts": {


### PR DESCRIPTION
### 💬 Description
Sets the `defaultActiveColor={false}` prop on a tick icon in the `<ApprovedLabel />` component. It was blue when it should have been green.

Also added David to the contributors on `package.json`. Was literally the first thing I did when I joined GC. @DavidHollins6, you are too humble.
### 🔗 Links
_Links that relate to the PR (Trello, Figma etc.)_
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
