### PR TITLE
Don't set radio/checkbox input width to 100%

### DIFF
--- a/lib/Form/styles.scss
+++ b/lib/Form/styles.scss
@@ -12,7 +12,7 @@ $form-checkbox-label-size: $typo-size-lead !default;
   display: flex;
   flex-direction: column;
 
-  input,
+  input:not([type=checkbox]):not([type=radio]),
   textarea {
     width: 100%;
     margin: 0 0 $layout-spacing-base/2;

--- a/lib/src/modules/selectionControls/SelectionControlsStory.js
+++ b/lib/src/modules/selectionControls/SelectionControlsStory.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { CheckboxInput, RadioInput } from 'lib';
+import { CheckboxInput, TextForm, RadioInput } from 'lib';
 import StoryItem from '../../../../stories/styleguide/StoryItem';
 
 function SelectionControlStoryItem({ children, title }) {
   return (
-    <div className="flex flex-col items-center px-2">
+    <TextForm onSubmit={() => {}} className="flex flex-col items-center px-2">
       <h4>{title}</h4>
-      <div>{children}</div>
-    </div>
+      {children}
+    </TextForm>
   );
 }
 


### PR DESCRIPTION
### 💬 Description
When we use a `RadioInput` or `CheckboxInput` inside of a `.form`, we were setting the `width: 100%`
<img width="327" alt="Screenshot 2021-09-10 at 10 37 10" src="https://user-images.githubusercontent.com/3472717/132844592-0b819fcd-e309-4fc3-9bbc-4113563c900e.png">
<img width="673" alt="Screenshot 2021-09-10 at 10 36 38" src="https://user-images.githubusercontent.com/3472717/132844601-f58dca54-5e88-44c0-8514-517aa5769348.png">

This PR fixes that.

NOTE: I had to commit this with `--no-verify` because the eslint and prettier are wildly off, see #1048 

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
