### PR TITLE
only apply today styles if not selected

### DIFF
--- a/lib/src/modules/calendar/calendar.scss
+++ b/lib/src/modules/calendar/calendar.scss
@@ -88,7 +88,7 @@
       content: '';
     }
 
-    &.DayPicker-Day--today:not(.DayPicker-Day--outside) {
+    &.DayPicker-Day--today:not(.DayPicker-Day--outside):not(.DayPicker-Day.DayPicker-Day--selected) {
       &:after {
         @apply bg-blue-95 border-blue-primary;
       }


### PR DESCRIPTION
### 💬 Description
When a due date was selected, if it was today then the background colour didn't change to blue. This PR ensures that the today styling only applies if the date is not also selected. If selected then that styling takes precedence.
### 🔗 Links
(https://trello.com/c/A4NCBl0Y/3650-regular-today-dates-in-the-calendar-display-white-text-making-it-difficult-to-read)
### 📹 GIF (optional)
![image](https://user-images.githubusercontent.com/37194621/189909544-40824d20-d7a4-464a-94ea-b4526fca1998.png)