### PR TITLE
Remove unused and error causing noIndentation prop

### DIFF
--- a/lib/FinderNavigation/FinderItem.js
+++ b/lib/FinderNavigation/FinderItem.js
@@ -28,16 +28,14 @@ FinderItem.propTypes = {
   active: PropTypes.bool,
   className: PropTypes.string,
   hoverSettings: PropTypes.bool,
-  selected: PropTypes.bool,
-  noIndentation: PropTypes.bool
+  selected: PropTypes.bool
 };
 
 FinderItem.defaultProps = {
   active: false,
   className: '',
   hoverSettings: true,
-  selected: false,
-  noIndentation: false
+  selected: false
 };
 
 export default FinderItem;


### PR DESCRIPTION
### 💬 Description
Just as the title says, we don't hook this prop up to anything so it just causes a bit of a rubbish error

![Screenshot 2021-03-01 at 16 19 06](https://user-images.githubusercontent.com/12775966/109525987-fdbcc280-7aa9-11eb-9e2f-6fa2f5c008cc.png)

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
