### PR TITLE
Pass className prop to modal-header-inner in ModalHeader

### DIFF
--- a/lib/Modal/ModalHeader.js
+++ b/lib/Modal/ModalHeader.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-bootstrap/lib/Modal';
 
-const ModalHeader = ({ children, text, useTitle, ...props }) => (
+const ModalHeader = ({ children, text, useTitle, className, ...props }) => (
   <Modal.Header {...props}>
-    <div className="modal-header-inner">
+    <div className={`modal-header-inner ${className}`}>
       {useTitle ? <Modal.Title>{children}</Modal.Title> : children}
       {text && <p className="modal__header-intro">{text}</p>}
     </div>
@@ -15,14 +15,16 @@ ModalHeader.propTypes = {
   children: PropTypes.node,
   closeButton: PropTypes.bool,
   text: PropTypes.string,
-  useTitle: PropTypes.bool
+  useTitle: PropTypes.bool,
+  className: PropTypes.string
 };
 
 ModalHeader.defaultProps = {
   children: null,
   closeButton: true,
   text: null,
-  useTitle: true
+  useTitle: true,
+  className: null
 };
 
 export default ModalHeader;


### PR DESCRIPTION
### 💬 Description
Can't override the classes/styling provided in the `ModalHeader` because the className prop is just sent to Modal.Header, not the modal-header-inner.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
