### PR TITLE
Update/add stucture editor layout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,3 +161,6 @@ export { Meta } from './src/modules/meta/Meta';
 export { PreviewImage } from './src/modules/preview/PreviewImage';
 export { Controls } from './src/modules/controls/Controls';
 export { Loader } from './src/modules/loader/Loader';
+export {
+  StructureEditorLayout
+} from './src/components/layouts/StructureEditorLayout/StructureEditorLayout';

--- a/lib/src/components/layouts/StructureEditorLayout/FieldsContainer.js
+++ b/lib/src/components/layouts/StructureEditorLayout/FieldsContainer.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Col } from 'react-bootstrap';
+
+function FieldsContainer({ children }) {
+  return (
+    <Col md={9} xs={12} className="structure-editor__fields-container h-full">
+      {children}
+    </Col>
+  );
+}
+
+export { FieldsContainer };

--- a/lib/src/components/layouts/StructureEditorLayout/InventoryContainer.js
+++ b/lib/src/components/layouts/StructureEditorLayout/InventoryContainer.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Col } from 'react-bootstrap';
+
+function InventoryContainer({ children }) {
+  return (
+    <Col md={1} sm={2} className="structure-editor__inventory-container">
+      {children}
+    </Col>
+  );
+}
+
+export { InventoryContainer };

--- a/lib/src/components/layouts/StructureEditorLayout/StructureEditorLayout.js
+++ b/lib/src/components/layouts/StructureEditorLayout/StructureEditorLayout.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function StructureEditorLayout({ children }) {
+  return <div className="structure-editor h-full">{children}</div>;
+}
+
+export { StructureEditorLayout };

--- a/lib/src/components/layouts/StructureEditorLayout/StructureEditorLayout.js
+++ b/lib/src/components/layouts/StructureEditorLayout/StructureEditorLayout.js
@@ -1,7 +1,17 @@
 import React from 'react';
+import { Row } from 'react-bootstrap';
+import { InventoryContainer } from './InventoryContainer';
+import { FieldsContainer } from './FieldsContainer';
 
 function StructureEditorLayout({ children }) {
-  return <div className="structure-editor h-full">{children}</div>;
+  return (
+    <div className="structure-editor h-full">
+      <Row className="pl-2 h-full">{children}</Row>
+    </div>
+  );
 }
+
+StructureEditorLayout.InventoryContainer = InventoryContainer;
+StructureEditorLayout.FieldsContainer = FieldsContainer;
 
 export { StructureEditorLayout };


### PR DESCRIPTION
### 💬 Description
The component editor page of the app shares a lot in common with the template editor, as you can see from these designs https://www.figma.com/file/HWmdpuNLjhxlKUhzYQJWPW/Components?node-id=218%3A0

To make this as easy as possible, we want to make as much of the UI reusable as is sensible.

This PR creates the components:
```javascript
<StructureEditorLayout>
  <StructureEditorLayout.InventoryContainer>
  {...}
  </StructureEditorLayout.InventoryContainer>

  <StructureEditorLayout.FieldsContainer>
  {...}
  </StructureEditorLayout.FieldsContainer>  
</StructureEditorLayout>
```

you can see it in action in this PR https://github.com/gathercontent/app/pull/3457/files

This can now be reused for the component editor.
