### PR TITLE
Fixes build:watch command, renames it to dev and adds source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "lint:fix": "eslint -c .eslintrc.json --fix 'lib/**/*.js' 'tests/**/*.js' 'stories/webapp/**/*.js'",
     "lint:check": "eslint --print-config . | eslint-config-prettier-check",
     "copy:styles:watch": "nodemon --exec \"yarn copy-styles\" --watch lib --watch styles -e scss --watch tailwind.config.js",
-    "dev": "concurrently \"yarn copy:styles:watch\" \"yarn build:lib --watch --source-maps inline\" \"yarn build:tailwind:config --watch --source-maps inline\""
+    "build:watch": "concurrently \"yarn copy:styles:watch\" \"yarn build:lib --watch --source-maps inline\" \"yarn build:tailwind:config --watch --source-maps inline\""
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   "scripts": {
     "copy-tailwind": "tailwind build styles/tailwind.css -o dist/styles/tailwind.css",
     "copy-styles": "echo Copying Sass settings... && yarn copy-tailwind && copyfiles styles/**/* dist/ && copyfiles styles/main.scss dist/ && copyfiles styles/bootstrap.scss dist/ && copyfiles lib/**/*.scss dist/ && copyfiles lib/**/**/*.scss dist/",
-    "build": "babel lib/ --out-dir dist/lib && babel tailwind.config.js --out-dir dist",
+    "build:lib": "babel lib/ --out-dir dist/lib",
+    "build:tailwind:config": "babel tailwind.config.js --out-dir dist",
+    "build": "yarn build:lib && yarn build:tailwind:config",
     "build:with:styles": "yarn build && yarn run copy-styles",
     "prepublish": "yarn run build:with:styles",
     "storybook": "start-storybook -p 6006 -c .storybook",
@@ -57,7 +59,7 @@
     "lint:fix": "eslint -c .eslintrc.json --fix 'lib/**/*.js' 'tests/**/*.js' 'stories/webapp/**/*.js'",
     "lint:check": "eslint --print-config . | eslint-config-prettier-check",
     "copy:styles:watch": "nodemon --exec \"yarn copy-styles\" --watch lib --watch styles -e scss --watch tailwind.config.js",
-    "build:watch": "concurrently \"yarn copy:styles:watch\" \"yarn build --watch\""
+    "dev": "concurrently \"yarn copy:styles:watch\" \"yarn build:lib --watch --source-maps inline\" \"yarn build:tailwind:config --watch --source-maps inline\""
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
### 💬 Description
#### ⁉ Issue
We previously had a command called `build:watch`, which was supposed to watch our `lib/` dir and `tailwind.config.js` file and build them into the `/dist` directory whenever they changed. However, I broke it with the following:

```javascript
{
  "build": "babel lib/ --out-dir dist/lib && babel tailwind.config.js --out-dir dist",
  "build:watch": "concurrently \"yarn copy:styles:watch\" \"yarn build --watch\""
}
```
looking at `build:watch`, when we call `yarn build --watch`, it is actually only passing the `--watch` flag to the second babel call. Thus it was only recompiling the tailwindconfig when that changed.
#### ✅ Fix
I have created a new command `yarn dev` that actually watches and rebuilds both  `lib/*` and `tailwind.config.js`.

As a bonus, this command adds inline source maps, which means we can debug the actual GUI code when linking it to the App.