### PR TITLE
Move button base styles

### DIFF
--- a/lib/ButtonNew/ButtonBase.js
+++ b/lib/ButtonNew/ButtonBase.js
@@ -17,19 +17,14 @@ function ButtonBase({
   disabled,
   ...rest
 }) {
-  const classes = cx(
-    'border border-solid leading-4 rounded font-display font-semi-bold inline-flex items-center focus:outline-none relative',
-    className,
-    {
-      'rounded-r-none mr-0': connectedRight,
-      'rounded-l-none ml-0': connectedLeft,
+  const classes = cx('button-base', className, {
+    'button-base-connected-r': connectedRight,
+    'button-base-connected-l': connectedLeft,
 
-      'text-base py-3 px-4': size && size === sizes.md,
-      'text-base p-2': size && size === sizes.sm,
-      'text-sm p-05 px-2 rounded-small': size && size === sizes.xs,
-      'pointer-events-none': disabled
-    }
-  );
+    'button-base-md': size && size === sizes.md,
+    'button-base-sm': size && size === sizes.sm,
+    'button-base-xs': size && size === sizes.xs
+  });
 
   if (typeof children === 'function') {
     return children(classes);

--- a/lib/ButtonNew/styles/buttonBase.scss
+++ b/lib/ButtonNew/styles/buttonBase.scss
@@ -1,0 +1,27 @@
+.button-base {
+  @apply border border-solid leading-4 rounded font-display font-semi-bold inline-flex items-center relative;
+
+  &-md {
+    @apply text-base py-3 px-4;
+  }
+  &-sm {
+    @apply text-base p-2;
+  }
+  &-xs {
+    @apply text-sm p-05 px-2 rounded-small;
+  }
+
+  &-connected-r {
+    @apply rounded-r-none mr-0;
+  }
+  &-connected-l {
+    @apply rounded-l-none ml-0;
+  }
+
+  &:focus {
+    @apply outline-none;
+  }
+  &:disabled {
+    @apply pointer-events-none;
+  }
+}

--- a/lib/ButtonNew/styles/styles.scss
+++ b/lib/ButtonNew/styles/styles.scss
@@ -1,0 +1,2 @@
+@import 'buttonBase';
+@import '../ButtonIcon/styles/buttonIcon';

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -78,7 +78,7 @@
 @import '../../lib/SelectionModal/styles.scss';
 @import '../../lib/InputConfirmationModal/styles.scss';
 
-@import '../../lib/ButtonNew/ButtonIcon/styles/buttonIcon';
+@import '../../lib/ButtonNew/styles/styles.scss';
 
 @import '../../lib/src/modules/preview/previewImage';
 @import '../../lib/src/modules/loader/loader';


### PR DESCRIPTION
### 💬 Description
I wanted a link to look like a ButtonIcon on the app, we now have a great `button-icon` class I can use, but sadly that doesn't give me everything. This adds the other piece of the puzzle and moves ButtonBase into its own class I can easily grab and use. 

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
