### PR TITLE
remove underline hover effect on tab navigation items

### DIFF
--- a/lib/Navigation/styles.scss
+++ b/lib/Navigation/styles.scss
@@ -16,7 +16,7 @@
   text-decoration: none;
   padding: $layout-spacing-base * 0.5 0;
   font-weight: $typo-weight-roman;
-  [class*="--dark"] & {
+  [class*='--dark'] & {
     color: $neutral-light;
   }
 
@@ -27,7 +27,7 @@
   &:hover {
     text-decoration: none;
     color: $primary-blue;
-    [class*="--dark"] & {
+    [class*='--dark'] & {
       color: white;
     }
   }
@@ -35,7 +35,7 @@
 
 .navigation__item--active > * {
   color: $primary-blue;
-  [class*="--dark"] & {
+  [class*='--dark'] & {
     color: white;
   }
 }
@@ -59,6 +59,7 @@
   color: $neutral-dark;
   &:hover {
     color: $primary-blue;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
### 💬 Description
Removes an ugly underline hover effect on tab navigation items.
### 🔗 Links
(https://trello.com/c/vGcyB5cf/2669-new-trial-snags)
### 📹 GIF (optional)
![hovereffect](https://user-images.githubusercontent.com/37194621/156375802-62b4e00d-d9a7-48df-9f77-7f3d198a8209.gif)

