### PR TITLE
Fix tab gradients

### DIFF
--- a/lib/TabsNew/TabNameForm.js
+++ b/lib/TabsNew/TabNameForm.js
@@ -47,7 +47,7 @@ export function TabNameForm({
     'border-solid block rounded outline-none px-2 z-10 bg-transparent',
     {
       'border border-transparent hover:border-neutral-90': !isEditing,
-      'border-2 border-blue-primary': isEditing
+      'border-2 border-blue-primary z-50': isEditing
     }
   );
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -207,18 +207,18 @@ module.exports = {
       ],
       'blur-white-right': [
         'to right',
-        'transparent',
+        'rgba(255, 255, 255, 0)',
         'rgba(255,255,255,1) 50%'
       ],
       'blur-grey-90-right': [
         'to right',
-        'transparent',
-        '#E1E6EB 50%'
+        'rgba(225,230,235, 0)',
+        'rgba(225,230,235, 1) 50%'
       ],
       'blur-grey-95-right': [
         'to right',
-        'transparent',
-        '#F0F2F5 50%'
+        'rgba(240,242,245, 0)',
+        'rgba(240,242,245, 1) 50%'
       ]
     }
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -207,17 +207,17 @@ module.exports = {
       ],
       'blur-white-right': [
         'to right',
-        'rgba(#fff, 0) 0%',
+        'transparent',
         'rgba(255,255,255,1) 50%'
       ],
       'blur-grey-90-right': [
         'to right',
-        'rgba(#E1E6EB, 0)',
+        'transparent',
         '#E1E6EB 50%'
       ],
       'blur-grey-95-right': [
         'to right',
-        'rgba(#F0F2F5, 0)',
+        'transparent',
         '#F0F2F5 50%'
       ]
     }


### PR DESCRIPTION
### 💬 Description
Tab asides have gradients that fade the text out when it gets close to the edge. In the process of fixing a browser bug with transparency in Safari, we broke the gradients everywhere 😒 

This PR corrects that by using RGB values in the config and also fixes another issue where the `TabForm` component when active doesn't appear above the gradient.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
