### PR TITLE
Fixing fade cutting into option menu items

### DIFF
--- a/lib/src/modules/optionMenuItem/option-menu-item.scss
+++ b/lib/src/modules/optionMenuItem/option-menu-item.scss
@@ -25,6 +25,7 @@
   white-space: nowrap;
   min-width: 0;
   overflow: hidden;
+  width: 100%;
 }
 
 .option-menu-item-active {


### PR DESCRIPTION
### 💬 Description
We need to full width the text in an option menu item, this is so the fade is at the end of its container. This same fade issue occurs on both usages of `OptionMenuItem`.

### ✅ Checklist
- [ ] Tests written
- [ ] Browser tested
- [ ] Added to documentation
- [ ] Added to storybook
