### PR TITLE
Fix DropdownMenu not closing after clicking on item or clicking outside of dropdown

### DIFF
--- a/lib/DropdownMenu/index.js
+++ b/lib/DropdownMenu/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import cx from 'classnames';
 import Button from '../Button';
 import Icon from '../Icon';
@@ -7,6 +7,7 @@ import { DropdownMenuItem } from './DropdownMenuItem';
 
 export function DropdownMenu({ items, className, listClassName, type, direction, caret, children, shouldDisplay, alignRight, selected, downIcon, fullWidth, buttonClassName, disabled }) {
   const [showItems, setShowItems] = useState(selected);
+  const eventSet = useRef(selected);
 
   const closeDropdown = (e) => {
     let isTargetDropDownButton = false;
@@ -21,11 +22,20 @@ export function DropdownMenu({ items, className, listClassName, type, direction,
   };
 
   useEffect(() => {
-    document.body.addEventListener('click', closeDropdown);
-    return () => {
-      document.body.removeEventListener('click', closeDropdown);
+    if (showItems) {
+      document.body.addEventListener('click', closeDropdown);
+      eventSet.current = true;
     }
-  }, []);
+    if (!showItems && eventSet.current) {
+      document.body.removeEventListener('click', closeDropdown);
+      eventSet.current = false;
+    }
+    return () => {
+      if (eventSet.current) {
+        document.body.removeEventListener('click', closeDropdown);
+      }
+    }
+  }, [showItems]);
 
   const toggleShowItems = () => {
     if (!disabled) {

--- a/lib/DropdownMenu/styles.scss
+++ b/lib/DropdownMenu/styles.scss
@@ -229,6 +229,8 @@ $dropdown-menu-font-color: $color-text-base !default;
     margin-left: auto;
     justify-self: end;
     color: $neutral-base;
+    flex-shrink: 0;
+    padding-left: 5px;
   }
 }
 


### PR DESCRIPTION
### 💬 Description
`useEffect` does some caching and because event listener is only set up on mount while `showItems` is false, it then always thinks its false every time that event is fired. 

Changing it so the event listener gets set up when `showItems` is true solves the problem, and as a nice side effect we're not needlessly setting up event listeners before someones even interacted with the dropdown

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
