### PR TITLE
Adds `loadingText` prop to LoadingOverlay

### DIFF
--- a/lib/LoadingOverlay/index.js
+++ b/lib/LoadingOverlay/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import loadingSVG from '../../assets/loading.svg';
 
-const LoadingOverlay = ({ fixed, hideSVG, percentageLoaded }) => {
+const LoadingOverlay = ({ fixed, hideSVG, percentageLoaded, loadingText }) => {
   const className = cx('loading-overlay', {
     'loading-overlay--fixed': fixed
   });
@@ -15,7 +15,7 @@ const LoadingOverlay = ({ fixed, hideSVG, percentageLoaded }) => {
         {percentageLoaded > 0 && (
           <Fragment>
             <p className="h-margin-bottom-quarter h-margin-top-clear">
-              Loading
+              {loadingText || 'Loading'}
             </p>
             <p className="h-margin-clear color-neutral-base">{`${percentageLoaded}%`}</p>
           </Fragment>
@@ -28,13 +28,15 @@ const LoadingOverlay = ({ fixed, hideSVG, percentageLoaded }) => {
 LoadingOverlay.propTypes = {
   fixed: PropTypes.bool,
   hideSVG: PropTypes.bool,
-  percentageLoaded: PropTypes.number
+  percentageLoaded: PropTypes.number,
+  loadingText: PropTypes.string
 };
 
 LoadingOverlay.defaultProps = {
   fixed: false,
   hideSVG: false,
-  percentageLoaded: 0
+  percentageLoaded: 0,
+  loadingText: null
 };
 
 export default LoadingOverlay;

--- a/lib/LoadingOverlay/index.js
+++ b/lib/LoadingOverlay/index.js
@@ -15,7 +15,7 @@ const LoadingOverlay = ({ fixed, hideSVG, percentageLoaded, loadingText }) => {
         {percentageLoaded > 0 && (
           <Fragment>
             <p className="h-margin-bottom-quarter h-margin-top-clear">
-              {loadingText || 'Loading'}
+              {loadingText}
             </p>
             <p className="h-margin-clear color-neutral-base">{`${percentageLoaded}%`}</p>
           </Fragment>
@@ -36,7 +36,7 @@ LoadingOverlay.defaultProps = {
   fixed: false,
   hideSVG: false,
   percentageLoaded: 0,
-  loadingText: null
+  loadingText: 'Loading'
 };
 
 export default LoadingOverlay;


### PR DESCRIPTION
Adds `loadingText` prop to LoadingOverlay so that we can overwrite the default `Loading` text. 

Ronseal!

Companion to https://github.com/gathercontent/app/pull/3479 👫