### PR TITLE
add a useShiftSelect hook

### DIFF
--- a/lib/SelectionProvider/index.js
+++ b/lib/SelectionProvider/index.js
@@ -8,6 +8,7 @@ const SelectionProvider = ({ children, initialSelected }) => {
   const [selected, setSelected] = useState(initialSelected);
   const [intendedToSelect, setIntendedToSelect] = useState([]);
   const [currentSelectedType, setCurrentSelectedType] = useState(null);
+  const [lastInteracted, setLastInteracted] = useState(null);
 
   const updateSelected = (id, type) => {
     let newSelected;
@@ -56,7 +57,9 @@ const SelectionProvider = ({ children, initialSelected }) => {
     deselectMultiple,
     currentSelectedType,
     setIntendedToSelect,
-    intendedToSelect
+    intendedToSelect,
+    lastInteracted,
+    setLastInteracted
   };
   return (
     <SelectionContext.Provider value={sharedState}>

--- a/lib/SelectionProvider/useShiftSelect.js
+++ b/lib/SelectionProvider/useShiftSelect.js
@@ -1,0 +1,41 @@
+import { useContext } from 'react';
+import { SelectionContext, useObjectSelector } from '..';
+
+export function useShiftSelect(id, ids, type) {
+  const {
+    selected,
+    currentSelectedType,
+    selectMultiple,
+    deselectMultiple,
+    lastInteracted,
+    setLastInteracted
+  } = useContext(SelectionContext);
+  const { isSelected, handleClick } = useObjectSelector(id, type, [id]);
+
+  const handleSelection = e => {
+    setLastInteracted(id);
+    if (!e.shiftKey || selected.length === 0 || id === lastInteracted) {
+      handleClick(e);
+    } else {
+      const selectedIndex = ids.indexOf(id);
+      const lastInteractedIndex = ids.indexOf(lastInteracted);
+      const selectUp = lastInteractedIndex < selectedIndex;
+      const sliceStart = selectUp ? lastInteractedIndex : selectedIndex;
+      const sliceEnd = selectUp ? selectedIndex : lastInteractedIndex;
+
+      const interactedIds = ids.slice(sliceStart, sliceEnd + 1);
+
+      if (isSelected) {
+        deselectMultiple(interactedIds);
+      } else {
+        selectMultiple(interactedIds, currentSelectedType);
+      }
+    }
+  };
+
+  return {
+    handleSelection,
+    isSelected,
+    selected
+  };
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,6 +114,7 @@ export Person from './Person';
 export { Sidebar } from './Sidebar/Sidebar';
 export { SelectionProvider, SelectionContext } from './SelectionProvider';
 export { useObjectSelector } from './SelectionProvider/useObjectSelector';
+export { useShiftSelect } from './SelectionProvider/useShiftSelect';
 export {
   DndProvider,
   DragPreview,

--- a/tests/SelectionProvider/useShiftSelect.spec.js
+++ b/tests/SelectionProvider/useShiftSelect.spec.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useShiftSelect } from '../../lib/SelectionProvider/useShiftSelect';
+import { SelectionProvider } from '../../lib/SelectionProvider';
+
+describe('useShiftSelect', () => {
+  it('selects multiple when shift clicking', () => {
+    let id = 1;
+    // eslint-disable-next-line react/prop-types
+    const wrapper = ({ children }) => (
+      <SelectionProvider>{children}</SelectionProvider>
+    );
+    const { result, rerender } = renderHook(
+      () => useShiftSelect(id, [1, 2, 3], 'type'),
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.handleSelection({ shiftKey: false });
+    });
+
+    expect(result.current.isSelected).toBe(true);
+    expect(result.current.selected).toEqual([id]);
+
+    id = 3;
+    rerender();
+    act(() => {
+      result.current.handleSelection({ shiftKey: true });
+    });
+    expect(result.current.isSelected).toBe(true);
+    expect(result.current.selected).toEqual([1, 2, id]);
+
+    id = 1;
+    rerender();
+
+    act(() => {
+      result.current.handleSelection({ shiftKey: true });
+    });
+    expect(result.current.isSelected).toBe(false);
+    expect(result.current.selected).toEqual([]);
+  });
+
+  it('doesnt select multiple when shift isnt held down', () => {
+    let id = 1;
+    // eslint-disable-next-line react/prop-types
+    const wrapper = ({ children }) => (
+      <SelectionProvider>{children}</SelectionProvider>
+    );
+    const { result, rerender } = renderHook(
+      () => useShiftSelect(id, [1, 2, 3], 'type'),
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.handleSelection({ shiftKey: false });
+    });
+
+    expect(result.current.isSelected).toBe(true);
+    expect(result.current.selected).toEqual([id]);
+
+    id = 3;
+    rerender();
+    act(() => {
+      result.current.handleSelection({ shiftKey: false });
+    });
+    expect(result.current.isSelected).toBe(true);
+    expect(result.current.selected).toEqual([1, id]);
+  });
+});


### PR DESCRIPTION
### 💬 Description
This is adding a lovely hook to allow shift selection with the SelectionProvider.

We already have this code in a few places in the app, this is just that code but made a little more vague so we can hopefully use it for all the current shift select purposes! There's an upcoming app pr which makes the content hub active/trashed items & hierachy use this hook instead.

### ✅ Checklist
- [x] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
