### PR TITLE
Editable text input component and input tailwind components

### DIFF
--- a/lib/EditableChoiceInput/index.js
+++ b/lib/EditableChoiceInput/index.js
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { string, func, bool, node } from 'prop-types';
+import cx from 'classnames';
+
+function EditableChoiceInput({
+  type,
+  className,
+  label,
+  placeholder,
+  readOnly,
+  onChange,
+  aside,
+  ...props
+}) {
+  const [labelText, setLabelText] = useState(label);
+  const [isFocused, setIsFocused] = useState(false);
+  const [showAside, setShowAside] = useState(false);
+
+  const handleOnChange = e => {
+    onChange(e);
+    setLabelText(e.target.value);
+  };
+
+  const classNames = cx(`text-input-border pl-5 pr-2 ${className}`, {
+    'text-input-border-focus': isFocused
+  });
+
+  return (
+    <div
+      className={classNames}
+      onMouseEnter={() => setShowAside(true)}
+      onMouseLeave={() => setShowAside(false)}
+      {...props}
+    >
+      <div className="option-inner flex items-center">
+        <input type={type} disabled />
+        <input
+          data-testid="editable-choice-text-input"
+          value={labelText}
+          placeholder={placeholder}
+          type="text"
+          disabled={readOnly}
+          onChange={handleOnChange}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          className="border-none p-3 w-full text-input-base text-input-padding bg-transparent"
+        />
+        {aside && showAside && aside}
+      </div>
+    </div>
+  );
+}
+
+EditableChoiceInput.propTypes = {
+  type: string.isRequired,
+  onChange: func.isRequired,
+  className: string,
+  label: string,
+  placeholder: string,
+  readOnly: bool,
+  aside: node
+};
+
+EditableChoiceInput.defaultProps = {
+  className: '',
+  label: '',
+  placeholder: 'Add label text',
+  readOnly: false,
+  aside: null
+};
+
+export default EditableChoiceInput;

--- a/lib/EditableChoiceInput/stories/EditableChoiceInput.js
+++ b/lib/EditableChoiceInput/stories/EditableChoiceInput.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import EditableChoiceInput from '..';
+import StoryItem from '../../../stories/styleguide/StoryItem';
+
+const EditableChoiceInputStory = storiesOf('Components', module).add(
+  'EditableChoiceInput',
+  () => (
+    <div>
+      <StoryItem
+        title="EditableChoiceInput"
+        description="A text input next to a choice input"
+      >
+        <EditableChoiceInput
+          type="radio"
+          label="Prepopulated label"
+          placeholder="Add label text"
+          aside={<div>hello!</div>}
+        />
+      </StoryItem>
+      <StoryItem
+        title="EditableChoiceInput"
+        description="A text input next to a choice input"
+      >
+        <EditableChoiceInput type="checkbox" placeholder="Add label text" />
+      </StoryItem>
+    </div>
+  )
+);
+
+export default EditableChoiceInputStory;

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,3 +146,4 @@ export { Layout } from './Layout';
 export { Select } from './Select/Select';
 export { useLoader } from './Field/useLoader';
 export { Counter } from './Counter';
+export EditableChoiceInput from './EditableChoiceInput';

--- a/stories/index.js
+++ b/stories/index.js
@@ -81,3 +81,4 @@ import '../lib/OptionMenu/stories/OptionMenu';
 import '../lib/Select/stories/Select';
 import Sidebar from './components/Sidebar';
 import Layout from './components/Layout';
+import EditableChoiceInputStory from '../lib/EditableChoiceInput/stories/EditableChoiceInput';

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -70,3 +70,5 @@
 @import 'overrides/dropdown';
 @import 'overrides/daypicker';
 @import 'overrides/bootstrap';
+
+@import 'tailwind-components';

--- a/styles/tailwind-components/index.scss
+++ b/styles/tailwind-components/index.scss
@@ -1,0 +1,1 @@
+@import 'inputs';

--- a/styles/tailwind-components/inputs.scss
+++ b/styles/tailwind-components/inputs.scss
@@ -1,0 +1,54 @@
+.text-input-base {
+  @apply text-base text-neutral-20 bg-white;
+  &::placeholder {
+    @apply text-neutral-primary;
+  }
+}
+
+.text-input-border {
+  @apply border border-solid border-neutral-90 rounded relative;
+}
+
+.text-input-border-hover {
+  @apply border-neutral-primary transition-all duration-200;
+}
+
+.text-input-border:hover:not(:focus):not(.text-input-border-focus) {
+  @apply text-input-border-hover;
+}
+
+.text-input-border-focus {
+  @apply border-transparent;
+  @include before-border(
+    2px,
+    solid,
+    theme('colors.blue.primary'),
+    theme('borderRadius.default')
+  );
+}
+
+.text-input-border:active,
+.text-input-border:focus {
+  @apply text-input-border-focus;
+}
+
+.text-input {
+  @apply text-input-base text-input-border p-3;
+}
+
+.text-input:hover:not(:focus) {
+  @apply text-input-border-hover;
+}
+
+.text-input:active,
+.text-input:focus {
+  @apply text-input-border-focus;
+}
+
+.text-input-disabled {
+  @apply bg-neutral-95 text-neutral-primary;
+
+}
+.text-input:disabled {
+  @apply text-input-disabled;
+}

--- a/tests/EditableChoiceInput/EditableChoiceInput.spec.js
+++ b/tests/EditableChoiceInput/EditableChoiceInput.spec.js
@@ -1,0 +1,64 @@
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import { React } from '../setup';
+import { EditableChoiceInput } from '../../lib';
+
+describe('EditableChoiceInput', () => {
+  const defaultProps = {
+    type: 'radio',
+    onChange: () => {}
+  };
+  const renderWrapper = (props = defaultProps) =>
+    render(<EditableChoiceInput {...props} />);
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('displays a radio input', () => {
+    const { container } = renderWrapper();
+    const radio = container.querySelector('input[type="radio"]');
+    expect(radio).toBeInTheDocument();
+  });
+
+  test('displays a checkbox input', () => {
+    const { container } = renderWrapper({ ...defaultProps, type: 'checkbox' });
+    const checkbox = container.querySelector('input[type="checkbox"]');
+    expect(checkbox).toBeInTheDocument();
+  });
+
+  test('displays a text input', () => {
+    const onChangeSpy = jest.fn();
+    const { getByTestId } = renderWrapper({
+      ...defaultProps,
+      onChange: onChangeSpy
+    });
+    fireEvent.change(getByTestId('editable-choice-text-input'), {
+      target: {
+        value: 'A nice option'
+      }
+    });
+    expect(onChangeSpy).toBeCalled();
+  });
+
+  test('displays a readonly text input', () => {
+    const onChangeSpy = jest.fn();
+    const { getByTestId } = renderWrapper({
+      ...defaultProps,
+      onChange: onChangeSpy,
+      readOnly: true
+    });
+    expect(getByTestId('editable-choice-text-input')).toBeDisabled();
+    expect(onChangeSpy).not.toBeCalled();
+  });
+
+  test('displays the aside', () => {
+    const { queryByText, getByText, getByTestId } = renderWrapper({
+      ...defaultProps,
+      aside: <div>howdy!</div>
+    });
+    expect(queryByText('howdy!')).toEqual(null);
+    const input = getByTestId('editable-choice-text-input');
+    fireEvent.mouseEnter(input);
+    expect(getByText('howdy!'));
+  });
+});


### PR DESCRIPTION
### 💬 Description
Some fun things here!

We've got a new component which replaces some messy styles in the structure editor for choice field options, and its now up to date with GCDS.

Since I was doing some inputty styling I thought it's a good candidate for our first tailwind component! Any of how I've done this is open to change or up for discussion, its a real finger in the air from me.

The only sort of strange part about it is I've split up the component so we can apply just the border logic if needed. We have a 'text-input' component which applies everything, and then just a 'text-input-border' component. I needed to do this for mu new component and I'm sure there's other places where it may be needed. So its not as clean as we'd like, its a bit iffy about inheriting pseudo styles like :hover etc, so there's a little bit of repetition to get it all to work.

### ✅ Checklist
- [x] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
