### PR TITLE
Adding tooltip text to the comment form submit button

### DIFF
--- a/lib/Comment/CommentForm.js
+++ b/lib/Comment/CommentForm.js
@@ -13,6 +13,7 @@ import {
 } from 'lib';
 import Icon from '../Icon';
 import { CommentFailed } from './CommentFailed';
+import TooltipWrapper from '../TooltipWrapper';
 
 function CommentForm({
   children,
@@ -23,6 +24,7 @@ function CommentForm({
   onSubmit,
   onRowCountChange,
   submitText,
+  submitTooltipText,
   autoFocusInput,
   onMention
 }) {
@@ -176,14 +178,22 @@ function CommentForm({
           Cancel
         </ButtonTertiary>
 
-        <ButtonPrimary
-          disabled={!commentText}
-          size={ButtonPrimary.sizes.xs}
-          type="submit"
+        <TooltipWrapper
+          id="submit-conversation-button"
+          tooltipText={submitTooltipText}
+          placement="bottom"
         >
-          {isSubmitting && <Icon name="loader16" className="mr-2 fill-white" />}
-          {hasFailed ? 'Retry' : submitText}
-        </ButtonPrimary>
+          <ButtonPrimary
+            disabled={!commentText}
+            size={ButtonPrimary.sizes.xs}
+            type="submit"
+          >
+            {isSubmitting && (
+              <Icon name="loader16" className="mr-2 fill-white" />
+            )}
+            {hasFailed ? 'Retry' : submitText}
+          </ButtonPrimary>
+        </TooltipWrapper>
       </div>
 
       <input
@@ -207,7 +217,8 @@ CommentForm.propTypes = {
   placeholder: string,
   onChange: func,
   submitText: string,
-  onMention: func
+  onMention: func,
+  submitTooltipText: string
 };
 
 CommentForm.defaultProps = {
@@ -218,7 +229,8 @@ CommentForm.defaultProps = {
   autoFocusInput: false,
   placeholder: 'New Comment...',
   submitText: 'Comment',
-  onMention: () => {}
+  onMention: () => {},
+  submitTooltipText: ''
 };
 
 export { CommentForm };


### PR DESCRIPTION
### 💬 Description
This PR adds a new prop to CommentForm to have it's submitted button get some tooltip text! You may ask why I did this and not add a permanent tooltip. It's because I'd like to put a shortcut in there, and the amount of code needed to get the short key would make this too much of a hassle to port over to G-UI.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
