### PR TITLE
add throttle to hover handler

### DIFF
--- a/lib/DnD/Droppable.js
+++ b/lib/DnD/Droppable.js
@@ -2,6 +2,7 @@ import { useDrop } from 'react-dnd-cjs';
 import { func, node } from 'prop-types';
 import { useContext } from 'react';
 import { DndContext } from 'lib';
+import { throttle } from 'lodash';
 
 function Droppable({
   children,
@@ -19,7 +20,11 @@ function Droppable({
       return onDrop(...args);
     },
     canDrop: canDropChecker,
-    hover: onHoverHandler,
+    hover: throttle((item, monitor) => {
+      if (monitor && monitor.getItem()) {
+        onHoverHandler(item, monitor);
+      }
+    }, 150),
     collect: monitor => ({
       isOver: monitor.isOver(isOverOptions),
       canDrop: monitor.canDrop(),
@@ -39,7 +44,8 @@ Droppable.propTypes = {
 
 Droppable.defaultProps = {
   canDropChecker: () => true,
-  isOverOptions: { shallow: false }
+  isOverOptions: { shallow: false },
+  onHoverHandler: () => {}
 };
 
 export { Droppable };


### PR DESCRIPTION
### 💬 Description
We do quite a lot in our hover handlers on app, which causes some really slow and sluggish dnd behaviour for people on struggling computers. The on hover event fires an awful lot, so adding a throttle will reduce the strain and make dnd a bit nippier. 

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
