### PR TITLE
Improve loader & add FileCard thumbnail example with improved fallback padding.

### DIFF
--- a/lib/ButtonNew/ButtonIcon/ButtonIcon.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIcon.js
@@ -34,12 +34,7 @@ function ButtonIcon({
 
   return (
     <ButtonBase className={classes} disabled={disabled} size={false} {...rest}>
-      <Icon
-        name={name}
-        title={iconTitle}
-        defaultFillColor={false}
-        defaultActiveColor={false}
-      />
+      <Icon name={name} title={iconTitle} />
       {children}
     </ButtonBase>
   );

--- a/lib/ButtonNew/ButtonIcon/ButtonIconContained.js
+++ b/lib/ButtonNew/ButtonIcon/ButtonIconContained.js
@@ -1,13 +1,10 @@
 import React from 'react';
 import { ButtonIcon } from 'lib';
-import { buttonIconDefaultProps } from '../common';
 
 function ButtonIconContained(props) {
   const classNames = `button-icon-contained ${props.className}`;
 
   return <ButtonIcon className={classNames} {...props} />;
 }
-
-ButtonIconContained.propTypes = buttonIconDefaultProps;
 
 export { ButtonIconContained };

--- a/lib/ButtonNew/ButtonIcon/styles/buttonIconContained.scss
+++ b/lib/ButtonNew/ButtonIcon/styles/buttonIconContained.scss
@@ -1,10 +1,6 @@
 .button-icon-contained {
   @apply border border-solid border-neutral-90 bg-white;
 
-  path {
-    fill: theme('colors.neutral.primary');
-  }
-
   &:hover:not([disabled]) {
     @apply bg-blue-90 border-blue-primary;
 

--- a/lib/ButtonNew/ButtonIcon/styles/buttonIconContained.scss
+++ b/lib/ButtonNew/ButtonIcon/styles/buttonIconContained.scss
@@ -1,6 +1,10 @@
 .button-icon-contained {
   @apply border border-solid border-neutral-90 bg-white;
 
+  path {
+    fill: theme('colors.neutral.primary');
+  }
+
   &:hover:not([disabled]) {
     @apply bg-blue-90 border-blue-primary;
 

--- a/lib/ButtonNew/stories/ButtonIcon/ButtonIconStory.js
+++ b/lib/ButtonNew/stories/ButtonIcon/ButtonIconStory.js
@@ -19,7 +19,7 @@ storiesOf('Components/Buttons', module).add('ButtonIcon', () => (
       <ButtonStoryItem title="Base (MD)">
         {states.map(s => (
           <div className="h-16">
-            <ButtonIcon name="blockquote24" size={ButtonIcon.sizes.md} {...s} />
+            <ButtonIcon name="fullScreen" size={ButtonIcon.sizes.md} {...s} />
           </div>
         ))}
       </ButtonStoryItem>

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,3 +160,4 @@ export { FileCard } from './src/components/files/fileCard/FileCard';
 export { Meta } from './src/modules/meta/Meta';
 export { PreviewImage } from './src/modules/preview/PreviewImage';
 export { Controls } from './src/modules/controls/Controls';
+export { Loader } from './src/modules/loader/Loader';

--- a/lib/src/components/files/fileCard/FileCard.js
+++ b/lib/src/components/files/fileCard/FileCard.js
@@ -31,7 +31,6 @@ function FileCard({ preview, meta, insetMeta, children, ...cardProps }) {
 }
 
 FileCard.propTypes = {
-  ...Card.propTypes,
   meta: node,
   insetMeta: bool,
   preview: node.isRequired

--- a/lib/src/components/files/fileCard/stories/FileCardStory.js
+++ b/lib/src/components/files/fileCard/stories/FileCardStory.js
@@ -25,13 +25,13 @@ stories.add('FileCard', () => {
     ? 'http://fail'
     : 'http://placeimg.com/500/500/animals';
 
-  const preview = (
+  const Preview = ({ children }) => (
     <PreviewImage
       src={previewSrc}
       altText="preview image"
       title="preview image"
     >
-      {controls}
+      {children}
     </PreviewImage>
   );
 
@@ -59,15 +59,49 @@ stories.add('FileCard', () => {
   );
 
   return (
-    <StoryItem
-      title="FileCard"
-      description="A card component which utilises the thumb, meta and control modules to display a file."
-    >
-      <ul className="list-none grid p-0 m-0 tw grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-        <li>
-          <FileCard preview={preview} meta={meta} insetMeta={insetMeta} />
-        </li>
-      </ul>
-    </StoryItem>
+    <>
+      <StoryItem
+        title="FileCard"
+        description="A card component which utilises the thumb, meta and control modules to display a file."
+      >
+        <ul className="list-none grid p-0 m-0 tw grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          <li>
+            <FileCard
+              preview={<Preview>{controls}</Preview>}
+              meta={meta}
+              insetMeta={insetMeta}
+            />
+          </li>
+          <li>
+            <FileCard
+              preview={<Preview>{controls}</Preview>}
+              meta={meta}
+              insetMeta={insetMeta}
+            />
+          </li>
+          <li>
+            <FileCard
+              preview={<Preview>{controls}</Preview>}
+              meta={meta}
+              insetMeta={insetMeta}
+            />
+          </li>
+          <li>
+            <FileCard
+              preview={<Preview>{controls}</Preview>}
+              meta={meta}
+              insetMeta={insetMeta}
+            />
+          </li>
+        </ul>
+      </StoryItem>
+
+      <StoryItem
+        title="FileCard (thumbnail usage)"
+        description="A card component which utilises the thumb, meta and control modules to display a file."
+      >
+        <FileCard preview={<Preview />} className="w-10" />
+      </StoryItem>
+    </>
   );
 });

--- a/lib/src/components/files/fileCard/stories/FileCardStory.js
+++ b/lib/src/components/files/fileCard/stories/FileCardStory.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Pill, Meta, FileCard, PreviewImage, Controls } from 'lib';
+import { Pill, Meta, FileCard, PreviewImage, Controls, Loader } from 'lib';
 import StoryItem from 'stories/styleguide/StoryItem';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 
@@ -25,11 +25,12 @@ stories.add('FileCard', () => {
     ? 'http://fail'
     : 'http://placeimg.com/500/500/animals';
 
-  const Preview = ({ children }) => (
+  const Preview = ({ children, loader }) => (
     <PreviewImage
       src={previewSrc}
       altText="preview image"
       title="preview image"
+      loader={loader}
     >
       {children}
     </PreviewImage>
@@ -100,7 +101,10 @@ stories.add('FileCard', () => {
         title="FileCard (thumbnail usage)"
         description="A card component which utilises the thumb, meta and control modules to display a file."
       >
-        <FileCard preview={<Preview />} className="w-10" />
+        <FileCard
+          preview={<Preview loader={<Loader size="sm" />} />}
+          className="w-10"
+        />
       </StoryItem>
     </>
   );

--- a/lib/src/modules/controls/Control.js
+++ b/lib/src/modules/controls/Control.js
@@ -8,12 +8,7 @@ function Control({ onClick, iconName, children, className }) {
   return (
     <div className={classNames}>
       {children || (
-        <ButtonIconContained
-          name={iconName}
-          onClick={onClick}
-          size="sm"
-          contained
-        />
+        <ButtonIconContained name={iconName} onClick={onClick} size="sm" />
       )}
     </div>
   );

--- a/lib/src/modules/loader/Loader.js
+++ b/lib/src/modules/loader/Loader.js
@@ -6,7 +6,9 @@ import Icon from 'lib/Icon';
 function Loader({ heading, progress, size, className }) {
   const baseClassNames = `loader flex items-center flex-col justify-center ${className}`;
   const classNames = cx(baseClassNames, {
-    'loader-md': size === 'md' || progress
+    'loader-sm': size === 'sm',
+    'loader-md': size === 'md',
+    'loader-lrg': size === 'lrg' || progress
   });
 
   return (

--- a/lib/src/modules/loader/Loader.js
+++ b/lib/src/modules/loader/Loader.js
@@ -1,18 +1,26 @@
 import React from 'react';
 import { string } from 'prop-types';
+import cx from 'classnames';
 import Icon from 'lib/Icon';
 
-function Loader({ heading, progress, className }) {
-  const classNames = `loader ${className}`;
+function Loader({ heading, progress, size, className }) {
+  const baseClassNames = `loader flex items-center flex-col justify-center ${className}`;
+  const classNames = cx(baseClassNames, {
+    'loader-md': size === 'md' || progress
+  });
 
   return (
     <div className={classNames}>
-      {heading && <div className="loader-heading mb-2">{heading}</div>}
+      {heading && (
+        <div className="loader-heading weight-semi-bold mb-2">{heading}</div>
+      )}
 
       <div className="loader-spinner flex items-center justify-center w-full">
         <Icon name="loader" />
 
-        <div className="loader-progress">{progress}</div>
+        <div className="loader-progress absolute text-sm text-neutral-primary">
+          {progress}
+        </div>
       </div>
     </div>
   );

--- a/lib/src/modules/loader/LoaderStory.js
+++ b/lib/src/modules/loader/LoaderStory.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Loader } from 'lib';
+import StoryItem from 'stories/styleguide/StoryItem';
+
+const stories = storiesOf('Modules', module);
+
+stories.add('Loader', () => {
+  return (
+    <>
+      <StoryItem title="Loader">
+        <div className="grid tw grid-cols-4 col-gap-4">
+          <Loader />
+          <Loader size="md" />
+          <Loader progress="25%" />
+          <Loader heading="Processing" progress="100%" />
+        </div>
+      </StoryItem>
+    </>
+  );
+});

--- a/lib/src/modules/loader/LoaderStory.js
+++ b/lib/src/modules/loader/LoaderStory.js
@@ -9,9 +9,10 @@ stories.add('Loader', () => {
   return (
     <>
       <StoryItem title="Loader">
-        <div className="grid tw grid-cols-4 col-gap-4">
-          <Loader />
+        <div className="grid tw grid-cols-5 col-gap-4">
+          <Loader size="sm" />
           <Loader size="md" />
+          <Loader size="lrg" />
           <Loader progress="25%" />
           <Loader heading="Processing" progress="100%" />
         </div>

--- a/lib/src/modules/loader/loader.scss
+++ b/lib/src/modules/loader/loader.scss
@@ -1,0 +1,5 @@
+.loader-md {
+  svg {
+    @apply w-16 h-16;
+  }
+}

--- a/lib/src/modules/loader/loader.scss
+++ b/lib/src/modules/loader/loader.scss
@@ -1,5 +1,11 @@
-.loader-md {
-  svg {
-    @apply w-16 h-16;
-  }
+.loader-sm svg {
+  @apply w-4 h-4;
+}
+
+.loader-md svg {
+  @apply w-8 h-8;
+}
+
+.loader-lrg svg {
+  @apply w-16 h-16;
 }

--- a/lib/src/modules/meta/MetaText.js
+++ b/lib/src/modules/meta/MetaText.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function MetaText({ children, className }) {
-  const classNames = `meta-text text-neutral-base text-sm mb-2 ${className}`;
+  const classNames = `meta-text text-neutral-base text-sm mb-2 truncate ${className}`;
 
   return <div className={classNames}>{children}</div>;
 }

--- a/lib/src/modules/preview/PreviewImage.js
+++ b/lib/src/modules/preview/PreviewImage.js
@@ -19,9 +19,9 @@ function PreviewImage({
     useSuspense: false
   });
 
-  const imageIsLoading = true;
-  const imageHasSucceeded = false;
-  const imageHasFailed = false;
+  const imageIsLoading = image.isLoading && !image.error;
+  const imageHasSucceeded = !image.isLoading && !image.error;
+  const imageHasFailed = image.error && !image.isLoading;
 
   const commonAbsoluteLayoutClasses = 'absolute top-0 w-full h-full';
   const classNames = `preview-image relative flex overflow-hidden w-full h-full pb-100% ${

--- a/lib/src/modules/preview/PreviewImage.js
+++ b/lib/src/modules/preview/PreviewImage.js
@@ -19,9 +19,9 @@ function PreviewImage({
     useSuspense: false
   });
 
-  const imageIsLoading = image.isLoading && !image.error;
-  const imageHasSucceeded = !image.isLoading && !image.error;
-  const imageHasFailed = image.error && !image.isLoading;
+  const imageIsLoading = true;
+  const imageHasSucceeded = false;
+  const imageHasFailed = false;
 
   const commonAbsoluteLayoutClasses = 'absolute top-0 w-full h-full';
   const classNames = `preview-image relative flex overflow-hidden w-full h-full pb-100% ${
@@ -78,7 +78,7 @@ PreviewImage.defaultProps = {
       {previewFallback()}
     </div>
   ),
-  loader: <Loader size="md" />
+  loader: <Loader size="lrg" />
 };
 
 export { PreviewImage };

--- a/lib/src/modules/preview/PreviewImage.js
+++ b/lib/src/modules/preview/PreviewImage.js
@@ -73,8 +73,12 @@ PreviewImage.propTypes = {
 };
 
 PreviewImage.defaultProps = {
-  fallback: <div className="w-full h-full p-05">{previewFallback()}</div>,
-  loader: <Loader />
+  fallback: (
+    <div className="preview-image-fallback w-full h-full">
+      {previewFallback()}
+    </div>
+  ),
+  loader: <Loader size="md" />
 };
 
 export { PreviewImage };

--- a/lib/src/modules/preview/previewImage.scss
+++ b/lib/src/modules/preview/previewImage.scss
@@ -3,3 +3,7 @@
     @apply w-full h-full;
   }
 }
+
+.preview-image-fallback {
+  padding: 10%;
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -11,6 +11,8 @@ import 'lib/ButtonNew/stories/ButtonTertiary/ButtonTertiaryDangerStory';
 import 'lib/ButtonNew/stories/ButtonIcon/ButtonIconStory';
 import 'lib/ButtonNew/stories/ButtonLink/ButtonLinkStory';
 
+import 'lib/src/modules/loader/LoaderStory';
+
 import Avatar from '../lib/Avatar/stories/AvatarStory';
 import Button from './components/Button';
 import CheckToggle from './components/CheckToggle';

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -1,8 +1,3 @@
-@import '../../lib/ButtonNew/ButtonIcon/styles/buttonIcon';
-
-@import '../../lib/src/modules/preview/previewImage';
-@import '../../lib/src/modules/loader/loader';
-
 @import '../../lib/Icon/styles.scss';
 @import '../../lib/BoundaryClickWatcher/styles.scss';
 @import '../../lib/Button/styles.scss';
@@ -82,3 +77,8 @@
 @import '../../lib/ColField/styles.scss';
 @import '../../lib/SelectionModal/styles.scss';
 @import '../../lib/InputConfirmationModal/styles.scss';
+
+@import '../../lib/ButtonNew/ButtonIcon/styles/buttonIcon';
+
+@import '../../lib/src/modules/preview/previewImage';
+@import '../../lib/src/modules/loader/loader';

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -1,5 +1,7 @@
 @import '../../lib/ButtonNew/ButtonIcon/styles/buttonIcon';
-@import '../../lib/src/modules/preview/styles/previewImage';
+
+@import '../../lib/src/modules/preview/previewImage';
+@import '../../lib/src/modules/loader/loader';
 
 @import '../../lib/Icon/styles.scss';
 @import '../../lib/BoundaryClickWatcher/styles.scss';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -129,7 +129,7 @@ module.exports = {
           '80': neutral80,
           '70': '#A4B3C2',
           '60': '#8599AD',
-          primary: '#678099',
+          primary: '#678098',
           '40': neutral40,
           '30': '#3E4D5C',
           '20': neutral20


### PR DESCRIPTION
### 💬  Description
The loader module can have progress and heading text passed through to it but the styling wasn't there. It was also missing a story to show the states of the new module.

![loader](https://user-images.githubusercontent.com/147869/96976304-9b5c2000-1513-11eb-98ac-08d6c7247e7c.gif)

-------

The `FileCard` component uses the `PreviewImage` module which when used in a thumbnail scenario (e.g. in rows) had issues with padding and the fallback touching the edges. This PR adds padding which suits all scenarios. I also added a thumbnail example to the story.

<img width="720" alt="thumbnail" src="https://user-images.githubusercontent.com/147869/96976279-8f705e00-1513-11eb-8271-4cbd0bf5bb98.png">

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
