### PR TITLE
fix prop types warning in Windowing component

### DIFF
--- a/lib/Windowing/Windowing.js
+++ b/lib/Windowing/Windowing.js
@@ -1,5 +1,5 @@
 import React, { useState, createContext, useEffect } from 'react';
-import { node, number, arrayOf, string, oneOfType, oneOf } from 'prop-types';
+import { node, number, arrayOf, string, oneOfType } from 'prop-types';
 
 export const WindowingContext = createContext({});
 
@@ -67,7 +67,7 @@ Windowing.propTypes = {
   debounceTimer: number,
   containerHeight: oneOfType([string, number]),
   buffer: number,
-  allIds: arrayOf(oneOf([string, number])).isRequired
+  allIds: arrayOf(oneOfType([string, number])).isRequired
 };
 
 Windowing.defaultProps = {


### PR DESCRIPTION
### 💬 Description
Fix a prop-types warning in the Windowing component.

oneOf should only be used for literal values, ie. 'left', 'right'.
