### PR TITLE
Fix collapse padding on the TopBar component

### DIFF
--- a/lib/TopBar/index.js
+++ b/lib/TopBar/index.js
@@ -48,7 +48,7 @@ class TopBar extends Component {
       'top-bar__wrapper--fixed': this.props.fixed || this.state.scrollFixed
     });
 
-    const classes = cx(`top-bar ${this.props.className}`, {
+    const classes = cx(`top-bar p-0 ${this.props.className}`, {
       'top-bar--dark': this.props.useDarkTheme,
       'top-bar-light-grey': this.props.useLightGreyTheme,
       'top-bar--has-notification': this.props.notification


### PR DESCRIPTION
### 💬  Description
After refactoring `Grid` from bootstrap in #1038, padding collapsing that overrode bootstrap styles were being negated due to specificity. 

The only one I have managed to find is padding so I added a tailwind utility class to tackle this specific issue.