### PR TITLE
stop propagation when editable text edit button clicked

### DIFF
--- a/lib/EditableTextWrapper/EditableTextWrapperText.js
+++ b/lib/EditableTextWrapper/EditableTextWrapperText.js
@@ -15,6 +15,11 @@ export function EditableTextWrapperText({
     }
   };
 
+  const handleEditStart = event => {
+    event.stopPropagation();
+    startEditing();
+  };
+
   return (
     <div className={`editable-text__wrapper ${className}`}>
       <span
@@ -29,7 +34,7 @@ export function EditableTextWrapperText({
       <Button
         types={['icon-only']}
         className="editable-text__button"
-        clickHandler={startEditing}
+        clickHandler={e => handleEditStart(e)}
         title={title}
       >
         {buttonLabel && <span className="visually-hidden">{buttonLabel}</span>}


### PR DESCRIPTION
### 💬 Description
When an editable text wrapper edit button is clicked, events now no longer propagate to the parent. This should stop an item row being selected when the edit name button is clicked.
### 🔗 Links
(https://trello.com/c/v6Ib2Acm/241-small-improvements-to-item-creation-ux)
