### PR TITLE
update AvatarWithPopover component to use Tippy

### DIFF
--- a/lib/Avatar/AvatarWithPopover.js
+++ b/lib/Avatar/AvatarWithPopover.js
@@ -17,9 +17,7 @@ import Avatar from '.';
 function AvatarWithPopover({
   email,
   name,
-  popoverClass,
   children,
-  theme,
   overlayPosition,
   ...rest
 }) {
@@ -30,7 +28,6 @@ function AvatarWithPopover({
       content={children}
       animation="shift-toward"
       arrow={false}
-      theme="light"
       placement={overlayPosition}
       trigger="mouseenter focus"
       className="avatar-tooltip__wrapper"
@@ -48,9 +45,7 @@ function AvatarWithPopover({
 }
 
 AvatarWithPopover.defaultProps = {
-  overlayPosition: 'bottom',
-  popoverClass: '',
-  children: null
+  overlayPosition: 'bottom'
 };
 
 export default AvatarWithPopover;

--- a/lib/Avatar/AvatarWithPopover.js
+++ b/lib/Avatar/AvatarWithPopover.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import cx from 'classnames';
-import uuid from 'uuid/v1';
+import Tippy from '@tippyjs/react';
+import { v4 as uuid } from 'uuid';
 import Avatar from '.';
-import Icon from '../Icon';
-import Dropdown from '../Dropdown';
 
 /**
  * @usage
@@ -17,72 +15,42 @@ import Dropdown from '../Dropdown';
  */
 
 function AvatarWithPopover({
-  triggerEvent,
   email,
   name,
-  caret,
   popoverClass,
   children,
-  collapseDropdown,
-  autoPosition,
+  theme,
+  overlayPosition,
   ...rest
 }) {
-  const classes = showContent =>
-    cx('button button--icon-only avatar__wrapper', {
-      'is-active': showContent
-    });
-  const useHover = triggerEvent.includes('onHover');
+  const id = uuid();
 
   return (
-    <Dropdown
-      autoPosition={autoPosition}
-      id={uuid()}
-      className="overflow-visible"
+    <Tippy
+      content={children}
+      animation="shift-toward"
+      arrow={false}
+      theme="light"
+      placement={overlayPosition}
+      trigger="mouseenter focus"
+      className="avatar-tooltip__wrapper"
     >
-      {({ setShowContent, showContent }) => (
-        <>
-          <Dropdown.Trigger
-            useButton
-            useHover={useHover}
-            triggerClassName={classes(showContent)}
-            onMouseLeave={
-              useHover
-                ? () => {
-                    setShowContent(false);
-                  }
-                : null
-            }
-          >
-            <Avatar
-              email={email}
-              name={name}
-              {...rest}
-              className="avatar--with-toggle"
-            />
-            {!!caret && <Icon name="down" className="avatar__caret ml-2" />}
-          </Dropdown.Trigger>
-          {showContent && (
-            <Dropdown.Content
-              className={popoverClass}
-              collapse={collapseDropdown}
-            >
-              {children}
-            </Dropdown.Content>
-          )}
-        </>
-      )}
-    </Dropdown>
+      <span id={id} role="button">
+        <Avatar
+          email={email}
+          name={name}
+          {...rest}
+          className="avatar--with-toggle"
+        />
+      </span>
+    </Tippy>
   );
 }
 
 AvatarWithPopover.defaultProps = {
   overlayPosition: 'bottom',
-  triggerEvent: ['onHover', 'onClick'],
-  caret: false,
   popoverClass: '',
-  children: [],
-  collapseDropdown: false,
-  autoPosition: false
+  children: null
 };
 
 export default AvatarWithPopover;

--- a/lib/Avatar/stories/Avatar.stories.js
+++ b/lib/Avatar/stories/Avatar.stories.js
@@ -5,8 +5,7 @@ import {
   AvatarWithPopover,
   ParticipantInfo,
   AvatarInformation,
-  Button,
-  MenuItem
+  Button
 } from '../../index';
 import StoryItem from '../../../stories/styleguide/StoryItem';
 import { AvatarGroupMock } from './AvatarGroupMock';
@@ -53,20 +52,9 @@ export const Avatar = args => {
 
       <StoryItem
         title="AvatarComponent (with popover)"
-        description="An avatar can show a dropdown or popover on click, focus or hover."
+        description="An avatar can show a tooltip on hover."
       >
         <div className="h-display-flex">
-          <div className="h-margin-right">
-            <AvatarWithPopover
-              {...props}
-              triggerEvent="onClick"
-              caret
-              collapseDropdown
-            >
-              <MenuItem href="#test">Personal Settings</MenuItem>
-            </AvatarWithPopover>
-          </div>
-
           <AvatarWithPopover {...props}>
             <ParticipantInfo
               name={props.name}

--- a/lib/Avatar/styles.scss
+++ b/lib/Avatar/styles.scss
@@ -7,30 +7,49 @@ $avatar-size: 32px !default;
 $avatar-border-radius: $avatar-size !default;
 
 $avatar-size-small: $layout-spacing-base !default;
-$avatar-size-large: $layout-spacing-base*2 !default;
-$avatar-size-extra-large: $layout-spacing-base*4 !default;
+$avatar-size-large: $layout-spacing-base * 2 !default;
+$avatar-size-extra-large: $layout-spacing-base * 4 !default;
 
 $avatar-highlighted-background: $neutral-base !default;
 $avatar-highlighted-color: white !default;
 
-$avatar-offline-transparency: .5 !default;
-$avatar-pillbox-padding: $typo-size-lead*0.25 math.div($typo-size-lead, 3) !default;
+$avatar-offline-transparency: 0.5 !default;
+$avatar-pillbox-padding: $typo-size-lead * 0.25 math.div($typo-size-lead, 3) !default;
 
 /* ==========================================================================
    Styles
    ========================================================================== */
- @keyframes avatar {
-   0%   { opacity: 0; transform: scale(0.5); }
-   25%  { opacity: 1; transform: scale(1.1); }
-   50%  { transform: scale(0.8); }
-   100% { opacity: 1; transform: scale(1.0); animation-timing-function: ease-out; }
- }
+@keyframes avatar {
+  0% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  25% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+  50% {
+    transform: scale(0.8);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+    animation-timing-function: ease-out;
+  }
+}
 
- @keyframes ring {
-   0%   { box-shadow: none }
-   50%  { box-shadow: white 0px 0px 0px 3px, 0px 0px 0px 4px, white 0 0 0 5px; }
-   100% { box-shadow: white 0px 0px 0px 2px, 0px 0px 0px 3px, white 0 0 0 5px; animation-timing-function: ease; }
- }
+@keyframes ring {
+  0% {
+    box-shadow: none;
+  }
+  50% {
+    box-shadow: white 0px 0px 0px 3px, 0px 0px 0px 4px, white 0 0 0 5px;
+  }
+  100% {
+    box-shadow: white 0px 0px 0px 2px, 0px 0px 0px 3px, white 0 0 0 5px;
+    animation-timing-function: ease;
+  }
+}
 
 .avatar {
   background: $neutral-light;
@@ -66,7 +85,7 @@ $avatar-pillbox-padding: $typo-size-lead*0.25 math.div($typo-size-lead, 3) !defa
 
 .avatar__information {
   overflow: hidden;
-  margin-left: $layout-spacing-base*0.5;
+  margin-left: $layout-spacing-base * 0.5;
 
   .avatar__name,
   .avatar__email {
@@ -106,7 +125,7 @@ $avatar-pillbox-padding: $typo-size-lead*0.25 math.div($typo-size-lead, 3) !defa
 
 .avatar--supporting {
   flex-shrink: 0;
-  margin: 0 $layout-spacing-base*0.5 0 0;
+  margin: 0 $layout-spacing-base * 0.5 0 0;
 }
 
 .avatar__wrapper:focus,
@@ -169,7 +188,7 @@ $avatar-pillbox-padding: $typo-size-lead*0.25 math.div($typo-size-lead, 3) !defa
 
 .avatar__caret {
   margin-left: $layout-spacing-base * 0.25;
-  opacity: .6;
+  opacity: 0.6;
 }
 
 .is-active .avatar__caret {
@@ -194,7 +213,7 @@ $avatar-pillbox-padding: $typo-size-lead*0.25 math.div($typo-size-lead, 3) !defa
       display: block;
       margin-left: auto;
 
-      button[class*="button--link"] {
+      button[class*='button--link'] {
         padding-top: 0;
         padding-bottom: 0;
       }
@@ -210,7 +229,7 @@ $avatar-pillbox-padding: $typo-size-lead*0.25 math.div($typo-size-lead, 3) !defa
 }
 
 .avatar__actions {
-  padding-top: $layout-spacing-base*0.25;
+  padding-top: $layout-spacing-base * 0.25;
   display: block;
 }
 
@@ -226,19 +245,25 @@ $avatar-pillbox-padding: $typo-size-lead*0.25 math.div($typo-size-lead, 3) !defa
   &.avatar--has-colour {
     box-shadow: none;
   }
-  -webkit-animation: avatar 0.7s cubic-bezier(0.390, 0.575, 0.565, 1) forwards,
-                     ring 0.5s 0.4s ease-out forwards;
+  -webkit-animation: avatar 0.7s cubic-bezier(0.39, 0.575, 0.565, 1) forwards,
+    ring 0.5s 0.4s ease-out forwards;
 }
 
 .avatar__wrapper--size-xlrg {
   .avatar__name {
     font-size: $typo-size-larger;
     font-weight: $typo-weight-bold;
-    margin-bottom: $layout-spacing-base*0.25;
+    margin-bottom: $layout-spacing-base * 0.25;
   }
   .avatar__information .avatar__name + .avatar__email,
   .avatar__email {
     font-size: $typo-size-base;
     color: $neutral-dark;
   }
+}
+
+.avatar-tooltip__wrapper {
+  background-color: white !important;
+  color: black !important;
+  @apply border border-solid border-neutral-90 p-2;
 }


### PR DESCRIPTION
### 💬 Description
`AvatarWithPopover` has been updated to use Tippy rather than the `Dropdown` component.

With the `Dropdown` component, when hovering from the bottom of the trigger, the dropdown content overlays the trigger and causes the mouse to 'leave' the trigger, hiding the content. Using Tippy and a standard tooltip stops this from happening.

There is a slight drawback in that the avatar component loses some functionality to allow it to have links or menu items as the dropdown content, but this is never used inside the app and I think it's worth removing unused functionality to fix a bug. It also massively simplifies the component.
### 🔗 Links
(https://trello.com/c/CcQVR0my/2812-presence-avatar-tooltips-flash-and-disappear)
### 📹 GIF (optional)
![avatarpopover](https://user-images.githubusercontent.com/37194621/159470309-954b767e-9f7b-4347-9d93-bdb07e16396d.gif)

