### PR TITLE
Removing arbitrary width of dropdown menu name

### DIFF
--- a/lib/DropdownMenu/styles.scss
+++ b/lib/DropdownMenu/styles.scss
@@ -206,7 +206,6 @@ $dropdown-menu-font-color: $color-text-base !default;
   display: flex;
   .dropdown__item--name {
     display: block;
-    width: 65%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -214,6 +213,7 @@ $dropdown-menu-font-color: $color-text-base !default;
   .dropdown__item--additional {
     display: block;
     margin-left: auto;
+    justify-self: end;
     color: $neutral-base;
   }
 }


### PR DESCRIPTION
### 💬 Description
This fix is best explained in picture form.

BEFORE:
![before](https://trello-attachments.s3.amazonaws.com/5faacd515d2bbc2a7007fb3e/320x309/ed3b7d075d81e04916877f9b0af471c9/image.png)

AFTER:
![Screenshot 2020-11-18 at 14 27 53](https://user-images.githubusercontent.com/33638789/99545685-90c76600-29ad-11eb-9bcb-7cbb28648875.png)

### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
