### PR TITLE
update styling of participant info to be like tooltip

### DIFF
--- a/lib/Avatar/stories/Avatar.stories.js
+++ b/lib/Avatar/stories/Avatar.stories.js
@@ -56,11 +56,7 @@ export const Avatar = args => {
       >
         <div className="h-display-flex">
           <AvatarWithPopover {...props}>
-            <ParticipantInfo
-              name={props.name}
-              email={props.email}
-              pillboxText="Assigned"
-            />
+            <ParticipantInfo name={props.name} email={props.email} />
           </AvatarWithPopover>
         </div>
       </StoryItem>

--- a/lib/Avatar/styles.scss
+++ b/lib/Avatar/styles.scss
@@ -261,9 +261,3 @@ $avatar-pillbox-padding: $typo-size-lead * 0.25 math.div($typo-size-lead, 3) !de
     color: $neutral-dark;
   }
 }
-
-.avatar-tooltip__wrapper {
-  background-color: white !important;
-  color: black !important;
-  @apply border border-solid border-neutral-90 p-2;
-}

--- a/lib/ParticipantInfo/index.js
+++ b/lib/ParticipantInfo/index.js
@@ -1,23 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ParticipantInfo = ({ name, email, pillboxText }) => (
+const ParticipantInfo = ({ name, email }) => (
   <div className="participant_info">
     <p className="participant_info__name">{name}</p>
     <p className="participant_info__email">{email}</p>
-
-    {pillboxText && <span className="pillbox">{pillboxText}</span>}
   </div>
 );
 
 ParticipantInfo.propTypes = {
   name: PropTypes.string.isRequired,
-  email: PropTypes.string.isRequired,
-  pillboxText: PropTypes.string
-};
-
-ParticipantInfo.defaultProps = {
-  pillboxText: ''
+  email: PropTypes.string.isRequired
 };
 
 export default ParticipantInfo;

--- a/lib/ParticipantInfo/styles.scss
+++ b/lib/ParticipantInfo/styles.scss
@@ -2,26 +2,20 @@
    Config
    ========================================================================== */
 $participant-info-name-weight: $typo-weight-semi-bold !default;
-$participant-info-name-size: $typo-size-lead !default;
 
 /* ==========================================================================
    Styles
    ========================================================================== */
+
 .participant_info {
-  background: #fff;
+  text-align: center;
 }
 
 .participant_info__name {
   font-weight: $participant-info-name-weight;
-  font-size: $participant-info-name-size;
   margin: 0;
 }
 
 .participant_info__email {
-  margin: $typo-size-lead*0.2 0;
-}
-
-.participant_info__name + .participant_info__email {
-  color: $neutral-base;
-  font-size: $typo-size-slight;
+  margin: 0;
 }


### PR DESCRIPTION
### 💬 Description
Styles the `ParticipantInfo` like our original tooltip component and removes the 'assigned' pillbox.
### 🔗 Links
(https://trello.com/c/BUtSyCGq/2832-style-participantinfo-like-a-tooltip)
https://www.figma.com/file/rKBbivLiVBDi1IPimZg7Lh/GUI---Components?node-id=488%3A2615
### 📹 GIF (optional)
![participantinfo](https://user-images.githubusercontent.com/37194621/159690729-9ec59833-3886-4eb6-a352-e64dd3261dad.gif)

