### PR TITLE
Fix/modal spacing

### DIFF
--- a/lib/InputConfirmationModal/styles.scss
+++ b/lib/InputConfirmationModal/styles.scss
@@ -2,9 +2,6 @@
   .modal-header {
     min-height: 0;
   }
-  .modal-footer {
-    justify-content: flex-end;
-  }
   .modal-header,
   .modal-footer {
     @apply p-0;

--- a/lib/InputConfirmationModal/styles.scss
+++ b/lib/InputConfirmationModal/styles.scss
@@ -13,6 +13,6 @@
     @apply p-6;
   }
   .modal-header .close-button {
-    @apply static ml-auto;
+    @apply -mt-6 -mr-6 ml-auto;
   }
 }

--- a/lib/Modal/styles.scss
+++ b/lib/Modal/styles.scss
@@ -140,8 +140,7 @@ $modal-media-close-dimensions: 30px;
 	}
 }
 
-.modal--center,
-.modal--center .modal-footer {
+.modal--center {
 	text-align: center;
 
 	.modal-header {
@@ -151,6 +150,10 @@ $modal-media-close-dimensions: 30px;
 
 	.modal-title {
 		margin: 0 auto;
+	}
+
+	.modal-footer {
+		justify-content: center;
 	}
 }
 
@@ -177,7 +180,6 @@ $modal-media-close-dimensions: 30px;
 
 	.modal-footer {
 		padding-top: 0;
-		justify-content: center;
 	}
 
 	.modal-header,

--- a/stories/components/Modals.js
+++ b/stories/components/Modals.js
@@ -2,22 +2,27 @@ import React, {Component, Fragment} from 'react';
 import {storiesOf} from '@storybook/react';
 import {action} from '@storybook/addon-actions';
 import {
-    Modal,
-    Button,
-    ButtonGroup,
-    ConfirmationModal,
-    withModalTrigger,
-    FormModal,
-    StatusIndicator,
-    DueDatePicker,
-    Icon,
-    ImageLoader,
-    SelectionModal,
-    Checkbox,
-    InputConfirmationModal,
-    MenuItem,
-    Input,
-    Label, Row, Col
+  Modal,
+  Button,
+  ButtonGroup,
+  ConfirmationModal,
+  withModalTrigger,
+  FormModal,
+  StatusIndicator,
+  DueDatePicker,
+  Icon,
+  ImageLoader,
+  SelectionModal,
+  Checkbox,
+  InputConfirmationModal,
+  MenuItem,
+  Input,
+  Label,
+  Row,
+  Col,
+  FormInput,
+  ButtonPrimaryDanger,
+  ButtonTertiary
 } from "../../lib";
 import StoryItem from '../styleguide/StoryItem';
 
@@ -142,6 +147,43 @@ storiesOf('Components', module).add('Modals', () => (
                     </Modal.Body>
                 </Modal.Container>
             </ModalTrigger>
+        </StoryItem>
+
+        <StoryItem
+            title="Cleared and input-confirm"
+            description="A modal that has the backgrounds/borders cleared and a slightly larger padding"
+        >
+          <ModalTrigger>
+            <Modal.Container className="modal--clear modal--input-confirm">
+              <Modal.Header>Confirm deletion</Modal.Header>
+              <Modal.Body>
+                File deletion is permanent and cannot be undone. Please confirm you want
+                to delete these files by typing
+                ‘DELETE’ in the box below.
+                <FormInput
+                  placeholder="Type ‘DELETE’ to confirm..."
+                  className="block w-64 mt-3"
+                  focusOnMount
+                />
+              </Modal.Body>
+              <Modal.Footer>
+                <ButtonTertiary
+                  size={ButtonTertiary.sizes.md}
+                  onClick={action("Cancel delete")}
+                  className="mr-2"
+                >
+                  Cancel
+                </ButtonTertiary>
+                <ButtonPrimaryDanger
+                  size={ButtonPrimaryDanger.sizes.md}
+                  onClick={action("Confirm delete")}
+                  loading={false}
+                >
+                  Delete
+                </ButtonPrimaryDanger>
+              </Modal.Footer>
+            </Modal.Container>
+          </ModalTrigger>
         </StoryItem>
 
         <StoryItem


### PR DESCRIPTION
### 💬 Description
I noticed our `InputConfirmationModal` looks a bit off in the app. I think the cross hair close button needed moving to the top right. I also spotted that the `.modal--cleared` is centring the buttons/content in the footer - I think this is supposed to be the responsibility of `.modal--centred`, looks like a copy paste error to me - this is now fixed.

### 📹 GIF (optional)
**Before:**
<img width="649" alt="Screenshot 2021-09-29 at 17 55 40" src="https://user-images.githubusercontent.com/3472717/135314830-931aa67e-dd4a-4495-a382-ca25da3b0248.png">
**After:**
<img width="639" alt="Screenshot 2021-09-29 at 17 44 58" src="https://user-images.githubusercontent.com/3472717/135314834-f588ff3f-5f00-4baa-b723-2d231a070539.png">

This modal can now use the `.modal--cleared` class, instead of setting `classNames` directly, which is causing all the padding to disappear in the app.
<img width="638" alt="Screenshot 2021-09-29 at 17 56 23" src="https://user-images.githubusercontent.com/3472717/135314818-fec3f2b0-58ba-4d1d-ad51-f7043063a715.png">

### 🚪 Start Points
Commit by commit

### ✅ Checklist
- [ ] Tests written
- [x] Browser tested
- [ ] Added to documentation
- [x] Added to storybook
