### PR TITLE
Add prop to manually show the loader 

### DIFF
--- a/lib/src/components/files/fileCard/FileCardStory.js
+++ b/lib/src/components/files/fileCard/FileCardStory.js
@@ -18,6 +18,7 @@ stories.add('FileCard', () => {
   const added = boolean('Added', false, '');
   const removed = boolean('Removed', false, '');
   const disabled = boolean('Disabled', false, '');
+  const showLoader = boolean('Show loader', false, '');
   const onClick = interactive ? () => {} : null;
 
   const controls = (
@@ -40,6 +41,7 @@ stories.add('FileCard', () => {
       altText="preview image"
       title="preview image"
       loader={loader}
+      showLoader={showLoader}
     >
       {children}
     </PreviewImage>

--- a/lib/src/modules/preview/PreviewImage.js
+++ b/lib/src/modules/preview/PreviewImage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { node, string } from 'prop-types';
+import { bool, node, string } from 'prop-types';
 import { useImage } from 'react-image';
 import cx from 'classnames';
 import { Loader } from 'modules/loader/Loader';
@@ -12,6 +12,7 @@ function PreviewImage({
   fallback,
   children,
   loader,
+  showLoader,
   className
 }) {
   const image = useImage({
@@ -25,14 +26,17 @@ function PreviewImage({
 
   const commonAbsoluteLayoutClasses = 'absolute top-0 w-full h-full';
   const classNames = cx(
-    'preview-image relative flex overflow-hidden w-full h-full pb-100%',
+    'preview-image',
+    {
+      'preview-image-succeeded': imageHasSucceeded,
+      'preview-image-failed': imageHasFailed,
+      'preview-image-show-loader': showLoader
+    },
     className
   );
   const previewClassNames = cx(
-    `${commonAbsoluteLayoutClasses} bg-cover bg-center pb-100% transition-opacity duration-300 opacity-0`,
-    {
-      'opacity-100': imageHasSucceeded
-    }
+    'preview-image-img',
+    `${commonAbsoluteLayoutClasses}`
   );
 
   return (
@@ -55,7 +59,7 @@ function PreviewImage({
         <div
           className={`${commonAbsoluteLayoutClasses} flex items-center justify-center`}
         >
-          {imageIsLoading && loader}
+          {(imageIsLoading || showLoader) && loader}
           {imageHasFailed && fallback}
         </div>
 
@@ -66,6 +70,7 @@ function PreviewImage({
 }
 
 PreviewImage.propTypes = {
+  showLoader: bool,
   fallback: node,
   loader: node,
   src: string.isRequired,
@@ -74,12 +79,13 @@ PreviewImage.propTypes = {
 };
 
 PreviewImage.defaultProps = {
+  showLoader: false,
   fallback: (
     <div className="preview-image-fallback w-full h-full">
       {previewFallback()}
     </div>
   ),
-  loader: <Loader size="lrg" />
+  loader: <Loader size="md" />
 };
 
 export { PreviewImage };

--- a/lib/src/modules/preview/previewImage.scss
+++ b/lib/src/modules/preview/previewImage.scss
@@ -1,9 +1,35 @@
 .preview-image {
+  @apply relative flex overflow-hidden w-full h-full pb-100%;
+
   svg {
     @apply w-full h-full;
   }
 }
 
 .preview-image-fallback {
+  @apply absolute;
   padding: 10%;
+}
+
+.preview-image-img {
+  @apply bg-cover bg-center pb-100% transition-opacity duration-300 opacity-0;
+}
+
+.preview-image-succeeded .preview-image-img {
+  @apply opacity-100;
+}
+
+.preview-image-show-loader {
+  &.preview-image-succeeded {
+    @apply bg-neutral-20;
+
+    path {
+      fill: white;
+    }
+  }
+
+  .preview-image-img,
+  .preview-image-fallback {
+    @apply opacity-25;
+  }
 }

--- a/lib/src/modules/preview/previewImage.scss
+++ b/lib/src/modules/preview/previewImage.scss
@@ -30,6 +30,6 @@
 
   .preview-image-img,
   .preview-image-fallback {
-    @apply opacity-25;
+    @apply opacity-50;
   }
 }


### PR DESCRIPTION
### 💬  Description

The preview image module shows a loader before the image has loaded and now we need to be able to show the loader even if the image is present. Here's a GIF showing the option;

![Screen Recording 2020-11-10 at 12 46 52 pm](https://user-images.githubusercontent.com/147869/98676518-9bea1880-2353-11eb-9ad5-d93779d5d13a.gif)


### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
