### PR TITLE
Adding a max height to ModalUploadBody

### DIFF
--- a/lib/src/prefabs/modalUpload/ModalUploadBody.js
+++ b/lib/src/prefabs/modalUpload/ModalUploadBody.js
@@ -4,7 +4,7 @@ import { Dropzone } from '../../components/dropzone/Dropzone';
 
 export function ModalUploadBody({ fileCards, onDrop, maxSize }) {
   return (
-    <Modal.Body className="h-screen70 border border-solid border-neutral-90 border-r-0 border-l-0">
+    <Modal.Body className="modal-upload-body">
       <Dropzone onDrop={onDrop} maxSize={maxSize}>
         {fileCards}
       </Dropzone>

--- a/lib/src/prefabs/modalUpload/modalUpload.scss
+++ b/lib/src/prefabs/modalUpload/modalUpload.scss
@@ -1,0 +1,4 @@
+.modal-upload-body {
+  @apply h-screen70 border border-solid border-neutral-90 border-r-0 border-l-0;
+  max-height: 800px;
+}

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -81,6 +81,7 @@
 
 @import '../../lib/src/components/card/card';
 @import '../../lib/src/components/modal/modal';
+@import '../../lib/src/prefabs/modalUpload/modalUpload';
 @import '../../lib/src/components/viewOptions/viewOptions';
 @import '../../lib/src/prefabs/files/fileCard/fileCard';
 @import '../../lib/src/components/componentWrapper/componentWrapper';


### PR DESCRIPTION
We really should have a max-height for the ModalUpload body prefab.