### PR TITLE
Sidebar Footer now uses justify-end instead of a nested div with ml-auto

### DIFF
--- a/lib/src/components/sidebar/SidebarFooter.js
+++ b/lib/src/components/sidebar/SidebarFooter.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 export function SidebarFooter({ children, className = '', ...rest }) {
   return (
     <div className={`sidebar-footer ${className}`} {...rest}>
-      <div className="ml-auto">{children}</div>
+      {children}
     </div>
   );
 }

--- a/lib/src/components/sidebar/SidebarStory.js
+++ b/lib/src/components/sidebar/SidebarStory.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { ButtonPrimary, ButtonTertiary } from 'lib';
+import { ButtonPrimary, ButtonTertiary, Icon } from 'lib';
 import { Sidebar } from './Sidebar';
 
 const ExampleOfUsingShowMoreToggle = () => {
@@ -107,7 +107,8 @@ export const SidebarExample = () => (
     </Sidebar.Body>
 
     <Sidebar.Footer>
-      <ButtonTertiary size="sm" onClick={() => {}}>
+      <a href="#" className="mr-auto"><Icon name="help"/></a>
+      <ButtonTertiary size="sm" onClick={() => {}} className="mr-2">
         Cancel
       </ButtonTertiary>
       <ButtonPrimary size="sm" onClick={() => {}}>

--- a/lib/src/components/sidebar/sidebar.scss
+++ b/lib/src/components/sidebar/sidebar.scss
@@ -11,7 +11,7 @@
 }
 
 .sidebar-footer {
-  @apply flex p-4 border-b-0 border-l-0 border-r-0 border-t border-solid border-neutral-90
+  @apply flex p-2 justify-end items-center border-b-0 border-l-0 border-r-0 border-t border-solid border-neutral-90
 }
 
 .sidebar-body {


### PR DESCRIPTION
### 💬 Description
This means we can more easily custimise the layout of the children, for
example having a help button that aligns to the left of the footer

### 📹 GIF (optional)
![Screenshot 2021-09-17 at 17 06 41](https://user-images.githubusercontent.com/3472717/133819592-231258a9-2999-4da7-8a81-18ec383e2d1d.png)

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
