### PR TITLE
Feature/fix topbar icons

### DIFF
--- a/lib/TopBar/styles.scss
+++ b/lib/TopBar/styles.scss
@@ -101,10 +101,6 @@ $top-bar-notification-height: 42px;
 
   .top-bar__action {
     fill: $neutral-dark;
-  }
-
-  .top-bar__action {
-    display: block;
     padding: $layout-spacing-base/2.5;
   }
 

--- a/stories/components/TopBar.js
+++ b/stories/components/TopBar.js
@@ -15,6 +15,7 @@ import Logo from '../../lib/Logo';
 import DropdownSwitcher from '../../lib/DropdownSwitcher';
 import Search from '../../lib/Search';
 import NotificationBar from '../../lib/Notification/bar';
+import { ButtonIcon } from 'lib';
 
 storiesOf('Components', module).add('TopBar', () => (
   <div>
@@ -56,13 +57,13 @@ storiesOf('Components', module).add('TopBar', () => (
             </AvatarGroup>
           </TopBarCell>
           <TopBarCell bordered>
-            <Button
-              types={['icon-only']}
+            <ButtonIcon
+              name="menuDotted"
+              size={ButtonIcon.sizes.md}
+              onClick={() => {}}
               className="top-bar__action"
-              clickHandler={() => {}}
-            >
-              <Icon name="menuDotted" />
-            </Button>
+              iconTitle="Open item settings"
+            />
           </TopBarCell>
         </TopBarContent>
         <TopBarContent center xs={12} md={3}>
@@ -108,13 +109,13 @@ storiesOf('Components', module).add('TopBar', () => (
             </AvatarGroup>
           </TopBarCell>
           <TopBarCell bordered>
-            <Button
-              types={['icon-only']}
+            <ButtonIcon
+              name="menuDotted"
+              size={ButtonIcon.sizes.md}
+              onClick={() => {}}
               className="top-bar__action"
-              clickHandler={() => {}}
-            >
-              <Icon name="menuDotted" />
-            </Button>
+              iconTitle="Open item settings"
+            />
           </TopBarCell>
         </TopBarContent>
         <TopBarContent center xs={12} md={3}>
@@ -147,13 +148,13 @@ storiesOf('Components', module).add('TopBar', () => (
         </TopBarContent>
         <TopBarContent right xs={2} md={4}>
           <TopBarCell bordered>
-            <Button
-              types={['icon-only']}
+            <ButtonIcon
+              name="menuDotted"
+              size={ButtonIcon.sizes.md}
+              onClick={() => {}}
               className="top-bar__action"
-              clickHandler={() => {}}
-            >
-              <Icon name="menuDotted" />
-            </Button>
+              iconTitle="Open item settings"
+            />
           </TopBarCell>
         </TopBarContent>
         <TopBarContent center xs={12} md={3}>


### PR DESCRIPTION
### 💬 Description

I recently tried to fix the menu-dotted button from appearing wonky in the top bar by fixing the SVG. 
I didn't test it with the TopBar and the new ButtonIcon components either though as it is still wonky from the `.top-bar__action` class. This PR updates the TopBar story to bring it inline with the web app, where you can see the problem matches, then removes the `display: block` property from that css class, so the `.button-icon` `display: inline-flex` should take precedent.

### 👫 Related PRs (optional)
https://github.com/gathercontent/gather-ui/pull/966

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
