### PR TITLE
Makes check toggle label a label element

### DIFF
--- a/lib/CheckToggle/index.js
+++ b/lib/CheckToggle/index.js
@@ -85,7 +85,11 @@ class CheckToggle extends Component {
 
     return (
       <div className={wrapperClasses}>
-        {labelLeft && <p className={wrapperLabelClasses}>{labelLeft}</p>}
+        {labelLeft && (
+          <label htmlFor={id} className={wrapperLabelClasses}>
+            {labelLeft}
+          </label>
+        )}
         <span className="toggle-wrapper__inner">
           <input
             data-testid={id}
@@ -102,7 +106,11 @@ class CheckToggle extends Component {
             htmlFor={id}
           />
         </span>
-        {labelRight && <p className={wrapperLabelClasses}>{labelRight}</p>}
+        {labelRight && (
+          <label htmlFor={id} className={wrapperLabelClasses}>
+            {labelRight}
+          </label>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
### 💬 Description
Updates the `<CheckToggle />` label to be a `<label />` tag rather than a `<p />` tag.

Turns out an input can have multiple labels (you'll notice in the file we also have another label that is the actual toggle.

This update was added for targeting `<CheckToggle />` in tests.

> Related to https://github.com/gathercontent/app/pull/3154