### PR TITLE
Add an InputConfirmationModal component

### DIFF
--- a/lib/InputConfirmationModal/InputConfirmationModal.js
+++ b/lib/InputConfirmationModal/InputConfirmationModal.js
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { node, string, bool, func, oneOfType } from 'prop-types';
+import {
+  Modal,
+  FormInput,
+  ButtonPrimaryDanger,
+  ButtonTertiary,
+  ButtonSecondary
+} from 'lib';
+
+function InputConfirmationModal({
+  onHide,
+  show,
+  introTitle,
+  confirmTitle,
+  introBody,
+  confirmBody,
+  buttonText,
+  confirmKeyword,
+  onConfirm,
+  className,
+  loading,
+  skipConfirm,
+  ...rest
+}) {
+  const [value, setValue] = useState('');
+  const [showIntro, setShowIntro] = useState(true);
+
+  const disableButton = (!skipConfirm && value !== confirmKeyword) || loading;
+
+  return (
+    <Modal.Container
+      className={`modal--clear modal--input-confirm ${className}`}
+      show={show}
+      onHide={onHide}
+      {...rest}
+    >
+      <Modal.Header>{showIntro ? introTitle : confirmTitle}</Modal.Header>
+      <Modal.Body>
+        {showIntro ? (
+          introBody
+        ) : (
+          <>
+            {confirmBody}
+            <FormInput
+              className="mt-3 w-64"
+              value={value}
+              onInputChange={setValue}
+              placeholder={`Type ${confirmKeyword} to confirm`}
+            />
+          </>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <ButtonTertiary onClick={onHide}>Cancel</ButtonTertiary>
+        {showIntro && !skipConfirm ? (
+          <ButtonSecondary onClick={() => setShowIntro(false)}>
+            Confirm
+          </ButtonSecondary>
+        ) : (
+          <ButtonPrimaryDanger
+            onClick={onConfirm}
+            disabled={disableButton}
+            loading={loading}
+          >
+            {buttonText}
+          </ButtonPrimaryDanger>
+        )}
+      </Modal.Footer>
+    </Modal.Container>
+  );
+}
+
+InputConfirmationModal.propTypes = {
+  onHide: func,
+  show: bool,
+  introTitle: string.isRequired,
+  confirmTitle: string.isRequired,
+  introBody: oneOfType([string, node]).isRequired,
+  confirmBody: oneOfType([string, node]).isRequired,
+  buttonText: string,
+  confirmKeyword: string,
+  onConfirm: func.isRequired,
+  className: string,
+  loading: bool,
+  skipConfirm: bool
+};
+
+InputConfirmationModal.defaultProps = {
+  onHide: () => {},
+  show: false,
+  buttonText: 'Delete',
+  confirmKeyword: 'DELETE',
+  className: '',
+  loading: false,
+  skipConfirm: false
+};
+
+export default InputConfirmationModal;

--- a/lib/InputConfirmationModal/styles.scss
+++ b/lib/InputConfirmationModal/styles.scss
@@ -1,0 +1,15 @@
+.modal--input-confirm {
+  .modal-header-inner,
+  .modal-footer {
+    @apply p-0;
+  }
+  .modal-body {
+    @apply px-0 leading-6;
+  }
+  .modal-content {
+    @apply p-6;
+  }
+  .modal-header .close {
+    @apply static;
+  }
+}

--- a/lib/InputConfirmationModal/tests/InputConfirmationModal.spec.js
+++ b/lib/InputConfirmationModal/tests/InputConfirmationModal.spec.js
@@ -1,0 +1,65 @@
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import { InputConfirmationModal } from 'lib';
+import { React } from 'tests/setup';
+
+describe('ColField', () => {
+  const onConfirmSpy = jest.fn();
+  const defaultProps = {
+    onConfirm: onConfirmSpy,
+    introTitle: 'Do a delete',
+    confirmTitle: 'Confirm a delete',
+    introBody: 'ready to delete something?',
+    confirmBody: 'are you sure you are sure?',
+    show: true,
+    onHide: jest.fn()
+  };
+
+  const renderWrapper = (props = defaultProps) =>
+    render(<InputConfirmationModal {...props} />);
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test('makes you confirm by typing the keyword', () => {
+    const { getByText, getByPlaceholderText } = renderWrapper();
+    expect(getByText(defaultProps.introTitle));
+    expect(getByText(defaultProps.introBody));
+    fireEvent.click(getByText('Confirm'));
+
+    expect(getByText(defaultProps.confirmTitle));
+    expect(getByText(defaultProps.confirmBody));
+    fireEvent.click(getByText('Delete'));
+    expect(onConfirmSpy).not.toBeCalled();
+
+    const confirmInput = getByPlaceholderText('Type DELETE to confirm');
+    fireEvent.change(confirmInput, {
+      target: {
+        value: 'PLOP'
+      }
+    });
+    fireEvent.click(getByText('Delete'));
+    expect(onConfirmSpy).not.toBeCalled();
+
+    fireEvent.change(confirmInput, {
+      target: {
+        value: 'DELETE'
+      }
+    });
+    fireEvent.click(getByText('Delete'));
+    expect(onConfirmSpy).toBeCalled();
+  });
+
+  test('lets you skip the confirmation', () => {
+    const { getByText } = renderWrapper({
+      ...defaultProps,
+      skipConfirm: true
+    });
+    expect(getByText(defaultProps.introTitle));
+    expect(getByText(defaultProps.introBody));
+    fireEvent.click(getByText('Delete'));
+    expect(onConfirmSpy).toBeCalled();
+  });
+});

--- a/lib/InputConfirmationModal/tests/InputConfirmationModal.spec.js
+++ b/lib/InputConfirmationModal/tests/InputConfirmationModal.spec.js
@@ -2,7 +2,7 @@ import { cleanup, render, fireEvent } from '@testing-library/react';
 import { InputConfirmationModal } from 'lib';
 import { React } from 'tests/setup';
 
-describe('ColField', () => {
+describe('InputConfirmationModal', () => {
   const onConfirmSpy = jest.fn();
   const defaultProps = {
     onConfirm: onConfirmSpy,

--- a/lib/index.js
+++ b/lib/index.js
@@ -150,3 +150,4 @@ export { useDeferredList } from './useDeferredList/useDeferredList';
 export EditableChoiceInput from './EditableChoiceInput';
 export ColField from './ColField/ColField';
 export SelectionModal from './SelectionModal/SelectionModal';
+export InputConfirmationModal from './InputConfirmationModal/InputConfirmationModal';

--- a/stories/components/Modals.js
+++ b/stories/components/Modals.js
@@ -19,7 +19,8 @@ import {
     Icon,
     ImageLoader,
     SelectionModal,
-    Checkbox
+    Checkbox,
+    InputConfirmationModal
 } from '../../lib';
 import StoryItem from '../styleguide/StoryItem';
 import Navigation from "../../lib/Navigation";
@@ -614,6 +615,20 @@ storiesOf('Components', module).add('Modals', () => (
                 </Button>
                 </Modal.Footer>
             </SelectionModal>
+          </ModalTrigger>
+        </StoryItem>
+        <StoryItem
+          title="InputConfirmationModal"
+          description="A modal to make sure you are really sure that you want to do something."
+        >
+          <ModalTrigger>
+            <InputConfirmationModal
+              introTitle="Delete templates"
+              confirmTitle="Confirm deletion"
+              introBody="This template is currently being used. Any items using this template will be converted to use a custom structure. Are you sure you want to continue?"
+              confirmBody="Template deletion is permanent and cannot be undone. Please confirm you want to delete this template by typing ‘DELETE’ in the box below."
+              onConfirm={() => {}}
+            />
           </ModalTrigger>
         </StoryItem>
     </div>

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -76,3 +76,4 @@
 @import '../../lib/Counter/styles.scss';
 @import '../../lib/ColField/styles.scss';
 @import '../../lib/SelectionModal/styles.scss';
+@import '../../lib/InputConfirmationModal/styles.scss';


### PR DESCRIPTION
### 💬 Description
This adds a new modal for making people type in a keyword to confirm they do definitely want to do a thing. 
### 📹 GIF (optional)
http://g.recordit.co/oStjH8rurV.gif

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
