### PR TITLE
Sidebar component edits

### DIFF
--- a/lib/src/components/sidebar/Sidebar.js
+++ b/lib/src/components/sidebar/Sidebar.js
@@ -6,6 +6,9 @@ import { SidebarHeading } from './SidebarHeading';
 import { SidebarSubHeading } from './SidebarSubHeading';
 import { SidebarFooter } from './SidebarFooter';
 import { SidebarSubSection } from './SidebarSubSection';
+import { SidebarSectionHead } from './SidebarSectionHead';
+import { SidebarSectionToggle } from './SidebarSectionToggle';
+import { SidebarDescription } from './SidebarDescription';
 
 export function Sidebar({ children, className = '', ...rest }) {
   return (
@@ -23,3 +26,6 @@ Sidebar.Heading = SidebarHeading;
 Sidebar.SubSection = SidebarSubSection;
 Sidebar.SubHeading = SidebarSubHeading;
 Sidebar.Footer = SidebarFooter;
+Sidebar.SectionHead = SidebarSectionHead;
+Sidebar.SectionToggle = SidebarSectionToggle;
+Sidebar.Description = SidebarDescription;

--- a/lib/src/components/sidebar/SidebarDescription.js
+++ b/lib/src/components/sidebar/SidebarDescription.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export function SidebarDescription({ children, className = '', ...rest }) {
+  return (
+    <div className={`sidebar-description ${className}`} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/lib/src/components/sidebar/SidebarHeading.js
+++ b/lib/src/components/sidebar/SidebarHeading.js
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { ButtonSecondary } from 'lib';
 import { bool } from 'prop-types';
-import cx from 'classnames';
-import { SidebarSectionContext } from './SidebarSection';
 
 export function SidebarHeading({
   children,
@@ -10,26 +7,9 @@ export function SidebarHeading({
   showMoreToggle,
   ...rest
 }) {
-  const { showMore, setShowMore } = React.useContext(SidebarSectionContext);
-  const classNames = cx(className, {
-    'text-overflow-ellipsis pr-2': showMoreToggle
-  });
-
   return (
-    <div className="sidebar-heading flex items-center">
-      <div className={classNames} {...rest}>
-        {children}
-      </div>
-
-      {setShowMore && showMoreToggle && (
-        <ButtonSecondary
-          className="ml-auto whitespace-no-wrap"
-          size={ButtonSecondary.sizes.sm}
-          onClick={() => setShowMore(!showMore)}
-        >
-          {showMore ? 'Less info' : 'More info'}
-        </ButtonSecondary>
-      )}
+    <div className={`sidebar-heading ${className}`} {...rest}>
+      {children}
     </div>
   );
 }

--- a/lib/src/components/sidebar/SidebarSectionHead.js
+++ b/lib/src/components/sidebar/SidebarSectionHead.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import cx from 'classnames';
+import { node } from 'prop-types';
+
+export function SidebarSectionHead({
+  toggle,
+  children,
+  className = '',
+  ...rest
+}) {
+  const layoutClasses = cx({
+    'pr-2': toggle
+  });
+
+  return (
+    <div className={`sidebar-section-head ${className}`} {...rest}>
+      <div className={layoutClasses}>{children}</div>
+
+      {toggle && <div className="ml-auto">{toggle}</div>}
+    </div>
+  );
+}
+
+SidebarSectionHead.propTypes = {
+  toggle: node
+};
+
+SidebarSectionHead.defaultProps = {
+  toggle: null
+};

--- a/lib/src/components/sidebar/SidebarSectionToggle.js
+++ b/lib/src/components/sidebar/SidebarSectionToggle.js
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { ButtonSecondary } from 'lib';
+import { string } from 'prop-types';
+import { SidebarSectionContext } from './SidebarSection';
+
+export function SidebarSectionToggle({
+  showText,
+  hideText,
+  children,
+  className = '',
+  ...rest
+}) {
+  const { showMore, setShowMore } = React.useContext(SidebarSectionContext);
+
+  return (
+    <ButtonSecondary
+      className={`sidebar-section-toggle whitespace-no-wrap ${className}`}
+      size={ButtonSecondary.sizes.sm}
+      onClick={() => setShowMore(!showMore)}
+      {...rest}
+    >
+      {showMore ? hideText : showText}
+    </ButtonSecondary>
+  );
+}
+
+SidebarSectionToggle.propTypes = {
+  showText: string,
+  hideText: string
+};
+
+SidebarSectionToggle.defaultProps = {
+  showText: 'Show',
+  hideText: 'Hide'
+};

--- a/lib/src/components/sidebar/SidebarStory.js
+++ b/lib/src/components/sidebar/SidebarStory.js
@@ -52,9 +52,15 @@ export const SidebarExample = () => (
 
     <Sidebar.Body>
       <Sidebar.Section>
-        <Sidebar.Heading>
-          <h3>Meta</h3>
-        </Sidebar.Heading>
+        <Sidebar.SectionHead>
+          <Sidebar.Heading>
+            <h3>Meta</h3>
+          </Sidebar.Heading>
+          <Sidebar.Description>
+            Set width or height values in pixels, Aspect ratio is always
+            honoured.
+          </Sidebar.Description>
+        </Sidebar.SectionHead>
 
         <Sidebar.SubSection>
           <Sidebar.SubHeading>
@@ -65,9 +71,19 @@ export const SidebarExample = () => (
       </Sidebar.Section>
 
       <Sidebar.Section>
-        <Sidebar.Heading showMoreToggle>
-          <h4>Crop</h4>
-        </Sidebar.Heading>
+        <Sidebar.SectionHead
+          toggle={
+            <Sidebar.SectionToggle hideText="Less info" showText="More info" />
+          }
+        >
+          <Sidebar.Heading>
+            <h4>Crop</h4>
+          </Sidebar.Heading>
+          <Sidebar.Description>
+            Set width or height values in pixels, Aspect ratio is always
+            honoured.
+          </Sidebar.Description>
+        </Sidebar.SectionHead>
 
         <Sidebar.SubSection>
           <Sidebar.SubHeading>

--- a/lib/src/components/sidebar/sidebar.scss
+++ b/lib/src/components/sidebar/sidebar.scss
@@ -36,6 +36,14 @@
   }
 }
 
+.sidebar-description {
+  @apply text-neutral-primary text-sm mb-4 -mt-2;
+}
+
+.sidebar-section-head {
+  @apply flex;
+}
+
 .sidebar-header,
 .sidebar-heading {
   @apply font-semi-bold text-base text-neutral-20 leading-normal;


### PR DESCRIPTION
### 💬 Description
In the recent #947 PR we added a new sidebar component. This PR alters the work to make it easier to work with by;

- adding a missing `SidebarDescription` (recently added in the designs)
- making the show toggle composable as we need to alter the button text per instance
- making the section heading area perform better alongside the toggle (so it doesn't wrap)

To achieve some of this I had to abstract some things into their own component but the functionality is all the same 👍 

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
