### PR TITLE
Update/colfield animate transparent from

### DIFF
--- a/lib/ColField/ColField.js
+++ b/lib/ColField/ColField.js
@@ -21,6 +21,7 @@ const statuses = {
 function ColField({ children, className, visible, style, status, ...props }) {
   const animatedStyle = useSpring({
     opacity: visible ? 1 : 0,
+    from: { opacity: 0 },
     config: { duration: 100 }
   });
 

--- a/lib/Guideline/index.js
+++ b/lib/Guideline/index.js
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { node, arrayOf, oneOfType, string, func } from 'prop-types';
+import { useSpring, animated } from 'react-spring';
+import { node, arrayOf, oneOfType, string, func, bool } from 'prop-types';
 import cx from 'classnames';
 import Button from '../Button';
 
-function Guideline({ children, title, onToggle, className, dir }) {
+function Guideline({ children, title, onToggle, className, dir, visible }) {
   const [showContent, setShowContent] = useState(true);
   const [style, setStyle] = useState(null);
   const guidelineBody = useRef(null);
@@ -44,8 +45,14 @@ function Guideline({ children, title, onToggle, className, dir }) {
     'mr-auto': dir === 'rtl ml-0'
   });
 
+  const animatedStyle = useSpring({
+    opacity: visible ? 1 : 0,
+    from: { opacity: 0 },
+    config: { duration: 300 }
+  });
+
   return (
-    <div className={classNames} dir={dir}>
+    <animated.div style={animatedStyle} className={classNames} dir={dir}>
       <div className="guideline__head">
         <h2 className="guideline__title">{title}</h2>
         {children && (
@@ -68,7 +75,7 @@ function Guideline({ children, title, onToggle, className, dir }) {
           {children}
         </div>
       )}
-    </div>
+    </animated.div>
   );
 }
 
@@ -77,14 +84,16 @@ Guideline.propTypes = {
   title: string.isRequired,
   onToggle: func,
   className: string,
-  dir: string
+  dir: string,
+  visible: bool
 };
 
 Guideline.defaultProps = {
   children: '',
   onToggle: () => {},
   className: '',
-  dir: 'ltr'
+  dir: 'ltr',
+  visible: true
 };
 
 export default Guideline;


### PR DESCRIPTION
### 💬 Description
- [Updates ColField to fade in from opacity 0. This means if it's visible prop is true from the start, it will still fade in](https://github.com/gathercontent/gather-ui/pull/881/files#diff-861c1781ce7fa541fbe68d4f05b0f630c64328c01522e1d599eaa202e49f862a)
- [Adds visible prop to Guidelines](https://github.com/gathercontent/gather-ui/pull/881/files#diff-30599b96694af4e72599801c7a29b56b51207fc07ad3b5fa89f44d9becb7e6f0)

Related to https://github.com/gathercontent/app/pull/3417