### PR TITLE
More specific CSS chevron styles for active state

### DIFF
--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -297,7 +297,7 @@ $dropdown-status-circle-width-height: 15px !default;
     margin-left: auto;
   }
   &.dropdown__trigger-wrapper--top {
-    .is-active & .icon {
+    .dropdown-gc.is-active > & .icon {
       transform: rotateX(180deg);
     }
   }


### PR DESCRIPTION
### 💬 Description
Chevron was facing the wrong was as it was reading a higher 'is-active' class - https://trello.com/c/vBI8PfGp/4165-multiple-workflow-snags-v2
<img width="1185" alt="Screenshot 2022-12-13 at 12 19 39" src="https://user-images.githubusercontent.com/3248857/207316330-3b088f97-3bba-44cb-89e4-d866c7aa6b29.png">
