### PR TITLE
Adds visible prop to FieldNew

### DIFF
--- a/lib/Field/FieldNew.js
+++ b/lib/Field/FieldNew.js
@@ -1,4 +1,5 @@
 import React, { createContext } from 'react';
+import { useSpring, animated } from 'react-spring';
 import { bool, node, oneOf, string } from 'prop-types';
 import cx from 'classnames';
 import {
@@ -23,10 +24,22 @@ const InStructureEditModeContext = createContext({
   inStructureEditMode: false
 });
 
-export function FieldNew({ children, className, dir, inStructureEditMode }) {
+export function FieldNew({
+  children,
+  className,
+  dir,
+  inStructureEditMode,
+  visible
+}) {
+  const animatedStyle = useSpring({
+    opacity: visible ? 1 : 0,
+    config: { duration: 100 }
+  });
+
   return (
     <InStructureEditModeContext.Provider value={{ inStructureEditMode }}>
-      <div
+      <animated.div
+        style={animatedStyle}
         className={cx(
           'group grid grid-cols-12 col-gap-8 field field-new has-formatting',
           className
@@ -34,7 +47,7 @@ export function FieldNew({ children, className, dir, inStructureEditMode }) {
         dir={dir}
       >
         {children}
-      </div>
+      </animated.div>
     </InStructureEditModeContext.Provider>
   );
 }
@@ -43,13 +56,15 @@ FieldNew.propTypes = {
   children: node.isRequired,
   className: string,
   dir: oneOf(['ltr', 'rtl']),
-  inStructureEditMode: bool
+  inStructureEditMode: bool,
+  visible: bool
 };
 
 FieldNew.defaultProps = {
   className: '',
   dir: 'ltr',
-  inStructureEditMode: false
+  inStructureEditMode: false,
+  visible: true
 };
 
 FieldNew.Content = FieldContent;

--- a/lib/Field/stories/FieldStory.js
+++ b/lib/Field/stories/FieldStory.js
@@ -39,6 +39,8 @@ storiesOf('Components', module).add('Field', () => {
   );
   const inStructureEditMode = boolean('In Structure Edit Mode', false);
 
+  const visible = boolean('Visible', true);
+
   const label = text('Field label', 'Field label text');
   const isActive = boolean(
     'Is active (only used by old component, use the state selector for NewField)',
@@ -81,6 +83,7 @@ storiesOf('Components', module).add('Field', () => {
           className={cx({ 'mb-0': isRepeatable })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
+          visible={visible}
         >
           <FieldNew.Meta>
             {isRepeatable && (
@@ -164,6 +167,7 @@ storiesOf('Components', module).add('Field', () => {
           })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
+          visible={visible}
         >
           <FieldNew.Meta>
             {isRepeatable && (
@@ -246,6 +250,7 @@ storiesOf('Components', module).add('Field', () => {
           })}
           dir={dir}
           inStructureEditMode={inStructureEditMode}
+          visible={visible}
         >
           <FieldNew.Meta>
             {isRepeatable && (


### PR DESCRIPTION
### 💬 Description
Adds `visible` prop to field new. When toggled, the field fades in and out using opacity.

This is used when we are loading in fields in the Waypoint solution. It felt janky for fields to appear instantly, so this gives it a softer edge!

https://share.getcloudapp.com/X6uNv6Jq

