### PR TITLE
Fix Guidelines max height

### DIFF
--- a/lib/Guideline/index.js
+++ b/lib/Guideline/index.js
@@ -28,7 +28,7 @@ function Guideline({ children, title, onToggle, className }) {
     if (children) {
       getHeight();
     }
-  }, []);
+  }, [guidelineBody.current]);
 
   const toggleText = showContent ? 'Hide guidelines' : 'Show guidelines';
 


### PR DESCRIPTION
### 💬 Description
When using this for Quill content we get into a bit of a race condition where we calculate the max height before the content had been populated. Tweaking the use effect fixes this.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
