### PR TITLE
Replace GUI Grid, Row and Col bootstrap components with like for like ❤️

### DIFF
--- a/lib/ColField/stories/ColFieldStory.js
+++ b/lib/ColField/stories/ColFieldStory.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean } from '@storybook/addon-knobs';
-import Row from 'react-bootstrap/lib/Row';
-import Col from 'react-bootstrap/lib/Col';
 import ColField from 'lib/ColField/ColField';
+import { Col, Row } from 'lib';
 import StoryItem from '../../../stories/styleguide/StoryItem';
 import TextPreviewSVG from '../../../assets/text-preview.svg';
 

--- a/lib/ConversationContext/index.js
+++ b/lib/ConversationContext/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes, { arrayOf, shape } from 'prop-types';
-import Row from 'react-bootstrap/lib/Row';
-import Col from 'react-bootstrap/lib/Col';
-import { Person } from 'lib';
+import { Col, Person, Row } from 'lib';
 import { Conversation } from '../Conversation/Conversation';
 import { Comment } from '../Comment/Comment';
 

--- a/lib/SelectionBar/SelectionBarActions.js
+++ b/lib/SelectionBar/SelectionBarActions.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Col from 'react-bootstrap/lib/Col';
+import { Col } from 'lib';
 
 const SelectionBarActions = ({ children }) => (
   <Col

--- a/lib/SelectionBar/SelectionBarCancel.js
+++ b/lib/SelectionBar/SelectionBarCancel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Col from 'react-bootstrap/lib/Col';
+import { Col } from 'lib';
 import ShortcutTrigger from '../ShortcutTrigger';
 import Button from '../Button';
 

--- a/lib/SelectionBar/SelectionBarInformation.js
+++ b/lib/SelectionBar/SelectionBarInformation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Col from 'react-bootstrap/lib/Col';
+import { Col } from 'lib';
 
 const SelectionBarInformation = props => (
   <Col

--- a/lib/SelectionBar/index.js
+++ b/lib/SelectionBar/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import Row from 'react-bootstrap/lib/Row';
-import { AnimatedWrapper } from 'lib';
+import { AnimatedWrapper, Row } from 'lib';
 import SelectionBarAction from './SelectionBarAction';
 import SelectionBarDivider from './SelectionBarDivider';
 import SelectionBarCancel from './SelectionBarCancel';

--- a/lib/TopBar/TopBarContent.js
+++ b/lib/TopBar/TopBarContent.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import Col from 'react-bootstrap/lib/Col';
+import { Col } from 'lib';
 
 const TopBarContent = ({
   left,

--- a/lib/TopBar/index.js
+++ b/lib/TopBar/index.js
@@ -1,8 +1,7 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Grid from 'react-bootstrap/lib/Grid';
-import Row from 'react-bootstrap/lib/Row';
 import cx from 'classnames';
+import { Grid, Row } from 'lib';
 
 class TopBar extends Component {
   constructor() {
@@ -62,10 +61,10 @@ class TopBar extends Component {
             this.topbar = node;
           }}
         >
-          <Fragment>
+          <>
             {this.props.notification}
             <Row className="top-bar__inner">{this.props.children}</Row>
-          </Fragment>
+          </>
         </div>
       </Grid>
     );

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,6 +177,9 @@ export { Person } from './src/modules/person/Person';
 export { Calendar } from './src/modules/calendar/Calendar';
 export { DateSet } from './src/modules/dateSet/DateSet';
 export { MenuItem } from './src/modules/menuItem/MenuItem';
+export { Grid } from './src/modules/grid/Grid';
+export { Row } from './src/modules/grid/Row';
+export { Col } from './src/modules/grid/Col';
 
 export { ModalUpload } from './src/prefabs/modalUpload/ModalUpload';
 export { DueDateDropdown } from './src/prefabs/dueDateDropdown/DueDateDropdown';

--- a/lib/src/components/componentWrapper/ComponentWrapperStory.js
+++ b/lib/src/components/componentWrapper/ComponentWrapperStory.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, number, select } from '@storybook/addon-knobs';
-import Row from 'react-bootstrap/lib/Row';
-import Col from 'react-bootstrap/lib/Col';
-import { ComponentWrapper, ColField, ButtonIcon } from 'lib';
+import { ComponentWrapper, ColField, ButtonIcon, Row, Col } from 'lib';
 import StoryItem from 'stories/styleguide/StoryItem';
 import TextPreviewSVG from '../../../../assets/text-preview.svg';
 import { componentStatuses } from './ComponentWrapper';

--- a/lib/src/modules/grid/Col.js
+++ b/lib/src/modules/grid/Col.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import cx from 'classnames';
+
+const DEVICE_SIZES = ['lg', 'md', 'sm', 'xs'];
+
+export function Col({ children, className = '', ...rest }) {
+  const layoutClassNames = [];
+
+  DEVICE_SIZES.forEach(size => {
+    function popProp(propSuffix, modifier) {
+      const propName = `${size}${propSuffix}`;
+      const propValue = rest[propName];
+
+      if (propValue) {
+        layoutClassNames.push(`col-${size}${modifier}-${propValue}`);
+      }
+    }
+
+    popProp('', '');
+    popProp('Offset', '-offset');
+    popProp('Push', '-push');
+    popProp('Pull', '-pull');
+  });
+
+  const classNames = cx('col', layoutClassNames, className);
+
+  return (
+    <div className={classNames} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/lib/src/modules/grid/Grid.js
+++ b/lib/src/modules/grid/Grid.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export function Grid({ children, className = '', ...rest }) {
+  return (
+    <div className={`container-fluid ${className}`} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/lib/src/modules/grid/Row.js
+++ b/lib/src/modules/grid/Row.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export function Row({ children, className = '', ...rest }) {
+  return (
+    <div className={`row ${className}`} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/lib/src/modules/grid/grid.scss
+++ b/lib/src/modules/grid/grid.scss
@@ -1,0 +1,427 @@
+//== Grid system
+//
+//## Define your custom responsive grid.
+
+//** Number of columns in the grid.
+$grid-columns:              12 !default;
+//** Padding between columns. Gets divided in half for the left and right.
+$grid-gutter-width:         30px !default;
+// Navbar collapse
+//** Point at which the navbar becomes uncollapsed.
+$grid-float-breakpoint:     $screen-sm-min !default;
+//** Point at which the navbar begins collapsing.
+$grid-float-breakpoint-max: ($grid-float-breakpoint - 1) !default;
+
+//== Container sizes
+//
+//## Define the maximum width of `.container` for different screen sizes.
+
+// Small screen / tablet
+$container-tablet:             (720px + $grid-gutter-width) !default;
+//** For `$screen-sm-min` and up.
+$container-sm:                 $container-tablet !default;
+
+// Medium screen / desktop
+$container-desktop:            (940px + $grid-gutter-width) !default;
+//** For `$screen-md-min` and up.
+$container-md:                 $container-desktop !default;
+
+// Large screen / wide desktop
+$container-large-desktop:      (1140px + $grid-gutter-width) !default;
+//** For `$screen-lg-min` and up.
+$container-lg:                 $container-large-desktop !default;
+
+@mixin clearfix() {
+  &:before,
+  &:after {
+    display: table; // 2
+    content: " "; // 1
+  }
+  &:after {
+    clear: both;
+  }
+}
+
+// Framework grid generation
+//
+// Used only by Bootstrap to generate the correct number of grid classes given
+// any value of `$grid-columns`.
+
+// [converter] This is defined recursively in LESS, but Sass supports real loops
+@mixin make-grid-columns($i: 1, $list: ".col-xs-#{$i}, .col-sm-#{$i}, .col-md-#{$i}, .col-lg-#{$i}") {
+  @for $i from (1 + 1) through $grid-columns {
+    $list: "#{$list}, .col-xs-#{$i}, .col-sm-#{$i}, .col-md-#{$i}, .col-lg-#{$i}";
+  }
+  #{$list} {
+    position: relative;
+    // Prevent columns from collapsing when empty
+    min-height: 1px;
+    // Inner gutter via padding
+    padding-right: floor(($grid-gutter-width / 2));
+    padding-left: ceil(($grid-gutter-width / 2));
+  }
+}
+
+
+// [converter] This is defined recursively in LESS, but Sass supports real loops
+@mixin float-grid-columns($class, $i: 1, $list: ".col-#{$class}-#{$i}") {
+  @for $i from (1 + 1) through $grid-columns {
+    $list: "#{$list}, .col-#{$class}-#{$i}";
+  }
+  #{$list} {
+    float: left;
+  }
+}
+
+
+@mixin calc-grid-column($index, $class, $type) {
+  @if ($type == width) and ($index > 0) {
+    .col-#{$class}-#{$index} {
+      width: percentage(($index / $grid-columns));
+    }
+  }
+  @if ($type == push) and ($index > 0) {
+    .col-#{$class}-push-#{$index} {
+      left: percentage(($index / $grid-columns));
+    }
+  }
+  @if ($type == push) and ($index == 0) {
+    .col-#{$class}-push-0 {
+      left: auto;
+    }
+  }
+  @if ($type == pull) and ($index > 0) {
+    .col-#{$class}-pull-#{$index} {
+      right: percentage(($index / $grid-columns));
+    }
+  }
+  @if ($type == pull) and ($index == 0) {
+    .col-#{$class}-pull-0 {
+      right: auto;
+    }
+  }
+  @if ($type == offset) {
+    .col-#{$class}-offset-#{$index} {
+      margin-left: percentage(($index / $grid-columns));
+    }
+  }
+}
+
+// [converter] This is defined recursively in LESS, but Sass supports real loops
+@mixin loop-grid-columns($columns, $class, $type) {
+  @for $i from 0 through $columns {
+    @include calc-grid-column($i, $class, $type);
+  }
+}
+
+
+// Create grid for specific class
+@mixin make-grid($class) {
+  @include float-grid-columns($class);
+  @include loop-grid-columns($grid-columns, $class, width);
+  @include loop-grid-columns($grid-columns, $class, pull);
+  @include loop-grid-columns($grid-columns, $class, push);
+  @include loop-grid-columns($grid-columns, $class, offset);
+}
+
+// Framework grid generation
+//
+// Used only by Bootstrap to generate the correct number of grid classes given
+// any value of `$grid-columns`.
+
+// [converter] This is defined recursively in LESS, but Sass supports real loops
+@mixin make-grid-columns($i: 1, $list: ".col-xs-#{$i}, .col-sm-#{$i}, .col-md-#{$i}, .col-lg-#{$i}") {
+  @for $i from (1 + 1) through $grid-columns {
+    $list: "#{$list}, .col-xs-#{$i}, .col-sm-#{$i}, .col-md-#{$i}, .col-lg-#{$i}";
+  }
+  #{$list} {
+    position: relative;
+    // Prevent columns from collapsing when empty
+    min-height: 1px;
+    // Inner gutter via padding
+    padding-right: floor(($grid-gutter-width / 2));
+    padding-left: ceil(($grid-gutter-width / 2));
+  }
+}
+
+
+// [converter] This is defined recursively in LESS, but Sass supports real loops
+@mixin float-grid-columns($class, $i: 1, $list: ".col-#{$class}-#{$i}") {
+  @for $i from (1 + 1) through $grid-columns {
+    $list: "#{$list}, .col-#{$class}-#{$i}";
+  }
+  #{$list} {
+    float: left;
+  }
+}
+
+
+@mixin calc-grid-column($index, $class, $type) {
+  @if ($type == width) and ($index > 0) {
+    .col-#{$class}-#{$index} {
+      width: percentage(($index / $grid-columns));
+    }
+  }
+  @if ($type == push) and ($index > 0) {
+    .col-#{$class}-push-#{$index} {
+      left: percentage(($index / $grid-columns));
+    }
+  }
+  @if ($type == push) and ($index == 0) {
+    .col-#{$class}-push-0 {
+      left: auto;
+    }
+  }
+  @if ($type == pull) and ($index > 0) {
+    .col-#{$class}-pull-#{$index} {
+      right: percentage(($index / $grid-columns));
+    }
+  }
+  @if ($type == pull) and ($index == 0) {
+    .col-#{$class}-pull-0 {
+      right: auto;
+    }
+  }
+  @if ($type == offset) {
+    .col-#{$class}-offset-#{$index} {
+      margin-left: percentage(($index / $grid-columns));
+    }
+  }
+}
+
+// [converter] This is defined recursively in LESS, but Sass supports real loops
+@mixin loop-grid-columns($columns, $class, $type) {
+  @for $i from 0 through $columns {
+    @include calc-grid-column($i, $class, $type);
+  }
+}
+
+
+// Create grid for specific class
+@mixin make-grid($class) {
+  @include float-grid-columns($class);
+  @include loop-grid-columns($grid-columns, $class, width);
+  @include loop-grid-columns($grid-columns, $class, pull);
+  @include loop-grid-columns($grid-columns, $class, push);
+  @include loop-grid-columns($grid-columns, $class, offset);
+}
+
+
+// Grid system
+//
+// Generate semantic grid columns with these mixins.
+
+// Centered container element
+@mixin container-fixed($gutter: $grid-gutter-width) {
+  padding-right: ceil(($gutter / 2));
+  padding-left: floor(($gutter / 2));
+  margin-right: auto;
+  margin-left: auto;
+  @include clearfix;
+}
+
+// Creates a wrapper for a series of columns
+@mixin make-row($gutter: $grid-gutter-width) {
+  margin-right: floor(($gutter / -2));
+  margin-left: ceil(($gutter / -2));
+  @include clearfix;
+}
+
+// Generate the extra small columns
+@mixin make-xs-column($columns, $gutter: $grid-gutter-width) {
+  position: relative;
+  float: left;
+  width: percentage(($columns / $grid-columns));
+  min-height: 1px;
+  padding-right: ($gutter / 2);
+  padding-left: ($gutter / 2);
+}
+@mixin make-xs-column-offset($columns) {
+  margin-left: percentage(($columns / $grid-columns));
+}
+@mixin make-xs-column-push($columns) {
+  left: percentage(($columns / $grid-columns));
+}
+@mixin make-xs-column-pull($columns) {
+  right: percentage(($columns / $grid-columns));
+}
+
+// Generate the small columns
+@mixin make-sm-column($columns, $gutter: $grid-gutter-width) {
+  position: relative;
+  min-height: 1px;
+  padding-right: ($gutter / 2);
+  padding-left: ($gutter / 2);
+
+  @media (min-width: $screen-sm-min) {
+    float: left;
+    width: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-sm-column-offset($columns) {
+  @media (min-width: $screen-sm-min) {
+    margin-left: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-sm-column-push($columns) {
+  @media (min-width: $screen-sm-min) {
+    left: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-sm-column-pull($columns) {
+  @media (min-width: $screen-sm-min) {
+    right: percentage(($columns / $grid-columns));
+  }
+}
+
+// Generate the medium columns
+@mixin make-md-column($columns, $gutter: $grid-gutter-width) {
+  position: relative;
+  min-height: 1px;
+  padding-right: ($gutter / 2);
+  padding-left: ($gutter / 2);
+
+  @media (min-width: $screen-md-min) {
+    float: left;
+    width: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-md-column-offset($columns) {
+  @media (min-width: $screen-md-min) {
+    margin-left: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-md-column-push($columns) {
+  @media (min-width: $screen-md-min) {
+    left: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-md-column-pull($columns) {
+  @media (min-width: $screen-md-min) {
+    right: percentage(($columns / $grid-columns));
+  }
+}
+
+// Generate the large columns
+@mixin make-lg-column($columns, $gutter: $grid-gutter-width) {
+  position: relative;
+  min-height: 1px;
+  padding-right: ($gutter / 2);
+  padding-left: ($gutter / 2);
+
+  @media (min-width: $screen-lg-min) {
+    float: left;
+    width: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-lg-column-offset($columns) {
+  @media (min-width: $screen-lg-min) {
+    margin-left: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-lg-column-push($columns) {
+  @media (min-width: $screen-lg-min) {
+    left: percentage(($columns / $grid-columns));
+  }
+}
+@mixin make-lg-column-pull($columns) {
+  @media (min-width: $screen-lg-min) {
+    right: percentage(($columns / $grid-columns));
+  }
+}
+
+
+//
+// Grid system
+// --------------------------------------------------
+
+
+// Container widths
+//
+// Set the container width, and override it for fixed navbars in media queries.
+
+.container {
+  @include container-fixed;
+
+  @media (min-width: $screen-sm-min) {
+    width: $container-sm;
+  }
+  @media (min-width: $screen-md-min) {
+    width: $container-md;
+  }
+  @media (min-width: $screen-lg-min) {
+    width: $container-lg;
+  }
+}
+
+
+// Fluid container
+//
+// Utilizes the mixin meant for fixed width containers, but without any defined
+// width for fluid, full width layouts.
+
+.container-fluid {
+  @include container-fixed;
+}
+
+
+// Row
+//
+// Rows contain and clear the floats of your columns.
+
+.row {
+  @include make-row;
+}
+
+.row-no-gutters {
+  margin-right: 0;
+  margin-left: 0;
+
+  [class*="col-"] {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+
+// Columns
+//
+// Common styles for small and large grid columns
+
+@include make-grid-columns;
+
+
+// Extra small grid
+//
+// Columns, offsets, pushes, and pulls for extra small devices like
+// smartphones.
+
+@include make-grid(xs);
+
+
+// Small grid
+//
+// Columns, offsets, pushes, and pulls for the small device range, from phones
+// to tablets.
+
+@media (min-width: $screen-sm-min) {
+  @include make-grid(sm);
+}
+
+
+// Medium grid
+//
+// Columns, offsets, pushes, and pulls for the desktop device range.
+
+@media (min-width: $screen-md-min) {
+  @include make-grid(md);
+}
+
+
+// Large grid
+//
+// Columns, offsets, pushes, and pulls for the large desktop device range.
+
+@media (min-width: $screen-lg-min) {
+  @include make-grid(lg);
+}

--- a/styles/components/_ui.scss
+++ b/styles/components/_ui.scss
@@ -97,6 +97,7 @@
 @import '../../lib/src/modules/calendar/calendar';
 @import '../../lib/src/modules/dateSet/dateSet';
 @import '../../lib/src/modules/menuItem/menu-item';
+@import '../../lib/src/modules/grid/grid';
 
 @import '../../lib/src/prefabs/modalUpload/modalUpload';
 @import '../../lib/src/prefabs/files/fileCard/fileCard';


### PR DESCRIPTION
The last of bootstrap has been replaced! `Grid`, `Row`, `Col are now refactored out and we use a like for like version of the library components.