### PR TITLE
Fix leaks in comment forms

### DIFF
--- a/lib/BoundaryClickWatcher/index.js
+++ b/lib/BoundaryClickWatcher/index.js
@@ -64,13 +64,13 @@ function BoundaryClickWatcher(props) {
   };
 
   const handleInnerClick = () => {
-    props.insideClickHandler();
     setBoundaryIsActive(true);
+    props.insideClickHandler();
   };
 
   const handleOuterClick = event => {
-    props.outsideClickHandler(event);
     setBoundaryIsActive(false);
+    props.outsideClickHandler(event);
   };
 
   const handleMouseDown = ({ target }) => {

--- a/lib/Comment/CommentForm.js
+++ b/lib/Comment/CommentForm.js
@@ -90,10 +90,10 @@ function CommentForm({
   const [isSubmitting, handleSubmitWithLoader] = useLoader(handleSubmit);
 
   const handleCancel = () => {
-    onCancel();
     setCommentText(children);
     focusFallback.current.focus();
     setIsEditing(false);
+    onCancel();
   };
 
   const inputWrapperClassNames = cx('relative p-2 w-full rounded text-sm', {


### PR DESCRIPTION
### 💬 Description
In `CommentForm` we call external props before executing internal state changes. This isn't ideal as the external function could unmount the component causing a memory leak.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
