### PR TITLE
Updates useDeferredList to output itemCount rather than deferredList

### DIFF
--- a/lib/useDeferredList/specs/useDeferredList.spec.js
+++ b/lib/useDeferredList/specs/useDeferredList.spec.js
@@ -1,69 +1,76 @@
-import { times } from 'lodash';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useDeferredList } from '../useDeferredList';
 
 describe('useDeferredList', () => {
-  const list = times(100, index => index);
-  const options = { list, initialItemCount: 10, numberOfItemsToLoad: 5 };
+  const options = {
+    listLength: 100,
+    initialItemCount: 10,
+    numberOfItemsToLoad: 5
+  };
 
-  it('should render the initial list items', () => {
+  it('should return initialItemCount for itemCount', () => {
     const { result } = renderHook(() => useDeferredList(options));
 
-    expect(result.current.deferredList).toEqual(times(10, index => index));
+    expect(result.current.itemCount).toEqual(10);
   });
 
-  it('should load more items when loadItems is called', () => {
+  it('should increase the itemCount when loadItems is called', () => {
     const { result } = renderHook(() => useDeferredList(options));
 
-    expect(result.current.deferredList).toEqual(times(10, index => index));
+    expect(result.current.itemCount).toEqual(10);
 
     act(() => result.current.loadItems());
 
-    expect(result.current.deferredList).toEqual(times(15, index => index));
+    expect(result.current.itemCount).toEqual(15);
   });
 
-  it('should load more items if the initialItems argument is updated to a higher number than the current item count', () => {
+  it('should increase itemCount if the initialItems argument is updated to a higher number than the current itemCount', () => {
     let initialItemCount = 10;
 
     const { result, rerender } = renderHook(
-      () => useDeferredList({ initialItemCount, list, numberOfItemsToLoad: 5 }),
+      () =>
+        useDeferredList({
+          initialItemCount,
+          listLength: 100,
+          numberOfItemsToLoad: 5
+        }),
       {}
     );
 
-    expect(result.current.deferredList).toEqual(times(10, index => index));
+    expect(result.current.itemCount).toEqual(10);
 
     initialItemCount = 15;
     rerender();
     rerender();
 
-    expect(result.current.deferredList).toEqual(times(15, index => index));
+    expect(result.current.itemCount).toEqual(15);
   });
 
-  it('should not error if you try to load more items when already at the item limit', () => {
+  it('should not error if you call loadItems when already at the item limit', () => {
     const { result } = renderHook(() =>
-      useDeferredList({ ...options, list: times(10, index => index) })
+      useDeferredList({ ...options, listLength: 10 })
     );
 
-    expect(result.current.deferredList).toEqual(times(10, index => index));
+    expect(result.current.itemCount).toEqual(10);
 
     act(() => result.current.loadItems());
 
-    expect(result.current.deferredList).toEqual(times(10, index => index));
+    expect(result.current.itemCount).toEqual(10);
   });
 
   it('should not error if you try to load more items than are in the list', () => {
     const { result } = renderHook(() =>
       useDeferredList({
-        list: times(10, index => index),
+        listLength: 10,
         initialItemCount: 5,
         numberOfItemsToLoad: 6
       })
     );
 
-    expect(result.current.deferredList).toEqual(times(5, index => index));
+    expect(result.current.itemCount).toEqual(5);
 
     act(() => result.current.loadItems());
 
-    expect(result.current.deferredList).toEqual(times(10, index => index));
+    expect(result.current.itemCount).toEqual(10);
   });
 });

--- a/lib/useDeferredList/useDeferredList.js
+++ b/lib/useDeferredList/useDeferredList.js
@@ -1,24 +1,23 @@
 import { useState, useEffect } from 'react';
 
-function useDeferredList({ list, initialItemCount, numberOfItemsToLoad }) {
-  const [deferredList, setDeferredList] = useState([]);
+function useDeferredList({
+  listLength,
+  initialItemCount,
+  numberOfItemsToLoad
+}) {
   const [itemCount, setItemCount] = useState(initialItemCount);
 
   const setItemCountWithinLimits = count => {
-    if (count === list.length) {
+    if (count === listLength) {
       return;
     }
 
-    setItemCount(Math.min(list.length, count));
+    setItemCount(Math.min(listLength, count));
   };
 
   const loadItems = () => {
     setItemCountWithinLimits(itemCount + numberOfItemsToLoad);
   };
-
-  useEffect(() => {
-    setDeferredList(list.slice(0, itemCount));
-  }, [itemCount]);
 
   useEffect(() => {
     if (initialItemCount > itemCount) {
@@ -27,8 +26,8 @@ function useDeferredList({ list, initialItemCount, numberOfItemsToLoad }) {
   }, [initialItemCount]);
 
   return {
-    deferredList,
-    loadItems
+    loadItems,
+    itemCount
   };
 }
 


### PR DESCRIPTION
> ⚠️ Follows on from https://github.com/gathercontent/gather-ui/pull/876
### 💬 Description
#### ⁉️ Problem
Previously, `useDeferredList` worked as follows:
```javascript
const list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];

const { deferredList, loadItems } = useDeferredList({
  list,
  initialItemCount: 5,
  numberOfItemsToLoad: 5
});

console.log(deferredList) // [1,2,3,4,5]

loadItems()
console.log(deferredList) // [1,2,3,4,5,6,7,8,9,10]
```
☝️ This is fine until the list is changed, at which point the deferred version of the list stored in `useDeferredList` state becomes stale!
```javascript
let list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];

const { deferredList, loadItems } = useDeferredList({
  list,
  initialItemCount: 5,
  numberOfItemsToLoad: 5
});

console.log(deferredList); // [1,2,3,4,5]

loadItems();
console.log(deferredList); // [1,2,3,4,5,6,7,8,9,10]

list = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]; // List change, imagine this change coming from prop change

console.log(deferredList) // [1,2,3,4,5,6,7,8,9,10] - INCORRECT! 😱
```
#### ✅ Solution
This PR updates `useDeferredList` to output the number of items to display in the list, rather than the sliced list itself.

This way, if the list changes in a render pass, then the values are updated!
```javascript
let list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];

const { itemCount, loadItems } = useDeferredList({
  listLength: list.length,
  initialItemCount: 5,
  numberOfItemsToLoad: 5
});

const deferredList = list.slice(0, itemCount) // Slice the list ourselves

console.log(deferredList); // [1,2,3,4,5]

loadItems();
console.log(deferredList); // [1,2,3,4,5,6,7,8,9,10]

list = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]; // List updated on render pass

console.log(deferredList) // [11, 12, 13, 14, 15, 16, 17, 18, 19, 20] - CORRECT! ✅
```