### PR TITLE
Hiding conversation blur

### DIFF
--- a/lib/Comment/CommentText.js
+++ b/lib/Comment/CommentText.js
@@ -4,9 +4,12 @@ import Linkify from 'linkifyjs/react';
 import cx from 'classnames';
 import { Comment } from 'lib';
 
-function BlurBottom() {
+// eslint-disable-next-line react/prop-types
+function BlurBottom({ className }) {
   return (
-    <span className="comment-blur-bottom absolute h-8 w-full top-0 left-0 mt-24 bg-blur-white-bottom group-hover:bg-blur-grey-bottom conversation__text__cutoff" />
+    <span
+      className={`comment-blur-bottom absolute h-8 w-full top-0 left-0 mt-24 bg-blur-white-bottom group-hover:bg-blur-grey-bottom conversation__text__cutoff ${className}`}
+    />
   );
 }
 
@@ -66,7 +69,7 @@ function CommentText({
       <p className="comment-text m-0 text-sm break-words">
         <Linkify>{highlightMentions()}</Linkify>
         {hasBeenEdited && <EditedText />}
-        {!showFullText && <BlurBottom />}
+        <BlurBottom className={showFullText ? 'hidden' : ''} />
       </p>
     </div>
   );


### PR DESCRIPTION
### 💬 Description
We should just hide the BottomBlur of a conversation instead of re-rendering it. This was causing issues because it was rendering and pushing other elements around.

### 🚪 Start Points
`lib/Comment/CommentText.js`

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
