### PR TITLE
make preview image contain the image, not cover

### DIFF
--- a/lib/src/modules/preview/previewImage.scss
+++ b/lib/src/modules/preview/previewImage.scss
@@ -12,7 +12,9 @@
 }
 
 .preview-image-img {
-  @apply bg-cover bg-center pb-100% transition-opacity duration-300 opacity-0;
+  @apply bg-center pb-100% transition-opacity duration-300 opacity-0;
+  background-size: contain;
+  background-repeat: no-repeat;
 }
 
 .preview-image-succeeded .preview-image-img {

--- a/lib/src/prefabs/files/fileCard/FileCard.stories.js
+++ b/lib/src/prefabs/files/fileCard/FileCard.stories.js
@@ -24,7 +24,9 @@ export default {
     added: false,
     removed: false,
     disabled: false,
-    showLoader: false
+    showLoader: false,
+    imgHeight: 500,
+    imgWidth: 500
   }
 };
 
@@ -43,7 +45,7 @@ export const FileCard = args => {
 
   const previewSrc = args.previewFailedToLoad
     ? 'http://fail'
-    : 'http://placeimg.com/500/500/animals';
+    : `http://placeimg.com/${args.imgWidth}/${args.imgHeight}/animals`;
 
   const Preview = ({ children, loader }) => (
     <PreviewImage


### PR DESCRIPTION
### 💬 Description
This ended up being really easy, as its a background image its just a case of using contain rather than cover for background size 👌
### 📹 GIF (optional)
http://g.recordit.co/6eH1VBpSvi.gif
