### PR TITLE
GC-530 remove focus and active styling from ButtonIcon

### DIFF
--- a/lib/src/modules/Button/ButtonIcon/styles/buttonIconBase.scss
+++ b/lib/src/modules/Button/ButtonIcon/styles/buttonIconBase.scss
@@ -1,26 +1,8 @@
 .button-icon {
   @apply p-0 items-center justify-center bg-transparent border-transparent;
 
-  &:focus {
-    @apply bg-neutral-primary/10 text-neutral-20;
-    .icon {
-      path {
-        @apply fill-neutral-20;
-      }
-    }
-  }
-
   &:hover {
     @apply bg-neutral-primary/10 text-neutral-20 no-underline;
-    .icon {
-      path {
-        @apply fill-neutral-20;
-      }
-    }
-  }
-
-  &:active {
-    @apply bg-neutral-primary/20 text-neutral-20;
     .icon {
       path {
         @apply fill-neutral-20;


### PR DESCRIPTION
### 💬 Description
Remove the active styling as it is handled in a separate block, and remove the focus styling as it is causing active buttons to not have active styling until the user clicks somewhere else.
