### PR TITLE
Updates Repeatable fields control button to not flicker on hover

### DIFF
--- a/lib/Field/FieldRepeatableControls.js
+++ b/lib/Field/FieldRepeatableControls.js
@@ -18,7 +18,7 @@ export function FieldRepeatableControls({
 
   const buttonClasses = cx(
     'mx-1',
-    'transition ease-animation-curve duration-200',
+    'transition-opacity ease-animation-curve duration-200',
     {
       'opacity-0 group-hover:opacity-100': !isActive
     }


### PR DESCRIPTION
### 💬 Description
The repeatable field controls up and down buttons were flickering on hover.

This was being caused by an animation class being inherited by the button from its parent, so on hover it was animating adding the background color, causing the flicker!

This PR updates the parents class name to only animate opacity, meaning the background color is no longer animated 🙏 
