### PR TITLE
Add a selected state to ComponentWrapper

### DIFF
--- a/lib/src/components/componentWrapper/ComponentWrapper.js
+++ b/lib/src/components/componentWrapper/ComponentWrapper.js
@@ -13,6 +13,7 @@ export function ComponentWrapper({
   onInstructionChange,
   className,
   children,
+  isSelected,
   ...rest
 }) {
   return (
@@ -25,8 +26,9 @@ export function ComponentWrapper({
         onLabelChange={onLabelChange}
         instructions={instructions}
         onInstructionChange={onInstructionChange}
+        isSelected={isSelected}
       />
-      <ComponentWrapperFooter editable={editable}>
+      <ComponentWrapperFooter editable={editable} isSelected={isSelected}>
         {children}
       </ComponentWrapperFooter>
     </div>

--- a/lib/src/components/componentWrapper/ComponentWrapperBody.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperBody.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import cx from 'classnames';
 
-export function ComponentWrapperBody({ children, editable }) {
+export function ComponentWrapperBody({ children, editable, isSelected }) {
   const classes = cx('component-body', {
-    'component-body-editable': editable
+    'component-body-editable': editable,
+    'component-body-selected': isSelected
   });
 
   return <div className={classes}>{children}</div>;

--- a/lib/src/components/componentWrapper/ComponentWrapperFooter.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperFooter.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import cx from 'classnames';
 
-export function ComponentWrapperFooter({ children, editable }) {
+export function ComponentWrapperFooter({ children, editable, isSelected }) {
   const classes = cx('component-footer', {
-    'component-footer-editable': editable
+    'component-footer-editable': editable,
+    'component-footer-selected': isSelected
   });
 
   return <div className={classes}>{children}</div>;

--- a/lib/src/components/componentWrapper/ComponentWrapperHeader/ComponentWrapperHeader.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperHeader/ComponentWrapperHeader.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Icon } from 'lib';
+import cx from 'classnames';
 import { ComponentLabel } from './ComponentLabel';
 import { ComponentInstructions } from './ComponentInstructions';
 
@@ -10,10 +11,15 @@ export function ComponentWrapperHeader({
   subLabel,
   onLabelChange,
   instructions,
-  onInstructionChange
+  onInstructionChange,
+  isSelected
 }) {
+  const classes = cx('component-header', {
+    'component-header-selected': isSelected
+  });
+
   return (
-    <div className="component-header">
+    <div className={classes}>
       <div className="component-header-top">
         <div className="component-label">
           <Icon name="component16" types={['neutral-20']} className="mr-2" />

--- a/lib/src/components/componentWrapper/ComponentWrapperStory.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperStory.js
@@ -17,6 +17,7 @@ const Aside = (
 
 storiesOf('Components', module).add('ComponentWrapper', () => {
   const editable = boolean('Editable', true);
+  const isSelected = boolean('Selected', false);
 
   return (
     <>
@@ -31,6 +32,7 @@ storiesOf('Components', module).add('ComponentWrapper', () => {
               onInstructionChange={() => {}}
               headerAside={Aside}
               subLabel="(Goodbye!)"
+              isSelected={isSelected}
             >
               <ColField className="mb-10">
                 <ColField.Header>
@@ -70,8 +72,9 @@ storiesOf('Components', module).add('ComponentWrapper', () => {
               editable={editable}
               label="I'm split up!"
               onLabelChange={() => {}}
+              isSelected={isSelected}
             />
-            <ComponentWrapper.Body editable={editable}>
+            <ComponentWrapper.Body editable={editable} isSelected={isSelected}>
               <ColField>
                 <ColField.Header>
                   <ColField.Label label="Howdy" />
@@ -86,7 +89,10 @@ storiesOf('Components', module).add('ComponentWrapper', () => {
                 </ColField.Footer>
               </ColField>
             </ComponentWrapper.Body>
-            <ComponentWrapper.Footer editable={editable}>
+            <ComponentWrapper.Footer
+              editable={editable}
+              isSelected={isSelected}
+            >
               <ColField className="mt-6">
                 <ColField.Header>
                   <ColField.Label label="Howdy" />

--- a/lib/src/components/componentWrapper/componentWrapper.scss
+++ b/lib/src/components/componentWrapper/componentWrapper.scss
@@ -1,5 +1,8 @@
 .component-header {
-  @apply rounded-t-xlarge border border-b-0 border-solid border-neutral-90;
+  @apply rounded-t-xlarge border border-b-0 border-solid border-neutral-90 relative;
+  &-selected {
+    @include before-border(2px 2px 0px 2px, solid, theme('colors.blue.primary'), theme('borderRadius.xlarge') theme('borderRadius.xlarge') 0px 0px);
+  }
 }
 
 .component-header-top {
@@ -35,8 +38,14 @@
   }
 }
 
+.component-body {
+  &-selected {
+    @include before-border(0px 2px, solid, theme('colors.blue.primary'), 0);
+  }
+}
+
 .component-body, .component-footer {
-  @apply px-4 pt-4 border-0 border-l border-r border-solid border-neutral-90;
+  @apply px-4 pt-4 border-0 border-l border-r border-solid border-neutral-90 relative;
 
   &-editable {
     @apply bg-neutral-95;
@@ -45,4 +54,8 @@
 
 .component-footer {
   @apply border-b rounded-b-xlarge py-4;
+
+  &-selected {
+    @include before-border(0px 2px 2px 2px, solid, theme('colors.blue.primary'), 0px 0px theme('borderRadius.xlarge') theme('borderRadius.xlarge'));
+  }
 }

--- a/styles/tools/_mixins.scss
+++ b/styles/tools/_mixins.scss
@@ -142,7 +142,8 @@
     right: 0;
     top: 0;
     height: 100%;
-    border: $pixelSize $style $colour;
+    border: $style $colour;
+    border-width: $pixelSize;
     border-radius: $radius;
     pointer-events: none;
   }


### PR DESCRIPTION
### 💬 Description
Just like ColField our ComponentWrapper also needs a selected state. We're using our `before-border` mixin to give our component wrapper sections a lovely thick blue border

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
