### PR TITLE
Change the default background colour for tertiary buttons

### DIFF
--- a/lib/ButtonNew/ButtonTertiary/ButtonTertiary.js
+++ b/lib/ButtonNew/ButtonTertiary/ButtonTertiary.js
@@ -10,7 +10,7 @@ function ButtonTertiary({ children, className, disabled, active, ...rest }) {
     'hover:bg-neutral-95 hover:border-neutral-95',
     'active:bg-neutral-90 active:border-neutral-90 active:shadow-none',
     'focus:border-neutral-20 focus:shadow-button-tertiary-focus',
-    'text-neutral-20 bg-transparent',
+    'text-neutral-20 bg-white',
     {
       'bg-neutral-90': active
     }


### PR DESCRIPTION
### 💬 Description
When `ButtonTertiary` is used over a UI with colour (e.g. files) the transparent background becomes troublesome. This PR fixes that by adding a default background of white.

I've checked this with @p34ks and all is well 👍  (unless you can think of a reason why not of course)

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
