### PR TITLE
Stopping the text fade from touching the shadow on tabs

### DIFF
--- a/lib/TabsNew/TabsScrollShadow.js
+++ b/lib/TabsNew/TabsScrollShadow.js
@@ -23,7 +23,7 @@ export function TabsScrollShadow({ scrollPosition }) {
     opacity: shouldBottomShadowBeVisible ? 1 : 0
   });
 
-  const initialClassName = 'absolute w-full h-4 -mr-4 pointer-events-none';
+  const initialClassName = 'absolute w-full h-4 -mr-4 pointer-events-none z-50';
 
   return (
     <Fragment>

--- a/lib/TabsNew/TabsScrollShadow.js
+++ b/lib/TabsNew/TabsScrollShadow.js
@@ -23,7 +23,7 @@ export function TabsScrollShadow({ scrollPosition }) {
     opacity: shouldBottomShadowBeVisible ? 1 : 0
   });
 
-  const initialClassName = 'absolute w-full h-4 -mr-4 pointer-events-none z-50';
+  const initialClassName = 'absolute w-full h-4 -mr-4 pointer-events-none z-20';
 
   return (
     <Fragment>


### PR DESCRIPTION
### 💬 Description
We have a shadow on tabs when you are able to scroll to indicate that there are more, the fade for a tab name clashes with it and makes things look a bit nasty. This PR just adds a z-index to the shadow so it is always about the fade, and not part of it.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
