### PR TITLE
Stop SearchInputs from spanning 100% width

### DIFF
--- a/lib/SearchInput/index.js
+++ b/lib/SearchInput/index.js
@@ -10,7 +10,9 @@ function SearchInputField({
   hideIcon,
   value,
   label,
-  id
+  id,
+  className,
+  inputClassName
 }) {
   const transitionsForClearButton = useTransition(value, null, {
     from: { opacity: 0 },
@@ -19,7 +21,7 @@ function SearchInputField({
   });
 
   return (
-    <span className="relative flex items-center">
+    <span className={`relative inline-flex items-center ${className}`}>
       {label && (
         <label className="visually-hidden" htmlFor={id}>
           {label}
@@ -29,7 +31,7 @@ function SearchInputField({
       <input
         value={value}
         onChange={onChangeHandler}
-        className="border border-solid border-neutral-90 focus:border-blue-primary text-base rounded m-0 w-full p-2 pl-8 outline-none transition-colors duration-200"
+        className={`border border-solid border-neutral-90 focus:border-blue-primary text-base rounded m-0 w-full p-2 pl-8 outline-none transition-colors duration-200 ${inputClassName}`}
         placeholder={placeholder}
         id={id}
       />
@@ -54,7 +56,9 @@ SearchInputField.defaultProps = {
   hideIcon: false,
   value: '',
   label: null,
-  id: null
+  id: null,
+  className: '',
+  inputClassName: ''
 };
 
 SearchInputField.propTypes = {
@@ -64,7 +68,9 @@ SearchInputField.propTypes = {
   hideIcon: PropTypes.bool,
   value: PropTypes.string,
   label: PropTypes.string,
-  id: PropTypes.string
+  id: PropTypes.string,
+  className: PropTypes.string,
+  inputClassName: PropTypes.string
 };
 
 export default SearchInputField;


### PR DESCRIPTION
### 💬 Description
Like the title says, we don't want this to happen. 
![Screenshot 2020-09-29 at 09 45 52](https://user-images.githubusercontent.com/12775966/94534686-979cec80-0238-11eb-85b2-1214e63092cc.png)
If we use inline-flex instead of flex the element doesnt take up the entire width it can. I've also added the ability to add classnames, since this always is needed at some point

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
