### PR TITLE
Add isOverOptions prop to Droppable component

### DIFF
--- a/lib/DnD/Droppable.js
+++ b/lib/DnD/Droppable.js
@@ -8,7 +8,8 @@ function Droppable({
   acceptDragTypes,
   onDrop,
   canDropChecker,
-  onHoverHandler
+  onHoverHandler,
+  isOverOptions
 }) {
   const { setIsDragging } = useContext(DndContext);
   const [collected, defineDropRef] = useDrop({
@@ -20,7 +21,7 @@ function Droppable({
     canDrop: canDropChecker,
     hover: onHoverHandler,
     collect: monitor => ({
-      isOver: monitor.isOver(),
+      isOver: monitor.isOver(isOverOptions),
       canDrop: monitor.canDrop(),
       item: monitor.getItem()
     })
@@ -37,7 +38,8 @@ Droppable.propTypes = {
 };
 
 Droppable.defaultProps = {
-  canDropChecker: () => true
+  canDropChecker: () => true,
+  isOverOptions: { shallow: false }
 };
 
 export { Droppable };


### PR DESCRIPTION
### 💬 Description
Adds prop to `<Droppable />` so that we can pass options to the `monitor.isOver(...)` function.

This is so we can pass `{ shallow: true }` so that `isOver` is false if the dragged item is over a child of the target that is also droppable.