### PR TITLE
Fixing scroll bars in structure fields, fixing word breaks in labels

### DIFF
--- a/lib/Field/styles.scss
+++ b/lib/Field/styles.scss
@@ -244,12 +244,12 @@ $field-data-p-line-height: 1.688rem !default;
   .field__label,
   .field__instructions {
     resize: none;
-    overflow: auto;
     outline: none;
     display: block;
     width: 100%;
     height: auto;
     color: $neutral-dark;
+    word-break: break-all;
   }
   .field__instructions {
     font-size: $typo-size-slight;


### PR DESCRIPTION
### 💬 Description
This PR was originally meant to fix those pesky scroll bars in structure field labels, but I ended up finding a bonus bug while fixing it!

Here is a video of it: https://share.getcloudapp.com/Jru6kwLJ

I fixed this by adding some word breaks to that label. 

NOTE:

Structure fields are the only fields to not be converted to `FieldNew`, I had a look into this and asked around, structure mode is not styled fully in `FieldNew` so would need to have that done before it can be converted.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
