### PR TITLE
Add ButtonIcon for darker backgrounds

### DIFF
--- a/lib/ButtonNew/ButtonBase.js
+++ b/lib/ButtonNew/ButtonBase.js
@@ -26,7 +26,8 @@ function ButtonBase({
 
       'text-base py-3 px-4': size && size === sizes.md,
       'text-base p-2': size && size === sizes.sm,
-      'text-sm p-05 px-2 rounded-small': size && size === sizes.xs
+      'text-sm p-05 px-2 rounded-small': size && size === sizes.xs,
+      'pointer-events-none': disabled
     }
   );
 

--- a/lib/ButtonNew/ButtonIcon/ButtonIconDark.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIconDark.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import cx from 'classnames';
+import { Icon } from 'lib';
+import { ButtonBase } from '../ButtonBase';
+import {
+  sizes,
+  getSizeClasses,
+  buttonIconPropTypes,
+  buttonIconDefaultProps
+} from '../common';
+
+function ButtonIconDark({
+  className,
+  disabled,
+  name,
+  active,
+  size,
+  iconTitle,
+  children,
+  ...rest
+}) {
+  const nonDisabledClasses = cx(
+    'bg-transparent border-transparent focus:bg-neutral-40 focus:border-white focus:shadow-button-icon-dark-focus',
+    {
+      'active:bg-neutral-40 active:border-neutral-40 active:shadow-none hover:bg-neutral-30 hover:border-neutral-30': !active,
+      'button__icon-active bg-neutral-40 border-neutral-40 hover:bg-neutral-30': active
+    }
+  );
+
+  const classes = cx(
+    className,
+    'button__icon',
+    'p-0',
+    'items-center justify-center',
+    {
+      [nonDisabledClasses]: !disabled,
+      'opacity-30 border-transparent bg-transparent': disabled,
+      'rounded-small': size === sizes.sm
+    },
+    getSizeClasses(size)
+  );
+
+  const iconTypes = [];
+
+  if (!disabled) {
+    iconTypes.push('white-on-button-parent-active');
+  }
+
+  if (!active) {
+    iconTypes.push('neutral-70');
+  }
+
+  if (active) {
+    iconTypes.push('white');
+  }
+
+  return (
+    <ButtonBase className={classes} disabled={disabled} size={false} {...rest}>
+      <Icon name={name} types={iconTypes} title={iconTitle} />
+      {children}
+    </ButtonBase>
+  );
+}
+
+ButtonIconDark.sizes = sizes;
+
+ButtonIconDark.propTypes = buttonIconPropTypes;
+
+ButtonIconDark.defaultProps = buttonIconDefaultProps;
+
+export { ButtonIconDark };

--- a/lib/ButtonNew/ButtonIcon/ButtonIconDark.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIconDark.js
@@ -56,7 +56,13 @@ function ButtonIconDark({
 
   return (
     <ButtonBase className={classes} disabled={disabled} size={false} {...rest}>
-      <Icon name={name} types={iconTypes} title={iconTitle} />
+      <Icon
+        name={name}
+        types={iconTypes}
+        title={iconTitle}
+        defaultActiveColor={false}
+        defaultFillColor={false}
+      />
       {children}
     </ButtonBase>
   );

--- a/lib/ButtonNew/stories/ButtonIcon/ButtonIconDark.js
+++ b/lib/ButtonNew/stories/ButtonIcon/ButtonIconDark.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { ButtonIconDark } from '../../ButtonIcon/ButtonIconDark';
+import StoryItem from '../../../../stories/styleguide/StoryItem';
+import { ButtonStoryItem } from '../ButtonStoryItem';
+import { Counter } from '../../../Counter';
+
+storiesOf('Components', module).add('ButtonIconDark', () => (
+  <StoryItem
+    title="ButtonIconDark"
+    description="The icon button component for dark backgrounds"
+  >
+    <div className="flex flex-wrap justify-around bg-neutral-20 pb-4 text-white">
+      <ButtonStoryItem title="MD">
+        <ButtonIconDark name="blockquote24" size={ButtonIconDark.sizes.md} />
+      </ButtonStoryItem>
+
+      <ButtonStoryItem title="SM">
+        <ButtonIconDark name="caption16" size={ButtonIconDark.sizes.sm} />
+      </ButtonStoryItem>
+
+      <ButtonStoryItem title="Disabled">
+        <ButtonIconDark name="caption16" disabled />
+      </ButtonStoryItem>
+
+      <ButtonStoryItem title="Active">
+        <ButtonIconDark name="caption16" active />
+      </ButtonStoryItem>
+
+      <ButtonStoryItem title="Counter">
+        <ButtonIconDark name="caption16">
+          <Counter>9</Counter>
+        </ButtonIconDark>
+      </ButtonStoryItem>
+    </div>
+  </StoryItem>
+));

--- a/lib/Dropdown/DropdownAction.js
+++ b/lib/Dropdown/DropdownAction.js
@@ -28,7 +28,7 @@ const DropdownAction = ({
     'dropdown__action--icon-only': iconOnly,
     'dropdown__action--selected': selected,
     'dropdown__action--overflow': overflow,
-    'dropdown__action--disabled': disabled
+    'dropdown__action--disabled pointer-events-none': disabled
   });
 
   const sharedProps = {

--- a/lib/Icon/styles.scss
+++ b/lib/Icon/styles.scss
@@ -125,6 +125,11 @@ $icon-active-color: $color-brand-blue !default;
   @apply fill-current;
 }
 
+.icon.icon--neutral-70 path {
+  @apply text-neutral-70;
+  @apply fill-current;
+}
+
 .icon.icon--purple path {
   @apply text-purple-primary fill-current #{!important};
 }
@@ -135,4 +140,8 @@ button:active .icon--blue-on-button-parent-active path  {
 
 button:active .icon--red-on-button-parent-active path  {
   fill: $primary-red;
+}
+
+button:active .icon--white-on-button-parent-active path  {
+  fill: white;
 }

--- a/lib/TopBar/styles.scss
+++ b/lib/TopBar/styles.scss
@@ -154,7 +154,7 @@ $top-bar-notification-height: 42px;
       color: white;
     }
     .top-bar__action,
-    .icon path {
+    .icon.icon--default-fill-color path {
       fill: white;
     }
     .top-bar__cell--bordered {

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,3 +151,4 @@ export EditableChoiceInput from './EditableChoiceInput';
 export ColField from './ColField/ColField';
 export SelectionModal from './SelectionModal/SelectionModal';
 export InputConfirmationModal from './InputConfirmationModal/InputConfirmationModal';
+export { ButtonIconDark } from './ButtonNew/ButtonIcon/ButtonIconDark';

--- a/stories/index.js
+++ b/stories/index.js
@@ -76,6 +76,7 @@ import '../lib/ButtonNew/stories/ButtonIcon/ButtonIcon';
 import '../lib/ButtonNew/stories/ButtonLink/ButtonLink';
 import '../lib/ButtonNew/stories/ButtonIcon/ButtonIconDanger';
 import '../lib/ButtonNew/stories/ButtonIcon/ButtonIconBubble';
+import '../lib/ButtonNew/stories/ButtonIcon/ButtonIconDark';
 import '../lib/Toolbar/stories/Toolbar';
 import '../lib/OptionMenu/stories/OptionMenu';
 import '../lib/Select/stories/Select';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ const red80 = '#F5A3AA';
 const redPrimary = '#E51A2B';
 
 const neutral20 = '#29333D';
+const neutral40 = '#52667A';
 const neutral80 = '#C2CCD6';
 const neutral90 = '#E1E6EB';
 
@@ -53,6 +54,7 @@ module.exports = {
       'button-icon-danger-focus': `0px 0px 0px 3px ${red80}`,
       'button-icon-bubble-focus': `0px 0px 0px 3px ${blue80}`,
       'button-icon-enabled-focus': `0px 0px 0px 3px ${green80}`,
+      'button-icon-dark-focus': `0px 0px 0px 3px ${neutral40}`,
 
       'bottom-inset': 'inset 0px -4px 4px rgba(0, 0, 0, 0.06)',
       'top-inset': 'inset 0px 4px 4px rgba(0, 0, 0, 0.06)',
@@ -128,7 +130,7 @@ module.exports = {
           '70': '#A4B3C2',
           '60': '#8599AD',
           primary: '#678099',
-          '40': '#52667A',
+          '40': neutral40,
           '30': '#3E4D5C',
           '20': neutral20
         }


### PR DESCRIPTION
### 💬 Description
A lovely new Button type, this time to work with darker backgrounds. 

I've also added pointer events none to disabled Buttons/DropdownActions, this is a work around for tooltips to work on disabled elements that I generally have to add in. 
### 📹 GIF (optional)
![Screenshot 2020-10-19 at 17 20 12](https://user-images.githubusercontent.com/12775966/96478498-a707c800-122f-11eb-82db-df63a2c377fb.png)

### 🚪 Start Points
lib/ButtonNew/ButtonIcon/ButtonIconDark.js

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
