### PR TITLE
GC-557 remove in from DueDateLabel text

### DIFF
--- a/lib/DueDatePicker/DueDateLabel.js
+++ b/lib/DueDatePicker/DueDateLabel.js
@@ -20,7 +20,7 @@ const DueDateLabel = ({ overdue, children }) => {
     <div className={classNames}>
       {overdue && <Icon name="warning" />}
       <span>
-        {`Due in `}
+        {`Due `}
         <span className="duedate__label--button">{children}</span>
       </span>
     </div>


### PR DESCRIPTION
### 💬 Description
The text that is returned from the API already contains `in`, so the component does not need to render it.
