### PR TITLE
Feature/borders and figures

### DIFF
--- a/stories/components/Figure.js
+++ b/stories/components/Figure.js
@@ -6,7 +6,7 @@ import Col from 'react-bootstrap/lib/Col';
 import { Figure, Icon, TooltipWrapper, FigurePlaceholder } from '../../lib';
 import StoryItem from '../styleguide/StoryItem';
 
-const trashButton = <a key="hello"><Icon name="trash" /></a>;
+const trashButton = <a tabIndex={0} key="hello"><Icon name="trash" /></a>;
 const commentButton = <button onClick={action('test')} key="hello2"><Icon name="comment" /></button>;
 const fullScreenButton = <button onClick={action('test')} key="hello3"><Icon name="fullScreen" /></button>;
 const downloadButton = <button onClick={action('test')} key="hello4">{<Icon name="quoteStart" />}</button>;
@@ -19,7 +19,8 @@ storiesOf('Components', module).add('Figure', () => (
       description="A Figure showing a preview of the file."
     >
       <Row>
-        <Col xs={4}>
+        <button className='group relative w-64 h-64 overflow-hidden pseudo-border-blue-2px rounded
+          p-0 m-0 border-0 outline-none text-left focus:shadow-button-tertiary-focus '>
           <Figure
             filename="cute_sheep_in_iceland.jpg"
             label="Sheep in Iceland"
@@ -28,7 +29,13 @@ storiesOf('Components', module).add('Figure', () => (
           >
             {actions}
           </Figure>
-        </Col>
+          <span title='cute_sheep_in_iceland'
+                className="absolute bottom-0 bg-white text-neutral-20 w-full text-base leading-6 py-2 px-3 h-10 truncate
+                          -mb-10 group-hover:mb-0 transition-mb duration-200"
+          >
+            cute_sheep_in_iceland
+          </span>
+        </button>
       </Row>
     </StoryItem>
 

--- a/styles/helpers/_borders.scss
+++ b/styles/helpers/_borders.scss
@@ -1,5 +1,5 @@
 .pseudo-border-blue-2px {
-  @include before-border(
+  @include after-border(
     2px,
     solid,
     theme('colors.blue.primary'),

--- a/styles/tools/_mixins.scss
+++ b/styles/tools/_mixins.scss
@@ -147,3 +147,20 @@
     pointer-events: none;
   }
 }
+
+/**
+ * A border that appears in the `after` element - this may be useful if the content messes with z-indexes
+ */
+@mixin after-border($pixelSize, $style, $colour, $radius) {
+  &:after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 100%;
+    border: $pixelSize $style $colour;
+    border-radius: $radius;
+    pointer-events: none;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -136,6 +136,9 @@ module.exports = {
       transitionTimingFunction: {
         'animation-curve': 'cubic-bezier(0.68, -0.55, 0.265, 1.55)'
       },
+      transitionProperty: {
+        'mb': 'margin-bottom',
+      },
       opacity: {
         '30': 0.3
       },
@@ -249,7 +252,7 @@ module.exports = {
       'hover',
       'focus-within'
     ],
-    margin: ['responsive', 'focus', 'hover', 'focus-within'],
+    margin: ['responsive', 'group-hover', 'focus', 'hover', 'focus-within'],
     gradients: ['responsive', 'hover', 'group-hover'],
     backgroundColor: ['responsive', 'group-hover', 'hover', 'focus', 'active'],
     border: ['focus'],


### PR DESCRIPTION
### 💬 Description
To support the new designs for the files project library, we need to tweak the border styles of namely the `pseudo-border-blue-2px`, to get around z-index issues and pseudo before elements.
Also updated the example in the storybook.

Unfortunately, we can only use `group-hover` tailwind css pseudo selector; we cant use `group-focus` until we upgrade to 1.3+.

### 🔗 Links
https://www.figma.com/file/7uaL7O73bIuNhyBnfLs6lt/Upload-modal?node-id=3%3A3298

### 📹 GIF (optional)
![Screen Recording 2020-09-23 at 04 44 26 pm](https://user-images.githubusercontent.com/3472717/94036423-33070b00-fdbc-11ea-9fc2-029ed593ce1e.gif)


### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
