### PR TITLE
make search term lowercase so search not case sensitive

### DIFF
--- a/lib/Comment/CommentForm.js
+++ b/lib/Comment/CommentForm.js
@@ -67,13 +67,15 @@ function CommentForm({
 
   const searchForUsers = term => {
     if (term.trim() !== '' && users.length > 0) {
+      const termLowerCase = term.toLowerCase();
       return users.filter(
         user =>
           user.name
             .toLowerCase()
             .split(' ')
-            .filter(subStr => subStr.lastIndexOf(term, 0) === 0).length > 0 ||
-          user.display.toLowerCase().lastIndexOf(term, 0) === 0
+            .filter(subStr => subStr.lastIndexOf(termLowerCase, 0) === 0)
+            .length > 0 ||
+          user.display.toLowerCase().lastIndexOf(termLowerCase, 0) === 0
       );
     }
     return users;


### PR DESCRIPTION
### 💬 Description
When searching for users to tag in a comment, the search term is now converted to lower case before searching for a user.
### 🔗 Links
(https://trello.com/c/uiDBRBKU/2919-regular-finding-people-to-mention-is-case-sensitive)
### 📹 GIF (optional)
![tagging](https://user-images.githubusercontent.com/37194621/162980108-d4795597-48f4-448a-98e2-088197fd3d04.gif)

