### PR TITLE
Update/avatar snags

### DIFF
--- a/assets/icons/locked12.svg
+++ b/assets/icons/locked12.svg
@@ -1,0 +1,4 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6 3C5.44772 3 5 3.44772 5 4V5H4V4C4 2.89543 4.89543 2 6 2C7.10457 2 8 2.89543 8 4V5H7V4C7 3.44772 6.55228 3 6 3Z" fill="#678098"/>
+<path d="M3 7C3 6.44772 3.44772 6 4 6H8C8.55228 6 9 6.44772 9 7V8C9 8.55228 8.55228 9 8 9H4C3.44772 9 3 8.55228 3 8V7Z" fill="#678098"/>
+</svg>

--- a/lib/Avatar/AvatarGroup/index.js
+++ b/lib/Avatar/AvatarGroup/index.js
@@ -11,7 +11,8 @@ const AvatarGroup = ({
   className,
   small,
   micro,
-  noTransform
+  noTransform,
+  stacked
 }) => {
   const total = (children && children.length) || 0;
   const plusLabel = `+${total - maximum}`;
@@ -27,7 +28,8 @@ const AvatarGroup = ({
 
   const classes = cx(`avatar-group ${className}`, {
     'avatar-group--small': small,
-    'avatar-group--micro': micro
+    'avatar-group--micro': micro,
+    'avatar-group-stacked': stacked
   });
 
   return (
@@ -71,7 +73,8 @@ AvatarGroup.defaultProps = {
   maximum: 3,
   className: '',
   small: false,
-  micro: false
+  micro: false,
+  stacked: true
 };
 
 AvatarGroup.propTypes = {
@@ -79,7 +82,8 @@ AvatarGroup.propTypes = {
   maximum: number,
   className: string,
   small: bool,
-  micro: bool
+  micro: bool,
+  stacked: bool
 };
 
 export default AvatarGroup;

--- a/lib/Avatar/AvatarGroup/styles.scss
+++ b/lib/Avatar/AvatarGroup/styles.scss
@@ -1,7 +1,7 @@
 /* ==========================================================================
    Config
    ========================================================================== */
-$avatar-group-item-spacing: .115em;
+$avatar-group-item-spacing: 0.115em;
 $avatar-group-size-small: 24px !default;
 $avatar-group-size-micro: 20px !default;
 
@@ -10,12 +10,19 @@ $avatar-group-size-micro: 20px !default;
    ========================================================================== */
 .avatar-group {
   display: flex;
+  gap: 4px;
+}
+
+.avatar-group-stacked {
+  gap: 0;
   margin-right: $avatar-group-item-spacing;
+  .avatar-group__item {
+    margin-right: -$avatar-group-item-spacing;
+    z-index: 1;
+  }
 }
 
 .avatar-group__item {
-  margin-right: -$avatar-group-item-spacing;
-  z-index: 1;
 }
 
 .avatar-group .dropdown__trigger {

--- a/lib/Avatar/AvatarWithPopover.js
+++ b/lib/Avatar/AvatarWithPopover.js
@@ -45,7 +45,7 @@ function AvatarWithPopover({
 }
 
 AvatarWithPopover.defaultProps = {
-  overlayPosition: 'bottom'
+  overlayPosition: 'top'
 };
 
 export default AvatarWithPopover;

--- a/lib/Avatar/index.js
+++ b/lib/Avatar/index.js
@@ -91,7 +91,7 @@ class Avatar extends Component {
         )}
         {this.props.locked && (
           <div className="avatar__locked">
-            <Icon name="lock" types={['white']} defaultActiveColor={false} />
+            <Icon name="locked" types={['white']} defaultActiveColor={false} />
           </div>
         )}
       </div>

--- a/lib/Avatar/index.js
+++ b/lib/Avatar/index.js
@@ -64,7 +64,11 @@ class Avatar extends Component {
             )}
             {this.props.locked && (
               <div className="avatar__locked">
-                <Icon name="lock" types={['white']} />
+                <Icon
+                  name="locked"
+                  types={['white']}
+                  defaultActiveColor={false}
+                />
               </div>
             )}
           </div>

--- a/lib/Avatar/stories/Avatar.stories.js
+++ b/lib/Avatar/stories/Avatar.stories.js
@@ -21,7 +21,9 @@ export default {
     showImage: false,
     smallSize: false,
     bordered: false,
-    locked: false
+    locked: false,
+    stacked: true,
+    animate: true
   },
   argTypes: {
     colour: {
@@ -86,6 +88,7 @@ export const Avatar = args => {
           defaultCount={6}
           minCount={6}
           avatarProps={propsWithoutColour}
+          avatarGroupProps={{ stacked: args.stacked }}
         >
           {({ ui }) => ui}
         </AvatarGroupMock>

--- a/lib/Avatar/stories/AvatarGroupMock.js
+++ b/lib/Avatar/stories/AvatarGroupMock.js
@@ -13,6 +13,7 @@ const AvatarGroupMock = ({
   avatarGroupProps,
   overlayProps
 }) => {
+  console.log(avatarGroupProps);
   const count = Math.floor(
     Math.random() * number('Max number of assignees', defaultMaxCount || 0)
   );
@@ -58,7 +59,8 @@ AvatarGroupMock.defaultProps = {
   defaultMaxCount: 3,
   minCount: 0,
   avatarGroupProps: {
-    maximum: 3
+    maximum: 3,
+    stacked: true
   },
   avatarProps: {},
   overlayProps: {}

--- a/lib/Avatar/stories/AvatarGroupMock.js
+++ b/lib/Avatar/stories/AvatarGroupMock.js
@@ -13,7 +13,6 @@ const AvatarGroupMock = ({
   avatarGroupProps,
   overlayProps
 }) => {
-  console.log(avatarGroupProps);
   const count = Math.floor(
     Math.random() * number('Max number of assignees', defaultMaxCount || 0)
   );

--- a/lib/Avatar/styles.scss
+++ b/lib/Avatar/styles.scss
@@ -172,11 +172,7 @@ $avatar-pillbox-padding: $typo-size-lead * 0.25 math.div($typo-size-lead, 3) !de
 }
 
 .avatar__locked {
-  @apply absolute bg-neutral-20 rounded-full w-3 h-3 flex items-center justify-center right-0 bottom-0 -mb-1 -mr-1;
-
-  svg {
-    height: 9px;
-  }
+  @apply absolute bg-neutral-20 rounded-full w-3 h-3 flex items-center justify-center right-0 bottom-0;
 }
 
 .avatar--offline {

--- a/lib/Avatar/styles.scss
+++ b/lib/Avatar/styles.scss
@@ -131,14 +131,6 @@ $avatar-pillbox-padding: $typo-size-lead * 0.25 math.div($typo-size-lead, 3) !de
 .avatar__wrapper:focus,
 .avatar--with-toggle {
   cursor: pointer;
-
-  &:hover,
-  &:focus,
-  .avatar {
-    transform: scale3d(1.1, 1.1, 1);
-    transition: transform $animation-time-micro;
-    transition-timing-function: cubic-bezier(0.2, 1, 0.3, 1);
-  }
 }
 
 .avatar__initials {

--- a/lib/Icon/index.js
+++ b/lib/Icon/index.js
@@ -164,7 +164,7 @@ import settings16 from '../../assets/icons/settings16.svg';
 import earth from '../../assets/icons/earth.svg';
 import goto from '../../assets/icons/go-to16.svg';
 import bynder from '../../assets/icons/bynder.svg';
-
+import locked from '../../assets/icons/locked12.svg';
 /**
  * @usage
  *
@@ -332,7 +332,8 @@ const getIcon = name => {
     settings16,
     earth,
     goto,
-    bynder
+    bynder,
+    locked
   };
   return icons[name] || null;
 };

--- a/lib/src/modules/person/Person.js
+++ b/lib/src/modules/person/Person.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Avatar, Icon } from 'lib';
+import { Avatar, Icon, TooltipWrapper } from 'lib';
 import cx from 'classnames';
 import { TextHighlighter } from '../../../helpers/TextHighlighter';
 
@@ -16,7 +16,8 @@ export function Person({
   onClick,
   highlightText,
   colour,
-  locked
+  locked,
+  lockedTooltipText
 }) {
   const classes = cx('person', className, {
     'person-selected': selected,
@@ -55,12 +56,17 @@ export function Person({
         <Icon className="person-tick" name="tick16" types={['primary-blue']} />
       )}
       {locked && (
-        <Icon
-          name="lock"
-          className="person-lock"
-          types={['neutral-20']}
-          defaultActiveColor={false}
-        />
+        <TooltipWrapper
+          id={`${avatarUrl}-initials-locked`}
+          tooltipText={lockedTooltipText}
+        >
+          <Icon
+            name="lock"
+            className="person-lock"
+            types={['neutral-20']}
+            defaultActiveColor={false}
+          />
+        </TooltipWrapper>
       )}
     </WrapperElement>
   );
@@ -69,5 +75,6 @@ export function Person({
 Person.defaultProps = {
   interactive: false,
   highlightText: '',
-  locked: false
+  locked: false,
+  lockedTooltipText: ''
 };


### PR DESCRIPTION
### 💬 Description
- Avatar: Update mini padlock icon to match the design (This is the 12px icon, which is different from the 16px icon) 
- Avatar: Lock icon (and container) to be positioned +2px right and bottom outside of avatar container
- Avatar: Tooltips should appear above where possible
- Content editor: Contributor sidebar: `Set by workflow` tooltip should only appear when hovering over the padlock icon 
- General: Remove avatar stacking (or overlapping) and space 4px apart to help identify who the lock icon is associated with 
- General: Remove the hover zoom on avatars 
- Bouncy lock item
