### PR TITLE
Fixing a couple of dropzone issues

### DIFF
--- a/lib/src/components/dropzone/Dropzone.js
+++ b/lib/src/components/dropzone/Dropzone.js
@@ -13,7 +13,7 @@ function Dropzone({ onDrop, maxSize, children }) {
     );
   };
 
-  const { getRootProps, getInputProps, open } = useDropzone({
+  const { getRootProps, getInputProps } = useDropzone({
     onDrop: onDropzoneDrop,
     maxSize,
     noClick: !!children,
@@ -25,7 +25,9 @@ function Dropzone({ onDrop, maxSize, children }) {
       <input {...getInputProps()} />
       {children || (
         <div className="h-full flex items-center flex-col justify-center border border-dashed border-neutral-80 rounded">
-          <ButtonPrimary onClick={open}>Browse my local files</ButtonPrimary>
+          <ButtonPrimary onClick={() => {}}>
+            Browse my local files
+          </ButtonPrimary>
           <p>or drag and drop here</p>
         </div>
       )}

--- a/lib/src/components/modal/modal.scss
+++ b/lib/src/components/modal/modal.scss
@@ -32,6 +32,10 @@ $modal-small-width: 400px !default;
   &.x-large {
     width: $modal-x-large-width;
   }
+
+  &:focus {
+    outline: none;
+  }
 }
 
 .ReactModal__Overlay {


### PR DESCRIPTION
### 💬 Description
Just a couple more dropzone/upload modal fixes:

- There is no longer a focus border on the whole modal when it opens
- There was an issue where the OS file dialog was appearing twice when you clicked the dropzone.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
