### PR TITLE
Prevent ShortCutTrigger from triggering in text fields

### DIFF
--- a/lib/ShortcutTrigger/index.js
+++ b/lib/ShortcutTrigger/index.js
@@ -41,6 +41,10 @@ class ShortcutTrigger extends Component {
   }
 
   onKeyDown(event) {
+    if (event.target.type && event.target.type === 'text') {
+      return event;
+    }
+
     return this.shortcutHasBeenExecuted(event) && !event.repeat
       ? this.props.onShortcutTrigger(event)
       : event;

--- a/lib/src/modules/input/Input.js
+++ b/lib/src/modules/input/Input.js
@@ -32,8 +32,6 @@ export function Input({
       value={_value}
       className={classNames}
       onChange={e => {
-        e.stopPropagation();
-        e.preventDefault();
         onChange(e);
         setValue(e.target.value);
       }}

--- a/lib/src/modules/input/Input.js
+++ b/lib/src/modules/input/Input.js
@@ -32,6 +32,8 @@ export function Input({
       value={_value}
       className={classNames}
       onChange={e => {
+        e.stopPropagation();
+        e.preventDefault();
         onChange(e);
         setValue(e.target.value);
       }}

--- a/tests/ShortcutTrigger/index.js
+++ b/tests/ShortcutTrigger/index.js
@@ -33,14 +33,18 @@ describe('Shortcut Trigger', () => {
   });
 
   test('triggers the function when the shortcut is pressed', () => {
-    wrapper.instance().onKeyDown({ repeat: false, key: 'enter' });
+    wrapper.instance().onKeyDown({ repeat: false, key: 'enter', target: {} });
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({ repeat: false, key: 'enter' });
+    expect(spy).toHaveBeenCalledWith({
+      repeat: false,
+      key: 'enter',
+      target: {}
+    });
 
     wrapper.setProps({ withCtrlKey: true });
     wrapper
       .instance()
-      .onKeyDown({ repeat: false, key: 'enter', ctrlKey: true });
+      .onKeyDown({ repeat: false, key: 'enter', ctrlKey: true, target: {} });
     expect(spy).toHaveBeenCalledTimes(2);
 
     wrapper.setProps({
@@ -55,33 +59,34 @@ describe('Shortcut Trigger', () => {
       ctrlKey: true,
       metaKey: true,
       shiftKey: true,
-      altKey: true
+      altKey: true,
+      target: {}
     });
     expect(spy).toHaveBeenCalledTimes(3);
   });
 
   test('does not trigger the function when the shortcut is not pressed', () => {
-    wrapper.instance().onKeyDown({ repeat: false, key: 'a' });
+    wrapper.instance().onKeyDown({ repeat: false, key: 'a', target: {} });
     expect(spy).not.toHaveBeenCalled();
 
     wrapper
       .instance()
-      .onKeyDown({ repeat: false, key: 'enter', ctrlKey: true });
+      .onKeyDown({ repeat: false, key: 'enter', ctrlKey: true, target: {} });
     expect(spy).not.toHaveBeenCalled();
 
     wrapper
       .instance()
-      .onKeyDown({ repeat: false, key: 'enter', metaKey: true });
+      .onKeyDown({ repeat: false, key: 'enter', metaKey: true, target: {} });
     expect(spy).not.toHaveBeenCalled();
 
     wrapper
       .instance()
-      .onKeyDown({ repeat: false, key: 'enter', shiftKey: true });
+      .onKeyDown({ repeat: false, key: 'enter', shiftKey: true, target: {} });
     expect(spy).not.toHaveBeenCalled();
   });
 
   test('does not trigger the function when the event is repeating', () => {
-    wrapper.instance().onKeyDown({ repeat: true });
+    wrapper.instance().onKeyDown({ repeat: true, target: {} });
     expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### 💬 Description
The title says it all. We check the event to see if it was from a text input, if it is we do nothing.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
