### PR TITLE
Refactor & fix race condition for auto positioned dropdown content

### DIFF
--- a/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
+++ b/lib/ConfirmationDropdown/ConfirmationDropdownContent.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Button from '../Button';
 import Icon from '../Icon';
 import TooltipWrapper from '../TooltipWrapper';
-import DropdownContent from '../Dropdown/DropdownContent';
+import { DropdownContent } from '../Dropdown/DropdownContent';
 import DropdownFooter from '../Dropdown/DropdownFooter';
 import { DropdownContext } from '../Dropdown/DropdownProvider';
 

--- a/lib/Dropdown/DropdownContent.js
+++ b/lib/Dropdown/DropdownContent.js
@@ -1,28 +1,30 @@
-import React, { Component } from 'react';
+import React, { useEffect, useState, useContext, useRef } from 'react';
 import { isEqual } from 'lodash';
 import cx from 'classnames';
-import PropTypes from 'prop-types';
 import { DropdownContext } from './DropdownProvider';
 
 const CONTENT_BOUNDARY_PADDING = 40;
 
-class DropdownContent extends Component {
-  static contextType = DropdownContext;
-
-  state = {
-    style: {}
+export function DropdownContent({
+  children,
+  className,
+  collapse,
+  right,
+  centre,
+  top,
+  fixRight,
+  full,
+  noBorder,
+  autoPositionLeft,
+  noTransform
+}) {
+  const { showContent, autoPosition, bounds } = useContext(DropdownContext) || {
+    showContent: false
   };
+  const [style, setStyle] = useState({});
+  const contentElementRef = useRef(null);
 
-  componentDidUpdate() {
-    const newStyle = this.getStyle();
-
-    if (!isEqual(newStyle, this.state.style)) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ style: newStyle });
-    }
-  }
-
-  getTopPosition = (pos, bounds, contentBounds) => {
+  const getTopPosition = (pos, contentBounds) => {
     let newPos = pos;
 
     const originalExceedsHeight = pos > window.innerHeight;
@@ -41,8 +43,7 @@ class DropdownContent extends Component {
     return bounds.bottom;
   };
 
-  getLeftPosition = (pos, bounds, contentBounds) => {
-    const { autoPositionLeft } = this.props;
+  const getLeftPosition = (pos, contentBounds) => {
     let newPos = pos;
 
     const originalExceedsWidth = pos > window.innerWidth;
@@ -62,11 +63,9 @@ class DropdownContent extends Component {
     return autoPositionLeft ? bounds.left : bounds.right;
   };
 
-  getStyle = () => {
-    const { autoPosition, bounds, showContent } = this.context;
-
-    if (this.content && autoPosition && showContent) {
-      const contentBounds = this.content.getBoundingClientRect();
+  const getStyle = () => {
+    if (contentElementRef?.current && autoPosition && showContent) {
+      const contentBounds = contentElementRef.current.getBoundingClientRect();
 
       const bottomOfDropdownContent =
         bounds.top !== 'auto'
@@ -79,16 +78,8 @@ class DropdownContent extends Component {
           : bounds.left;
 
       return {
-        top: this.getTopPosition(
-          bottomOfDropdownContent,
-          bounds,
-          contentBounds
-        ),
-        left: this.getLeftPosition(
-          rightOfDropdownContent,
-          bounds,
-          contentBounds
-        )
+        top: getTopPosition(bottomOfDropdownContent, contentBounds),
+        left: getLeftPosition(rightOfDropdownContent, contentBounds)
       };
     }
 
@@ -102,63 +93,34 @@ class DropdownContent extends Component {
     return null;
   };
 
-  render() {
-    const {
-      children,
-      right,
-      centre,
-      top,
-      fixRight,
-      collapse,
-      className,
-      full,
-      noBorder,
-      noTransform
-    } = this.props;
+  useEffect(() => {
+    const newStyle = getStyle();
+    if (!isEqual(newStyle, style)) {
+      setStyle(newStyle);
+    }
+  }, [showContent, !!contentElementRef.current]);
 
-    const { showContent } = this.context;
+  const classNames = cx(
+    `dropdown__content border border-solid border-neutral-90 rounded shadow ${className}`,
+    {
+      'is-active': showContent,
+      'dropdown__content--collapse': collapse,
+      'dropdown__content--right': right,
+      'dropdown__content--centre': centre,
+      'dropdown__content--top': top,
+      'dropdown__content--fix-right': fixRight,
+      'dropdown__content--full': full,
+      'dropdown__content--noborder': noBorder,
+      'dropdown__content--no-transform': noTransform
+    }
+  );
 
-    const classNames = cx(
-      `dropdown__content border border-solid border-neutral-90 rounded shadow ${className}`,
-      {
-        'is-active': showContent,
-        'dropdown__content--collapse': collapse,
-        'dropdown__content--right': right,
-        'dropdown__content--centre': centre,
-        'dropdown__content--top': top,
-        'dropdown__content--fix-right': fixRight,
-        'dropdown__content--full': full,
-        'dropdown__content--noborder': noBorder,
-        'dropdown__content--no-transform': noTransform
-      }
-    );
-
-    return (
-      <div
-        className={classNames}
-        style={this.state.style}
-        ref={content => {
-          this.content = content;
-        }}
-      >
-        {typeof children === 'function' ? children(showContent) : children}
-      </div>
-    );
-  }
+  return (
+    <div className={classNames} style={style} ref={contentElementRef}>
+      {typeof children === 'function' ? children(showContent) : children}
+    </div>
+  );
 }
-
-DropdownContent.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-  className: PropTypes.string,
-  collapse: PropTypes.bool,
-  right: PropTypes.bool,
-  centre: PropTypes.bool,
-  top: PropTypes.bool,
-  fixRight: PropTypes.bool,
-  full: PropTypes.bool,
-  noBorder: PropTypes.bool,
-  autoPositionLeft: PropTypes.bool
-};
 
 DropdownContent.defaultProps = {
   className: '',
@@ -171,5 +133,3 @@ DropdownContent.defaultProps = {
   noBorder: false,
   autoPositionLeft: false
 };
-
-export default DropdownContent;

--- a/lib/Dropdown/index.js
+++ b/lib/Dropdown/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DropdownAction from './DropdownAction';
 import DropdownActionGroup from './DropdownActionGroup';
-import DropdownContent from './DropdownContent';
+import { DropdownContent } from './DropdownContent';
 import DropdownSection from './DropdownSection';
 import DropdownTrigger from './DropdownTrigger';
 import DropdownHeader from './DropdownHeader';

--- a/stories/components/Dropdown.js
+++ b/stories/components/Dropdown.js
@@ -173,6 +173,25 @@ storiesOf('Components', module)
             {createContentWithItems()}
           </Dropdown>
         </StoryItem>
+
+        <StoryItem
+          title="Dropdown with unrednered content and auto positioning"
+          description="A dropdown where we don't render the dropdown content until the dropdown is active"
+        >
+          <Dropdown id="id-3-b" autoPosition>
+            {({ showContent }) => (
+              <>
+                <Dropdown.Trigger useButton>
+                  Auto Position
+                </Dropdown.Trigger>
+
+                {showContent && (
+                  createContentWithItems()
+                )}
+              </>
+            )}
+          </Dropdown>
+        </StoryItem>
         <StoryItem
           title="Confirmation Dropdown"
           description="A dropdown like component that renders a confirmation dropdown."


### PR DESCRIPTION
### 💬 Description
When conditionally rendering the dropdown content a race condition happens when auto positioning the dropdown content. It tries to grab the element and its bounds before its rendered, stopping auto positioning from working and keeping the dropdown off screen. 

I've refactored the component and tweaked when we calculate styles to stop this from happening. 
### 🚪 Start Points
`lib/Dropdown/DropdownContent.js`

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
