### PR TITLE
fix secondary button height in blank slates

### DIFF
--- a/lib/BlankSlate/styles.scss
+++ b/lib/BlankSlate/styles.scss
@@ -3,6 +3,7 @@
   text-align: center;
   a {
     text-decoration: none;
+    height: 100%;
     &:not(.button):hover {
       text-decoration: underline;
     }


### PR DESCRIPTION
### 💬 Description
Fixes secondary button height inside blank slates as they were displaying slightly smaller then the primary button next to them.
