### PR TITLE
Bug/modal header warning

### DIFF
--- a/lib/src/components/modal/ModalHeader.js
+++ b/lib/src/components/modal/ModalHeader.js
@@ -10,7 +10,3 @@ export function ModalHeader({ headerText, onCloseClick, navigationItems }) {
     </div>
   );
 }
-
-ModalHeader.defaultProps = {
-  navigationItems: () => {}
-};

--- a/lib/src/components/modal/ModalStory.js
+++ b/lib/src/components/modal/ModalStory.js
@@ -26,7 +26,7 @@ const modalStory = storiesOf('Components', module).add('Modal', () => {
     <div className="h-screen bg-blue-80">
       <StoryItem>
         <Modal show={value === 'Empty'} size="large">
-          <Modal.Header>Header</Modal.Header>
+          <Modal.Header headerText="Header" />
           <Modal.Body>Body</Modal.Body>
           <Modal.Footer>Footer</Modal.Footer>
         </Modal>


### PR DESCRIPTION
### 💬 Description

Fix warning from ModalHeader - The default prop for navigationItems was a function `() => {}`. This causes the error:

> [Error] Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.


### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
