### PR TITLE
Add styles for field editor, refactor Guideline

### DIFF
--- a/lib/ColField/styles.scss
+++ b/lib/ColField/styles.scss
@@ -1,0 +1,87 @@
+.col-field__body .ql-editor {
+  *:nth-child(1) {
+    @apply mt-0;
+  }
+  h1:nth-child(1) {
+    @apply -mt-1;
+  }
+
+  h2:nth-child(1),
+  h3:nth-child(1) {
+    margin-top: -.1rem;
+  }
+
+  h4:nth-child(1),
+  h5:nth-child(1),
+  h6:nth-child(1) {
+    margin-top: -.06rem;
+  }
+  p {
+    @apply mt-3 mb-5;
+  }
+
+  ul, ol {
+    @apply my-5;
+    ul, ol {
+      @apply my-0;
+    }
+  }
+
+  li {
+    @apply my-1;
+  }
+
+  table {
+    @apply w-full my-8 table-fixed;
+    td {
+      @apply w-full border border-solid border-neutral-20 p-1;
+    }
+  }
+
+  h1, h2, h3, h4, h5, h6, p, li {
+    @apply font-roman;
+  }
+
+  h1 {
+    @apply text-4xl leading-10 mt-8 mb-5;
+  }
+
+  h2 {
+    @apply text-3-5xl leading-9 mt-6 mb-3;
+  }
+
+  h3 {
+    @apply text-3xl leading-8 mt-6 mb-3;
+  }
+
+  h4 {
+    @apply text-2xl leading-7 my-3;
+  }
+
+  h5 {
+    @apply text-1xl leading-6 my-3;
+  }
+
+  h6 {
+    @apply text-xl leading-5 my-3;
+  }
+
+  p, li {
+    @apply text-lg leading-6;
+  }
+
+  *:last-child {
+    @apply mb-0;
+  }
+  @for $a from 1 through 6 {
+    @for $b from 1 through 6 {
+      h#{$a} + h#{$b} {
+        @apply mt-3;
+      }
+    }
+  }
+  &.ql-blank::before {
+    @apply absolute inset-x-0 text-neutral-primary cursor-text;
+    content: attr(data-placeholder);
+  }
+}

--- a/lib/Guideline/index.js
+++ b/lib/Guideline/index.js
@@ -1,93 +1,83 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { useState, useEffect, useRef } from 'react';
+import { node, arrayOf, oneOfType, string, func } from 'prop-types';
 import cx from 'classnames';
 import Button from '../Button';
 
-class Guideline extends Component {
-  static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.string
-    ]),
-    title: PropTypes.string.isRequired,
-    onToggle: PropTypes.func
-  };
+function Guideline({ children, title, onToggle, className }) {
+  const [showContent, setShowContent] = useState(true);
+  const [style, setStyle] = useState(null);
+  const guidelineBody = useRef(null);
 
-  static defaultProps = {
-    children: '',
-    onToggle: () => {}
-  };
-
-  state = { showContent: true, style: null };
-
-  componentDidMount() {
-    if (this.props.children) {
-      this.getHeight();
-    }
-  }
-
-  toggleShow = () => {
-    this.setState(
-      prevState => ({
-        showContent: !prevState.showContent
-      }),
-      () => this.props.onToggle(this.state.showContent)
-    );
-
-    this.getHeight();
-  };
-
-  getHeight = () => {
-    if (this.guidelineBody) {
-      const { height } = this.guidelineBody.getBoundingClientRect();
+  const getHeight = () => {
+    if (guidelineBody.current) {
+      const { height } = guidelineBody.current.getBoundingClientRect();
       if (height !== 0) {
-        this.setState({ style: { maxHeight: height } });
+        setStyle({ maxHeight: height });
       }
     }
   };
 
-  render() {
-    const toggleText = this.state.showContent
-      ? 'Hide guidelines'
-      : 'Show guidelines';
+  const toggleShow = () => {
+    const newShowContent = !showContent;
+    setShowContent(newShowContent);
+    onToggle(newShowContent);
+    getHeight();
+  };
 
-    const classNames = cx(
-      'guideline bg-blue-98 border border-blue-90 border-solid',
-      {
-        'is-active': this.state.showContent
-      }
-    );
+  useEffect(() => {
+    if (children) {
+      getHeight();
+    }
+  }, []);
 
-    return (
-      <div className={classNames}>
-        <div className="guideline__head">
-          <h2 className="guideline__title">{this.props.title}</h2>
-          {this.props.children && (
-            <Button
-              types={['link-default', 'collapse']}
-              onClick={this.toggleShow}
-              className="guideline__button"
-            >
-              {toggleText}
-            </Button>
-          )}
-        </div>
+  const toggleText = showContent ? 'Hide guidelines' : 'Show guidelines';
 
-        {this.props.children && (
-          <div
-            className="guideline__body"
-            style={this.state.showContent ? this.state.style : null}
-            ref={guidelineBody => {
-              this.guidelineBody = guidelineBody;
-            }}
+  const classNames = cx(
+    `guideline bg-blue-98 border border-blue-90 border-solid ${className}`,
+    {
+      'is-active': showContent
+    }
+  );
+
+  return (
+    <div className={classNames}>
+      <div className="guideline__head">
+        <h2 className="guideline__title">{title}</h2>
+        {children && (
+          <Button
+            types={['link-default', 'collapse']}
+            onClick={toggleShow}
+            className="guideline__button"
           >
-            {this.props.children}
-          </div>
+            {toggleText}
+          </Button>
         )}
       </div>
-    );
-  }
+
+      {children && (
+        <div
+          className="guideline__body"
+          style={showContent ? style : null}
+          ref={guidelineBody}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
 }
+
+Guideline.propTypes = {
+  children: oneOfType([node, arrayOf(node), string]),
+  title: string.isRequired,
+  onToggle: func,
+  className: string
+};
+
+Guideline.defaultProps = {
+  children: '',
+  onToggle: () => {},
+  className: ''
+};
 
 export default Guideline;

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -75,3 +75,4 @@
 @import '../../lib/Comment/styles.scss';
 @import '../../lib/TabsNew/styles.scss';
 @import '../../lib/Counter/styles.scss';
+@import '../../lib/ColField/styles.scss';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -148,6 +148,10 @@ module.exports = {
       },
       cursor: {
         grab: 'grab'
+      },
+      fontSize: {
+        '3-5xl': '2rem',
+        '1xl': '1.375rem'
       }
     },
     maxHeight: {

--- a/tests/Guideline/Guideline.js
+++ b/tests/Guideline/Guideline.js
@@ -21,7 +21,7 @@ describe('Guideline', () => {
   });
 
   test('toggles an active class', () => {
-    wrapper.setState({ showContent: false });
+    wrapper.find(Button).simulate('click');
     expect(wrapper.hasClass('is-active')).toBe(false);
   });
 
@@ -32,7 +32,7 @@ describe('Guideline', () => {
 
   test('switches the text for the show toggle', () => {
     expect(wrapper.find(Button).prop('children')).toEqual('Hide guidelines');
-    wrapper.setState({ showContent: false });
+    wrapper.find(Button).simulate('click');
     expect(wrapper.find(Button).prop('children')).toEqual('Show guidelines');
   });
 
@@ -46,7 +46,7 @@ describe('Guideline', () => {
     expect(wrapper.find('.guideline__body').prop('style')).toEqual({
       maxHeight: 120
     });
-    wrapper.setState({ showContent: false });
+    wrapper.find(Button).simulate('click');
     expect(wrapper.find('.guideline__body').prop('style')).toEqual(null);
   });
 


### PR DESCRIPTION
### 💬 Description
Turns out we need all these custom styles for quill editors within fields. I was umming and ahhing on whether this belonged in the app or here, since they're quite app specific. These live in GUI in the Field styles, so i thought I'd just follow that.

I also needed to pass className over to Guideline and thought I'd do a cheeky refactor while I was there.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
