### PR TITLE
Adding a shortcut trigger for submitting an input with mentions

### DIFF
--- a/lib/src/modules/input/InputWithMentions.js
+++ b/lib/src/modules/input/InputWithMentions.js
@@ -1,19 +1,21 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Mention, MentionsInput } from 'react-mentions';
 import cx from 'classnames';
-import { Avatar, AvatarInformation } from 'lib';
+import { Avatar, AvatarInformation, ShortcutTrigger } from 'lib';
 
 export function InputWithMentions({
   value,
   users,
   onChange,
   onMention,
+  onSubmitShortcutTriggered,
   ...rest
 }) {
   const [inputValue, setInputValue] = useState(value);
   const [currentInputHeight, setCurrentInputHeight] = useState('0px');
   const hiddenContentRef = useRef(null);
   const mentionsPortalRef = useRef(null);
+  const [hasFocus, setHasFocus] = useState(false);
 
   const getInputHeight = () => {
     if (hiddenContentRef.current) {
@@ -76,6 +78,8 @@ export function InputWithMentions({
         markup="@[__display__]"
         displayTransform={(id, display) => `@${display}`}
         suggestionsPortalHost={mentionsPortalRef.current}
+        onFocus={() => setHasFocus(true)}
+        onBlur={() => setHasFocus(false)}
         {...rest}
       >
         <Mention
@@ -94,6 +98,28 @@ export function InputWithMentions({
         />
       </MentionsInput>
       <div ref={mentionsPortalRef} />
+      <ShortcutTrigger
+        shortcutKey="Enter"
+        onShortcutTrigger={e => {
+          if (!hasFocus || !value) {
+            return e;
+          }
+
+          return onSubmitShortcutTriggered(e);
+        }}
+        withCtrlKey
+      />
+      <ShortcutTrigger
+        shortcutKey="Enter"
+        onShortcutTrigger={e => {
+          if (!hasFocus || !value) {
+            return e;
+          }
+
+          return onSubmitShortcutTriggered(e);
+        }}
+        withMetaKey
+      />
       <div
         ref={hiddenContentRef}
         style={{


### PR DESCRIPTION
### 💬 Description
The title says it all. We would like to submit the `InputWIthMentions` with cmd+enter.


### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
