### PR TITLE
make sure duedate picker closes after selecting or removing a due date

### DIFF
--- a/lib/DueDatePicker/index.js
+++ b/lib/DueDatePicker/index.js
@@ -45,14 +45,7 @@ class DueDatePicker extends Component {
     }
   }
 
-  hideDropdown = () => {
-    if (this.container) {
-      this.container.setShowContent(false);
-    }
-    this.setState(this.initialState);
-  };
-
-  applyDueDate = () => {
+  applyDueDate = hideDropdown => {
     if (this.state.selectedDay) {
       const dueDate = moment(this.state.selectedDay).set({
         hour: this.state.selectedTime.hour(),
@@ -60,17 +53,19 @@ class DueDatePicker extends Component {
       });
       this.props.applyDueDate(dueDate);
 
-      this.hideDropdown();
+      hideDropdown();
+      this.setState(this.initialState);
     }
   };
 
-  removeDueDate = () => {
+  removeDueDate = hideDropdown => {
     this.props.removeDueDate();
     this.setState({
       changed: false,
       selectedDay: null
     });
-    this.hideDropdown();
+    hideDropdown();
+    this.setState(this.initialState);
   };
 
   handleDayClick = (day, { selected }) => {
@@ -110,69 +105,74 @@ class DueDatePicker extends Component {
           id="duedate__dropdown"
           autoPosition={this.props.autoPosition}
           onToggle={onHide}
-          ref={el => {
-            this.container = el;
-          }}
         >
-          <DueDateButton
-            dueDate={this.props.dueDate}
-            userCanSetDueDate={this.props.userCanSetDueDate}
-            types={this.props.triggerButtonTypes}
-          >
-            {this.props.children}
-          </DueDateButton>
+          {({ setShowContent }) => (
+            <>
+              <DueDateButton
+                dueDate={this.props.dueDate}
+                userCanSetDueDate={this.props.userCanSetDueDate}
+                types={this.props.triggerButtonTypes}
+              >
+                {this.props.children}
+              </DueDateButton>
 
-          {this.props.userCanSetDueDate && (
-            <Dropdown.Content className="duedate__dropdown">
-              {showContent =>
-                showContent ? (
-                  <Fragment>
-                    <DueDateHeader
-                      dueDate={this.state.selectedDay}
-                      dueTime={this.state.selectedTime}
-                      setTime={this.handleTimeClick}
-                      removeDueDate={this.removeDueDate}
-                    />
-                    <div className="duedate__datepicker">
-                      <DayPicker
-                        weekdaysShort={[
-                          'Sun',
-                          'Mon',
-                          'Tues',
-                          'Wed',
-                          'Thu',
-                          'Fri',
-                          'Sat'
-                        ]}
-                        firstDayOfWeek={1}
-                        onDayClick={this.handleDayClick}
-                        selectedDays={this.state.selectedDay}
-                        month={this.state.selectedDay}
-                        modifiers={{
-                          past: day => day < today
-                        }}
-                      />
-                      <div className={buttonClasses}>
-                        <Button
-                          clickHandler={this.hideDropdown}
-                          types={['link-default', 'collapse']}
-                          className="duedate__submit--cancel"
-                        >
-                          Cancel
-                        </Button>
-                        <Button
-                          clickHandler={this.applyDueDate}
-                          types={['primary']}
-                          className="duedate__submit--save"
-                        >
-                          Set due date
-                        </Button>
-                      </div>
-                    </div>
-                  </Fragment>
-                ) : null
-              }
-            </Dropdown.Content>
+              {this.props.userCanSetDueDate && (
+                <Dropdown.Content className="duedate__dropdown">
+                  {showContent =>
+                    showContent ? (
+                      <Fragment>
+                        <DueDateHeader
+                          dueDate={this.state.selectedDay}
+                          dueTime={this.state.selectedTime}
+                          setTime={this.handleTimeClick}
+                          removeDueDate={() =>
+                            this.removeDueDate(() => setShowContent(false))
+                          }
+                        />
+                        <div className="duedate__datepicker">
+                          <DayPicker
+                            weekdaysShort={[
+                              'Sun',
+                              'Mon',
+                              'Tues',
+                              'Wed',
+                              'Thu',
+                              'Fri',
+                              'Sat'
+                            ]}
+                            firstDayOfWeek={1}
+                            onDayClick={this.handleDayClick}
+                            selectedDays={this.state.selectedDay}
+                            month={this.state.selectedDay}
+                            modifiers={{
+                              past: day => day < today
+                            }}
+                          />
+                          <div className={buttonClasses}>
+                            <Button
+                              clickHandler={() => setShowContent(false)}
+                              types={['link-default', 'collapse']}
+                              className="duedate__submit--cancel"
+                            >
+                              Cancel
+                            </Button>
+                            <Button
+                              clickHandler={() =>
+                                this.applyDueDate(() => setShowContent(false))
+                              }
+                              types={['primary']}
+                              className="duedate__submit--save"
+                            >
+                              Set due date
+                            </Button>
+                          </div>
+                        </div>
+                      </Fragment>
+                    ) : null
+                  }
+                </Dropdown.Content>
+              )}
+            </>
           )}
         </Dropdown>
       </span>


### PR DESCRIPTION
### 💬 Description
This was using a ref to close the dropdown after selecting or removing a due date. We cant really do that anymore since I've rejigged the dropdown components, plus thats a bit weird too! We're now using the render prop instead. 

Its probably worth coming back and cleaning up this component a bit, anything with `UNSAFE` lifecycle methods is crying out for a refactor. For now I've left it untouched apart from the fix.