### PR TITLE
Removing the margin from figure

### DIFF
--- a/lib/Figure/styles.scss
+++ b/lib/Figure/styles.scss
@@ -30,7 +30,6 @@ $figure-border-radius: 3px !default;
   border-radius: $figure-border-radius;
   width: $figure-size;
   padding-bottom: $figure-size;
-  margin: 0 0 $layout-spacing-base/2;
   height: 0;
 
   img {


### PR DESCRIPTION
### 💬 Description
The figure in the asset field now is separated using the css grid gap, meaning we no longer need the margin!

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
