### PR TITLE
Adding a close button to the sidebar header

### DIFF
--- a/lib/src/components/sidebar/SidebarHeader.js
+++ b/lib/src/components/sidebar/SidebarHeader.js
@@ -6,7 +6,12 @@ export function SidebarHeader({ children, className = '', onClose, ...rest }) {
     <Layout.Header className={`sidebar-header ${className}`} {...rest}>
       <div className="text-overflow-ellipsis">{children}</div>
       {onClose && (
-        <ButtonIcon name="cross" onClick={onClose} size={ButtonIcon.sizes.md} />
+        <ButtonIcon
+          name="cross"
+          onClick={onClose}
+          size={ButtonIcon.sizes.md}
+          iconTitle="Close sidebar"
+        />
       )}
     </Layout.Header>
   );

--- a/lib/src/components/sidebar/SidebarHeader.js
+++ b/lib/src/components/sidebar/SidebarHeader.js
@@ -1,10 +1,13 @@
 import * as React from 'react';
-import { Layout } from 'lib';
+import { ButtonIcon, Layout } from 'lib';
 
-export function SidebarHeader({ children, className = '', ...rest }) {
+export function SidebarHeader({ children, className = '', onClose, ...rest }) {
   return (
     <Layout.Header className={`sidebar-header ${className}`} {...rest}>
       <div className="text-overflow-ellipsis">{children}</div>
+      {onClose && (
+        <ButtonIcon name="cross" onClick={onClose} size={ButtonIcon.sizes.md} />
+      )}
     </Layout.Header>
   );
 }

--- a/lib/src/components/sidebar/SidebarSection.js
+++ b/lib/src/components/sidebar/SidebarSection.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { bool } from 'prop-types';
 
 export const SidebarSectionContext = React.createContext({});
 
@@ -22,3 +23,11 @@ export function SidebarSection({
     </SidebarSectionContext.Provider>
   );
 }
+
+SidebarSection.propTypes = {
+  initialShowMore: bool
+};
+
+SidebarSection.defaultProps = {
+  initialShowMore: false
+};

--- a/lib/src/components/sidebar/SidebarStory.js
+++ b/lib/src/components/sidebar/SidebarStory.js
@@ -46,7 +46,7 @@ const ExampleOfUsingShowMoreToggle = () => {
 
 export const SidebarExample = () => (
   <Sidebar>
-    <Sidebar.Header>
+    <Sidebar.Header onClose={() => {}}>
       <h2>Sidebar header</h2>
     </Sidebar.Header>
 

--- a/lib/src/components/sidebar/sidebar.scss
+++ b/lib/src/components/sidebar/sidebar.scss
@@ -3,7 +3,11 @@
 }
 
 .sidebar-header {
-  @apply p-4 flex;
+  @apply p-4 flex flex-row;
+
+  div {
+    @apply flex-grow self-center;
+  }
 }
 
 .sidebar-footer {


### PR DESCRIPTION
### 💬 Description
We'd like to be able to close the sidebar. So the header of it now accepts an onClose function which renders a lovely cross icon button!

<img width="358" alt="Screenshot 2021-03-26 at 08 55 47" src="https://user-images.githubusercontent.com/33638789/112607417-18682a00-8e11-11eb-85b1-21bc425945a9.png">

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
