### PR TITLE
Remove required prop and update story

### DIFF
--- a/lib/src/prefabs/files/fileCard/FileCard.js
+++ b/lib/src/prefabs/files/fileCard/FileCard.js
@@ -39,13 +39,14 @@ FileCard.propTypes = {
   meta: node,
   controls: node,
   insetMeta: bool,
-  preview: node.isRequired
+  preview: node
 };
 
 FileCard.defaultProps = {
   insetMeta: false,
   meta: null,
-  controls: null
+  controls: null,
+  preview: null
 };
 
 export { FileCard };

--- a/lib/src/prefabs/files/fileCard/FileCardStory.js
+++ b/lib/src/prefabs/files/fileCard/FileCardStory.js
@@ -108,7 +108,7 @@ stories.add('FileCard', () => {
 
       <StoryItem
         title="FileCard (thumbnail usage)"
-        description="A card component which utilises the thumb, meta and control modules to display a file."
+        description="A card component which utilises the thumbnail size to display a file at a reduced size."
       >
         <FileCard
           size="thumbnail"
@@ -117,8 +117,8 @@ stories.add('FileCard', () => {
       </StoryItem>
 
       <StoryItem
-        title="FileCard with Loader"
-        description="A card component to represent a loading file"
+        title="FileCard (loading usage)"
+        description="A card component which represents a loading file."
       >
         <div className="w-32 h-32">
           <FileCard className="h-full" innerClassName="h-full">


### PR DESCRIPTION
`preview` shouldn't be required in `FileCard`s. Even the story shows this via

```
<FileCard className="h-full" innerClassName="h-full">
  <Loader size="sm" className="h-full" />
</FileCard>
```