### PR TITLE
add isHovered prop to ColField and ComponentWrapper

### DIFF
--- a/lib/ColField/ColField.js
+++ b/lib/ColField/ColField.js
@@ -33,21 +33,20 @@ function ColField({
     config: { duration: 100 }
   });
 
-  const classes = cx(
-    `col-field border-solid rounded relative transition-all, transition-ease duration-200 ${className}`,
-    {
-      'bg-white border shadow': status === statuses.active,
-      'border-neutral-90': status === statuses.active && !isHovered,
-      'bg-neutral-98 border hover:bg-white border-neutral-90 hover:shadow':
-        status === statuses.unchanged,
-      'border-2 border-green-primary bg-white': status === statuses.added,
-      'border-2 border-red-primary bg-white': status === statuses.deleted,
-      'border-2 border-purple-primary bg-white':
-        status === statuses.movedDown || status === statuses.movedUp,
-      'col-field-selected': isSelected,
-      'border-blue-primary': isHovered
-    }
-  );
+  const classes = cx(`col-field border-solid rounded relative ${className}`, {
+    'bg-white border shadow': status === statuses.active,
+    'border-neutral-90':
+      (status === statuses.active || status === statuses.unchanged) &&
+      !isHovered,
+    'bg-neutral-98 border hover:bg-white hover:shadow':
+      status === statuses.unchanged,
+    'border-2 border-green-primary bg-white': status === statuses.added,
+    'border-2 border-red-primary bg-white': status === statuses.deleted,
+    'border-2 border-purple-primary bg-white':
+      status === statuses.movedDown || status === statuses.movedUp,
+    'col-field-selected': isSelected,
+    'border-blue-primary': isHovered
+  });
 
   return (
     <animated.div

--- a/lib/ColField/ColField.js
+++ b/lib/ColField/ColField.js
@@ -25,6 +25,7 @@ function ColField({
   style,
   status,
   isSelected,
+  isHovered,
   ...props
 }) {
   const animatedStyle = useSpring({
@@ -35,14 +36,16 @@ function ColField({
   const classes = cx(
     `col-field border-solid rounded relative transition-all, transition-ease duration-200 ${className}`,
     {
-      'bg-white border border-neutral-90 shadow': status === statuses.active,
+      'bg-white border shadow': status === statuses.active,
+      'border-neutral-90': status === statuses.active && !isHovered,
       'bg-neutral-98 border hover:bg-white border-neutral-90 hover:shadow':
         status === statuses.unchanged,
       'border-2 border-green-primary bg-white': status === statuses.added,
       'border-2 border-red-primary bg-white': status === statuses.deleted,
       'border-2 border-purple-primary bg-white':
         status === statuses.movedDown || status === statuses.movedUp,
-      'col-field-selected': isSelected
+      'col-field-selected': isSelected,
+      'border-blue-primary': isHovered
     }
   );
 

--- a/lib/ColField/stories/ColFieldStory.js
+++ b/lib/ColField/stories/ColFieldStory.js
@@ -11,13 +11,18 @@ storiesOf('Components', module).add('ColField', () => {
   const visible = boolean('Visible', true);
   const editable = boolean('Editable', true);
   const selected = boolean('Seleted', false);
+  const hovered = boolean('Hovered', false);
 
   return (
     <>
       <StoryItem title="ColField">
         <Row>
           <Col xs={12} sm={8} smOffset={2}>
-            <ColField visible={visible} isSelected={selected}>
+            <ColField
+              visible={visible}
+              isSelected={selected}
+              isHovered={hovered}
+            >
               <ColField.Header>
                 <ColField.Label
                   editable={editable}

--- a/lib/src/components/componentWrapper/ComponentWrapper.js
+++ b/lib/src/components/componentWrapper/ComponentWrapper.js
@@ -14,6 +14,7 @@ export function ComponentWrapper({
   className,
   children,
   isSelected,
+  isHovered,
   counter,
   ...rest
 }) {
@@ -28,9 +29,14 @@ export function ComponentWrapper({
         instructions={instructions}
         onInstructionChange={onInstructionChange}
         isSelected={isSelected}
+        isHovered={isHovered}
         counter={counter}
       />
-      <ComponentWrapperFooter editable={editable} isSelected={isSelected}>
+      <ComponentWrapperFooter
+        editable={editable}
+        isSelected={isSelected}
+        isHovered={isHovered}
+      >
         {children}
       </ComponentWrapperFooter>
     </div>

--- a/lib/src/components/componentWrapper/ComponentWrapperBody.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperBody.js
@@ -5,12 +5,14 @@ export function ComponentWrapperBody({
   children,
   editable,
   isSelected,
-  hovered
+  isHovered,
+  draggedOver
 }) {
   const classes = cx('component-body', {
     'component-body-editable': editable,
-    'component-body-hovered': hovered,
-    'component-body-selected': isSelected
+    'component-body-dragged-over': draggedOver,
+    'component-body-selected': isSelected,
+    'component-body-hovered': isHovered
   });
 
   return <div className={classes}>{children}</div>;
@@ -19,5 +21,5 @@ export function ComponentWrapperBody({
 ComponentWrapperBody.defaultProps = {
   editable: false,
   isSelected: false,
-  hovered: false
+  draggedOver: false
 };

--- a/lib/src/components/componentWrapper/ComponentWrapperFooter.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperFooter.js
@@ -5,13 +5,15 @@ export function ComponentWrapperFooter({
   children,
   editable,
   isSelected,
-  hovered,
+  draggedOver,
+  isHovered,
   className
 }) {
   const classes = cx('component-footer', className, {
     'component-footer-editable': editable,
-    'component-footer-hovered': hovered,
-    'component-footer-selected': isSelected
+    'component-footer-dragged-over': draggedOver,
+    'component-footer-selected': isSelected,
+    'component-footer-hovered': isHovered
   });
 
   return <div className={classes}>{children}</div>;

--- a/lib/src/components/componentWrapper/ComponentWrapperHeader/ComponentWrapperHeader.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperHeader/ComponentWrapperHeader.js
@@ -13,10 +13,12 @@ export function ComponentWrapperHeader({
   instructions,
   onInstructionChange,
   isSelected,
+  isHovered,
   counter
 }) {
   const classes = cx('component-header', {
-    'component-header-selected': isSelected
+    'component-header-selected': isSelected,
+    'component-header-hovered': isHovered
   });
 
   const countText = `${counter < 9 ? '0' : ''}${counter}`;

--- a/lib/src/components/componentWrapper/ComponentWrapperStory.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperStory.js
@@ -16,9 +16,10 @@ const Aside = (
 );
 
 storiesOf('Components', module).add('ComponentWrapper', () => {
-  const bodyHovered = boolean('Body Hovered', false);
+  const draggedOver = boolean('Dragged over', false);
   const editable = boolean('Editable', true);
   const isSelected = boolean('Selected', false);
+  const isHovered = boolean('Hovered', false);
   const counter = number('Counter', null);
 
   return (
@@ -36,6 +37,7 @@ storiesOf('Components', module).add('ComponentWrapper', () => {
               subLabel="(Goodbye!)"
               isSelected={isSelected}
               counter={counter}
+              isHovered={isHovered}
             >
               <ColField className="mb-10">
                 <ColField.Header>
@@ -77,11 +79,13 @@ storiesOf('Components', module).add('ComponentWrapper', () => {
               onLabelChange={() => {}}
               isSelected={isSelected}
               counter={counter}
+              isHovered={isHovered}
             />
             <ComponentWrapper.Body
               editable={editable}
               isSelected={isSelected}
-              hovered={bodyHovered}
+              draggedOver={draggedOver}
+              isHovered={isHovered}
             >
               <ColField>
                 <ColField.Header>
@@ -100,7 +104,8 @@ storiesOf('Components', module).add('ComponentWrapper', () => {
             <ComponentWrapper.Footer
               editable={editable}
               isSelected={isSelected}
-              hovered={bodyHovered}
+              draggedOver={draggedOver}
+              isHovered={isHovered}
             >
               <ColField className="mt-6">
                 <ColField.Header>

--- a/lib/src/components/componentWrapper/componentWrapper.scss
+++ b/lib/src/components/componentWrapper/componentWrapper.scss
@@ -3,6 +3,9 @@
   &-selected {
     @include before-border(2px 2px 0px 2px, solid, theme('colors.blue.primary'), theme('borderRadius.xlarge') theme('borderRadius.xlarge') 0px 0px);
   }
+  &-hovered {
+    @apply border-blue-primary;
+  }
 }
 
 .component-header-top {
@@ -50,8 +53,11 @@
     @apply bg-neutral-95;
   }
 
-  &-hovered {
+  &-dragged-over {
     @apply bg-neutral-90;
+  }
+  &-hovered {
+    @apply border-blue-primary;
   }
 }
 


### PR DESCRIPTION
### 💬 Description
When hovering over repeat buttons for fields/components we needed a 1px blue border style, enter our new prop `isHovered`. We already had a `hovered` prop for some `ComponentWrapper` components, but as we only use that for dnd i've renamed it to `draggedOver`, having a `isHovered` and `hovered` prop felt a bit icky!

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
