### PR TITLE
ensure dropdown handles hover correctly

### DIFF
--- a/lib/Avatar/AvatarWithPopover.js
+++ b/lib/Avatar/AvatarWithPopover.js
@@ -33,18 +33,13 @@ function AvatarWithPopover({
   const useHover = triggerEvent.includes('onHover');
 
   return (
-    <Dropdown id={uuid()} className="overflow-visible">
+    <Dropdown autoPosition id={uuid()} className="overflow-visible">
       {({ setShowContent, showContent }) => (
         <>
           <Dropdown.Trigger
+            useButton
+            useHover={useHover}
             triggerClassName={classes(showContent)}
-            onMouseEnter={
-              useHover
-                ? () => {
-                    setShowContent(true);
-                  }
-                : null
-            }
             onMouseLeave={
               useHover
                 ? () => {

--- a/lib/Dropdown/DropdownTrigger.js
+++ b/lib/Dropdown/DropdownTrigger.js
@@ -22,6 +22,22 @@ class DropdownTrigger extends Component {
     return toggleShowContent();
   };
 
+  handleMouseover = event => {
+    if (this.props.useHover) {
+      const { toggleShowContent, autoPosition, showContent } = this.context;
+
+      this.props.onClick(!showContent, event);
+
+      if (this.trigger && autoPosition) {
+        const bounds = this.trigger.getBoundingClientRect();
+        return toggleShowContent(bounds);
+      }
+
+      return toggleShowContent();
+    }
+    return null;
+  };
+
   render() {
     const {
       children,
@@ -31,6 +47,7 @@ class DropdownTrigger extends Component {
       direction,
       triggerClassName,
       blueOnActive,
+      useHover,
       ...rest
     } = this.props;
     const { showContent } = this.context;
@@ -65,6 +82,7 @@ class DropdownTrigger extends Component {
             className={buttonClassNames}
             {...rest}
             onClick={this.handleClick}
+            onMouseEnter={this.handleMouseover}
           >
             {children}
             {useSelect && <Icon name="down" />}
@@ -79,6 +97,7 @@ class DropdownTrigger extends Component {
         {...rest}
         className={buttonClassNames}
         onClick={this.handleClick}
+        onMouseEnter={this.handleMouseover}
         ref={createRef}
       >
         {children}
@@ -95,7 +114,8 @@ DropdownTrigger.propTypes = {
   triggerClassName: PropTypes.string,
   onClick: PropTypes.func,
   types: PropTypes.arrayOf(PropTypes.string),
-  blueOnActive: PropTypes.bool
+  blueOnActive: PropTypes.bool,
+  useHover: PropTypes.bool
 };
 
 DropdownTrigger.defaultProps = {
@@ -105,7 +125,8 @@ DropdownTrigger.defaultProps = {
   triggerClassName: '',
   onClick: () => {},
   types: [],
-  blueOnActive: false
+  blueOnActive: false,
+  useHover: false
 };
 
 export default DropdownTrigger;


### PR DESCRIPTION
### 💬 Description
Adds an `onMouseEnter` handler to the main `DropdownTrigger` component so that the dropdown can be positioned correctly when inside an `overflow: hidden` component.
### 🔗 Links
[_Links that relate to the PR (Trello, Figma etc.)_]
(https://trello.com/c/ZpxWO9N0/2799-there-was-no-tooltip-on-users-assigned-to-a-workflow-step-in-the-workflow-dropdown)
### 📹 GIF (optional)
![avatarpopover](https://user-images.githubusercontent.com/37194621/158840320-18b1d1d1-45af-466a-819d-eb906a19c106.gif)

