### PR TITLE
Fix enabled prop warning

### DIFF
--- a/lib/ButtonNew/ButtonIcon/ButtonIcon.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIcon.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { bool } from 'prop-types';
 import cx from 'classnames';
 import { ButtonBase } from '../ButtonBase';
 import Icon from '../../Icon';
@@ -67,8 +68,14 @@ function ButtonIcon({
 
 ButtonIcon.sizes = sizes;
 
-ButtonIcon.propTypes = buttonIconPropTypes;
+ButtonIcon.propTypes = {
+  ...buttonIconPropTypes,
+  enabled: bool
+};
 
-ButtonIcon.defaultProps = buttonIconDefaultProps;
+ButtonIcon.defaultProps = {
+  ...buttonIconDefaultProps,
+  enabled: false
+};
 
 export { ButtonIcon };

--- a/lib/ButtonNew/common.js
+++ b/lib/ButtonNew/common.js
@@ -43,11 +43,9 @@ export const buttonIconPropTypes = {
   ...omit(propTypes, 'children'),
   active: bool,
   iconTitle: string,
-  name: string.isRequired,
-  enabled: bool
+  name: string.isRequired
 };
 export const buttonIconDefaultProps = {
   ...defaultProps,
-  active: false,
-  enabled: false
+  active: false
 };


### PR DESCRIPTION
### 💬 Description
fixes: https://share.getcloudapp.com/rRu74Jpp

Only base ButtonIcon has this and deals with this prop, so it does not need to be in the shared prop types

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
