### PR TITLE
TopBar icon colours

### DIFF
--- a/lib/TopBar/styles.scss
+++ b/lib/TopBar/styles.scss
@@ -158,8 +158,7 @@ $top-bar-notification-height: 42px;
       border-color: $neutral-dark;
       color: white;
     }
-    .top-bar__action,
-    .icon:not(.structure__save-btn) path {
+    .top-bar__action {
       fill: white;
     }
     .top-bar__cell--bordered {

--- a/lib/TopBar/styles.scss
+++ b/lib/TopBar/styles.scss
@@ -25,7 +25,7 @@ $top-bar-notification-height: 42px;
   .top-bar__wrapper {
     background: #fff;
     border-bottom: 1px solid $color-border-base;
-    padding: $layout-spacing-base*0.5 math.div($layout-spacing-base, 1.5);
+    padding: $layout-spacing-base * 0.5 math.div($layout-spacing-base, 1.5);
     width: 100%;
   }
 
@@ -108,7 +108,8 @@ $top-bar-notification-height: 42px;
 
   .item-settings .button {
     display: block;
-    padding: math.div($layout-spacing-base, 2.5) math.div($layout-spacing-base, 1.55);
+    padding: math.div($layout-spacing-base, 2.5)
+      math.div($layout-spacing-base, 1.55);
   }
 
   .top-bar__action--collapse-left {
@@ -133,15 +134,21 @@ $top-bar-notification-height: 42px;
     @include respond-to($top-bar-main-breakpoint) {
       max-width: 400px;
       top: $top-bar-height-medium - ($layout-spacing-base * 0.5);
-      height: calc(100vh - #{$top-bar-height-medium+$top-bar-dropdown-bottom-margin});
+      height: calc(
+        100vh - #{$top-bar-height-medium+$top-bar-dropdown-bottom-margin}
+      );
     }
   }
 
   &.top-bar--has-notification {
     .top-bar__drop-down {
-      height: calc(100vh - #{$top-bar-height+$top-bar-dropdown-bottom-margin+$top-bar-notification-height});
+      height: calc(
+        100vh - #{$top-bar-height+$top-bar-dropdown-bottom-margin+$top-bar-notification-height}
+      );
       @include respond-to($top-bar-main-breakpoint) {
-        height: calc(100vh - #{$top-bar-height-medium+$top-bar-dropdown-bottom-margin+$top-bar-notification-height});
+        height: calc(
+          100vh - #{$top-bar-height-medium+$top-bar-dropdown-bottom-margin+$top-bar-notification-height}
+        );
       }
     }
   }
@@ -152,7 +159,7 @@ $top-bar-notification-height: 42px;
       color: white;
     }
     .top-bar__action,
-    .icon path {
+    .icon:not(.structure__save-btn) path {
       fill: white;
     }
     .top-bar__cell--bordered {
@@ -182,7 +189,6 @@ $top-bar-notification-height: 42px;
 .top-bar__content--left.top-bar__content--collapse {
   padding-left: 0;
 }
-
 
 .top-bar__group {
   display: flex;

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,6 +142,7 @@ export ColField from './ColField/ColField';
 export SelectionModal from './SelectionModal/SelectionModal';
 export InputConfirmationModal from './InputConfirmationModal/InputConfirmationModal';
 export ButtonIconDark from './src/modules/Button/ButtonIcon/ButtonIconDark';
+export ButtonIconWhite from './src/modules/Button/ButtonIcon/ButtonIconWhite';
 export { ButtonAvatar } from './src/modules/Button/ButtonAvatar/ButtonAvatar';
 
 export { FileCard } from './src/prefabs/files/fileCard/FileCard';

--- a/lib/src/modules/Button/ButtonIcon/ButtonIconWhite.js
+++ b/lib/src/modules/Button/ButtonIcon/ButtonIconWhite.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { bool } from 'prop-types';
+import cx from 'classnames';
+import { Icon } from 'lib';
+import { ButtonBase } from '../ButtonBase';
+import {
+  sizes,
+  getSizeClasses,
+  buttonIconPropTypes,
+  buttonIconDefaultProps
+} from '../common';
+
+function ButtonIconWhite({
+  className,
+  disabled,
+  name,
+  active,
+  size,
+  iconTitle,
+  children,
+  enabled,
+  ...rest
+}) {
+  const classes = cx(
+    'button-icon',
+    'button-icon-white',
+    className,
+    {
+      'rounded-small': size === sizes.sm
+    },
+    getSizeClasses(size)
+  );
+
+  return (
+    <ButtonBase className={classes} disabled={disabled} size={false} {...rest}>
+      {!!name && (
+        <Icon name={name} title={iconTitle} defaultActiveColor={false} />
+      )}
+      {children}
+    </ButtonBase>
+  );
+}
+
+ButtonIconWhite.sizes = sizes;
+
+ButtonIconWhite.propTypes = {
+  ...buttonIconPropTypes,
+  enabled: bool
+};
+
+ButtonIconWhite.defaultProps = {
+  ...buttonIconDefaultProps,
+  enabled: false
+};
+
+export default ButtonIconWhite;

--- a/lib/src/modules/Button/ButtonIcon/styles/buttonIcon.scss
+++ b/lib/src/modules/Button/ButtonIcon/styles/buttonIcon.scss
@@ -1,5 +1,6 @@
-@import "buttonIconBase";
-@import "buttonIconContained";
-@import "buttonIconDark";
-@import "buttonIconDanger";
-@import "buttonIconContainedDanger";
+@import 'buttonIconBase';
+@import 'buttonIconContained';
+@import 'buttonIconDark';
+@import 'buttonIconDanger';
+@import 'buttonIconContainedDanger';
+@import 'buttonIconWhite';

--- a/lib/src/modules/Button/ButtonIcon/styles/buttonIconWhite.scss
+++ b/lib/src/modules/Button/ButtonIcon/styles/buttonIconWhite.scss
@@ -1,0 +1,27 @@
+.button-icon-white {
+  &.button-icon:active {
+    @apply bg-neutral-40 border-neutral-40;
+    path {
+      fill: white;
+    }
+    &:hover {
+      @apply bg-neutral-30;
+    }
+    &:focus {
+      @apply border-white;
+    }
+  }
+  &:hover {
+    @apply bg-neutral-30 border-neutral-30;
+  }
+  &:focus {
+    @apply bg-neutral-40 border-white shadow-button-icon-dark-focus;
+    path {
+      fill: white;
+    }
+  }
+
+  path {
+    fill: white;
+  }
+}

--- a/lib/src/modules/Button/stories/ButtonIcon/ButtonIcon.stories.js
+++ b/lib/src/modules/Button/stories/ButtonIcon/ButtonIcon.stories.js
@@ -6,7 +6,8 @@ import {
   ButtonIconContainedDanger,
   Counter,
   ButtonIconBubble,
-  ButtonIconDark
+  ButtonIconDark,
+  ButtonIconWhite
 } from 'lib';
 import StoryItem from 'stories/styleguide/StoryItem';
 import { ButtonStoryItem } from '../ButtonStoryItem';
@@ -94,6 +95,14 @@ export const ButtonIcon = () => (
         {states.map(s => (
           <div className="h-16">
             <ButtonIconDark name="infoSquare" {...s} />
+          </div>
+        ))}
+      </ButtonStoryItem>
+
+      <ButtonStoryItem title="White" className="bg-neutral-20 text-white">
+        {states.map(s => (
+          <div className="h-16">
+            <ButtonIconWhite name="menuDotted" {...s} />
           </div>
         ))}
       </ButtonStoryItem>


### PR DESCRIPTION
### 💬 Description
TopBar dark mode icons no longer have their colour set by CSS.

A new component, ButtonIconWhite has been added to allow us to use white button icons.
ButtonIconWhite has been added to the button icon story.
### 🔗 Links
(https://trello.com/c/8fhSwIVx/2379-regular-icon-colour-is-incorrect-on-disabled-button-states)
### 👫 Related PRs (optional)
https://github.com/gathercontent/app/pull/4509
