### PR TITLE
Adding a default highlight prop to the person component

### DIFF
--- a/lib/src/modules/person/Person.js
+++ b/lib/src/modules/person/Person.js
@@ -53,5 +53,6 @@ export function Person({
 }
 
 Person.defaultProps = {
-  interactive: false
+  interactive: false,
+  highlightText: ''
 };


### PR DESCRIPTION
### 💬 Description
Whoops, there needs to be a default value for the new `highlightText` prop!

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
